### PR TITLE
examples: Update VPP plugin to VPP 22.02

### DIFF
--- a/examples/vpp-plugin/README.md
+++ b/examples/vpp-plugin/README.md
@@ -9,7 +9,10 @@ by building CNDP normally, then install with "sudo CNE_DEST_DIR=/ make install".
 
 ## Known limitations
 
-The plugin works with VPP version 21.01 and will not compile on newer versions.
+The plugin is tested with VPP versions 21.01 and 22.02. It may not compile with
+other versions. When using VPP version 21.01, the USE_2101_RX_QUEUES and
+USE_2110_ETHERNET_REGISTER_INTERFACE macros should be set to 1 in cndp.h. When
+using VPP version 22.02, they should be set to 0.
 
 The max number of devices supported right now is 6. This can be increased by
 increasing #define CNDP_MAX_DEVS 6 in cndp.h

--- a/examples/vpp-plugin/cndp/cndp.h
+++ b/examples/vpp-plugin/cndp/cndp.h
@@ -29,6 +29,8 @@
 #include <cndp/xskdev.h>
 #include "cndp_elog.h"
 
+#define USE_2110_ETHERNET_REGISTER_INTERFACE 0
+#define USE_2101_RX_QUEUES 0
 #define CNDP_MAX_PORTS 30
 #define CNDP_MAX_DEVS 6
 


### PR DESCRIPTION
VPP 21.06 changes how rx queues are assigned to threads and how they
are processed. Some functions are simply renamed from
vnet_hw_interface_* to vnet_hw_if_*. Looping through each queue changed
from using the foreach_device_and_queue macro to use the
vnet_hw_if_rxq_poll_vector_t type.

VPP 22.02 changed the ethernet device registration function. Instead of
calling ethernet_register_interface, software calls
vnet_eth_register_interface.

Signed-off-by: Jeff Shaw <jeffrey.b.shaw@intel.com>