### PR TITLE
jcfg:make umem regions dynamic size

### DIFF
--- a/lib/usr/app/jcfg/jcfg.c
+++ b/lib/usr/app/jcfg/jcfg.c
@@ -380,7 +380,8 @@ _object_free(jcfg_hdr_t *hdr)
         } while(0);
         break;
     case JCFG_UMEM_TYPE:
-        /* FALL-THRU */
+        jcfg_umem_free(hdr);
+        break;
     case JCFG_LGROUP_TYPE:
         break;
     case JCFG_LPORT_TYPE:

--- a/lib/usr/app/jcfg/jcfg.h
+++ b/lib/usr/app/jcfg/jcfg.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 #define DEFAULT_CHUNK_SIZE   1024
-#define UMEM_MAX_REGIONS     16
+#define UMEM_MAX_REGIONS     128
 #define JCFG_MAX_STRING_SIZE 32
 
 #include <cne_common.h>        // for CNDP_API, CNE_STD_C11
@@ -154,9 +154,8 @@ typedef struct jcfg_umem {
     uint16_t txdesc;            /**< Number of Tx descriptors */
     uint16_t idx;               /**< The UMEM index id 0 to N */
     uint16_t shared_umem;       /**< Enable shared umem support */
-
-    uint16_t region_cnt;                   /**< Number of regions defined */
-    region_info_t rinfo[UMEM_MAX_REGIONS]; /**< Region information data */
+    uint16_t region_cnt;        /**< Number of regions defined */
+    region_info_t *rinfo;       /**< Region information data */
 } jcfg_umem_t;
 
 /**

--- a/lib/usr/app/jcfg/jcfg_private.h
+++ b/lib/usr/app/jcfg/jcfg_private.h
@@ -90,6 +90,15 @@ jcfg_get_json_token(struct jcfg *cfg)
     return (cfg) ? cfg->tok : NULL;
 }
 
+/**
+ * Free the internal umem structure.
+ * @internal
+ *
+ * @param hdr
+ *   The generic header structure pointer.
+ */
+void jcfg_umem_free(jcfg_hdr_t *hdr);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The UMEM region size was fixed at 16, we need more than 16.
Convert the jcfg_umem_t.rinfo structure array to an allocated array
based on region count.
Increased max number of regions to 128.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>