### PR TITLE
cnet:create defines for node names

### DIFF
--- a/lib/cnet/arp/arp_request.c
+++ b/lib/cnet/arp/arp_request.c
@@ -31,6 +31,7 @@
 #include <cnet_eth.h>
 #include <net/cne_udp.h>
 
+#include <cnet_node_names.h>
 #include "arp_request_priv.h"
 
 static __cne_always_inline cne_edge_t
@@ -213,14 +214,14 @@ arp_request_node_init(const struct cne_graph *graph __cne_unused, struct cne_nod
 
 static struct cne_node_register arp_request_node_base = {
     .process = arp_request_node_process,
-    .name    = "arp_request",
+    .name    = ARP_REQUEST_NODE_NAME,
 
     .init = arp_request_node_init,
 
     .nb_edges = ARP_REQUEST_NEXT_MAX,
     .next_nodes =
         {
-            [ARP_REQUEST_NEXT_PKT_DROP] = "pkt_drop",
+            [ARP_REQUEST_NEXT_PKT_DROP] = PKT_DROP_NODE_NAME,
         },
 };
 

--- a/lib/cnet/chnl/chnl_callback.c
+++ b/lib/cnet/chnl/chnl_callback.c
@@ -26,6 +26,7 @@
 #include <pktmbuf.h>          // for pktmbuf_t, pktmbuf_data_len
 #include <pktmbuf_ptype.h>
 #include <cnet_chnl.h>        // for cnet_chnl_get
+#include <cnet_node_names.h>
 
 static inline void
 __callback(struct pcb_entry *pcb, pktmbuf_t **mbufs, int len)
@@ -98,7 +99,7 @@ chnl_callback_node_init(const struct cne_graph *graph __cne_unused,
 
 static struct cne_node_register chnl_callback_node_base = {
     .process = chnl_callback_node_process,
-    .name    = "chnl_callback",
+    .name    = CHNL_CALLBACK_NODE_NAME,
 
     .init = chnl_callback_node_init,
 

--- a/lib/cnet/chnl/chnl_recv.c
+++ b/lib/cnet/chnl/chnl_recv.c
@@ -27,6 +27,7 @@
 #include <pktmbuf_ptype.h>
 #include <cnet_chnl.h>        // for cnet_chnl_get
 
+#include <cnet_node_names.h>
 #include "chnl_recv_priv.h"
 
 static uint16_t
@@ -170,15 +171,15 @@ chnl_recv_node_init(const struct cne_graph *graph __cne_unused, struct cne_node 
 
 static struct cne_node_register chnl_recv_node_base = {
     .process = chnl_recv_node_process,
-    .name    = "chnl_recv",
+    .name    = CHNL_RECV_NODE_NAME,
 
     .init = chnl_recv_node_init,
 
     .nb_edges = CHNL_RECV_NEXT_MAX,
     .next_nodes =
         {
-            [CHNL_RECV_NEXT_PKT_DROP]     = "pkt_drop",
-            [CHNL_RECV_NEXT_PKT_CALLBACK] = "chnl_callback",
+            [CHNL_RECV_NEXT_PKT_DROP]     = PKT_DROP_NODE_NAME,
+            [CHNL_RECV_NEXT_PKT_CALLBACK] = CHNL_CALLBACK_NODE_NAME,
         },
 };
 

--- a/lib/cnet/chnl/chnl_send.c
+++ b/lib/cnet/chnl/chnl_send.c
@@ -26,6 +26,7 @@
 #include <pktmbuf_ptype.h>
 #include <cnet_pcb.h>
 
+#include <cnet_node_names.h>
 #include "chnl_send_priv.h"
 
 #define CHNL_SEND_NODE_LAST_NEXT(ctx) (((struct chnl_send_node_ctx *)ctx)->last_next)
@@ -203,17 +204,17 @@ chnl_send_node_init(const struct cne_graph *graph __cne_unused, struct cne_node 
 static struct cne_node_register chnl_send_node_base = {
     .process = chnl_send_node_process,
     .flags   = CNE_NODE_INPUT_F,
-    .name    = "chnl_send",
+    .name    = CHNL_SEND_NODE_NAME,
 
     .init = chnl_send_node_init,
 
     .nb_edges = CHNL_SEND_NEXT_MAX,
     .next_nodes =
         {
-            [CHNL_SEND_NEXT_PKT_DROP]   = "pkt_drop",
-            [CHNL_SEND_NEXT_UDP_OUTPUT] = "udp_output",
+            [CHNL_SEND_NEXT_PKT_DROP]   = PKT_DROP_NODE_NAME,
+            [CHNL_SEND_NEXT_UDP_OUTPUT] = UDP_OUTPUT_NODE_NAME,
 #if CNET_ENABLE_TCP
-            [CHNL_SEND_NEXT_TCP_OUTPUT] = "tcp_output",
+            [CHNL_SEND_NEXT_TCP_OUTPUT] = TCP_OUTPUT_NODE_NAME,
 #endif
         },
 };

--- a/lib/cnet/cmds/cnet_cmds.c
+++ b/lib/cnet/cmds/cnet_cmds.c
@@ -39,6 +39,7 @@
 #include "pktdev_api.h"        // for pktdev_port_count, pktdev_start, pktdev_...
 #include "pktmbuf.h"           // for DEFAULT_MBUF_SIZE, pktmbuf_t
 #include "cnet_chnl.h"         // for chnl_list
+#include <cnet_node_names.h>
 
 #define _prt(_s)                                                           \
     do {                                                                   \
@@ -313,20 +314,22 @@ _node_style(char *name, int src)
         const char *style;
     } styles[] = {
         // clang-format off
-        { 0,                    "ip4_*",            "[fillcolor=mediumspringgreen]" },
-        { 0,                    "udp_*",            "[fillcolor=cornsilk]" },
-        { 0,                    "pkt_drop",         "[fillcolor=lightgrey]" },
-        { 0,                    "chnl_callback",    "[fillcolor=lightgrey]" },
-        { 0,                    "chnl_*",           "[fillcolor=yellowgreen]" },
-        { 0,                    "kernel_recv",      "[fillcolor=lightcoral]" },
-        { 0,                    "eth_rx*",          "[fillcolor=lavender]" },
-        { 0,                    "arp_request",      "[fillcolor=mediumspringgreen]" },
-        { 0,                    "eth_tx*",          "[fillcolor=cyan]" },
-        { 0,                    "punt_kernel",      "[fillcolor=coral]" },
-        { 0,                    "ptype",            "[fillcolor=goldenrod]" },
-        { 0,                    "gtpu_input",       "[fillcolor=lightskyblue]" },
-        { CNE_NODE_SOURCE_F,    NULL,               "[fillcolor=cyan]" },
-        { CNE_NODE_INPUT_F,     NULL,               "[fillcolor=lightskyblue]" },
+        { 0,                    "ip4_*",                 "[fillcolor=mediumspringgreen]" },
+        { 0,                    "udp_*",                 "[fillcolor=cornsilk]" },
+        { 0,                    PKT_DROP_NODE_NAME,      "[fillcolor=lightgrey]" },
+        { 0,                    CHNL_CALLBACK_NODE_NAME, "[fillcolor=lightgrey]" },
+        { 0,                    "chnl_*",                "[fillcolor=yellowgreen]" },
+        { 0,                    KERNEL_RECV_NODE_NAME,   "[fillcolor=lightcoral]" },
+        { 0,                    ETH_RX_NODE_NAME"*",     "[fillcolor=lavender]" },
+        { 0,                    ARP_REQUEST_NODE_NAME,   "[fillcolor=mediumspringgreen]" },
+        { 0,                    ETH_TX_NODE_NAME"*",     "[fillcolor=cyan]" },
+        { 0,                    PUNT_KERNEL_NODE_NAME,   "[fillcolor=coral]" },
+        { 0,                    PTYPE_NODE_NAME,         "[fillcolor=goldenrod]" },
+        { 0,                    GTPU_INPUT_NODE_NAME,    "[fillcolor=lightskyblue]" },
+        { 0,                    "tcp_*",                 "[fillcolor=lightpink]" },
+        { CNE_NODE_SOURCE_F,    NULL,                    "[fillcolor=cyan]" },
+        { CNE_NODE_INPUT_F,     NULL,                    "[fillcolor=lightskyblue]" },
+        { 0,                    NULL,                    "[fillcolor=lightgrey]" }
         // clang-format on
     };
 

--- a/lib/cnet/eth/eth_rx.c
+++ b/lib/cnet/eth/eth_rx.c
@@ -28,6 +28,7 @@
 #include <cnet_eth.h>
 #include <cne_net.h>
 
+#include <cnet_node_names.h>
 #include "eth_rx_priv.h"
 
 static struct eth_rx_node_main eth_rx_main;
@@ -165,14 +166,14 @@ eth_rx_get_node_data_get(void)
 static struct cne_node_register eth_rx_node_base = {
     .process = eth_rx_node_process,
     .flags   = CNE_NODE_SOURCE_F,
-    .name    = "eth_rx",
+    .name    = ETH_RX_NODE_NAME,
 
     .init = eth_rx_node_init,
 
     .nb_edges = ETH_RX_NEXT_MAX,
     .next_nodes =
         {
-            [ETH_RX_NEXT_PTYPE] = "ptype",
+            [ETH_RX_NEXT_PTYPE] = PTYPE_NODE_NAME,
         },
 };
 

--- a/lib/cnet/eth/eth_tx.c
+++ b/lib/cnet/eth/eth_tx.c
@@ -14,6 +14,7 @@
 #include "cne_common.h"        // for CNE_MAX_ETHPORTS, CNE_PRIORITY_LAST
 #include "cne_log.h"           // for CNE_VERIFY
 
+#include <cnet_node_names.h>
 #include "eth_tx_priv.h"        // for eth_tx_node_ctx_t, ETH_TX_NEXT_MAX
 
 static struct eth_tx_node_main eth_tx_main;
@@ -72,7 +73,7 @@ eth_tx_node_data_get(void)
 
 static struct cne_node_register eth_tx_node_base = {
     .process = eth_tx_node_process,
-    .name    = "eth_tx",
+    .name    = ETH_TX_NODE_NAME,
 
     .init = eth_tx_node_init,
 

--- a/lib/cnet/gtpu/gtpu.c
+++ b/lib/cnet/gtpu/gtpu.c
@@ -10,6 +10,7 @@
 #include <stdint.h>                  // for uint8_t, uint16_t, uint32_t
 #include <string.h>                  // for memcpy
 
+#include <cnet_node_names.h>
 #include "gtpu_priv.h"                    // for GTPU_NEXT_IP4_LOOKUP
 #include "cne_branch_prediction.h"        // for likely, unlikely
 #include "cne_common.h"                   // for CNE_PRIORITY_LAST, __cne_cache_al...
@@ -171,14 +172,14 @@ gtpu_node_process(struct cne_graph *graph, struct cne_node *node, void **objs, u
 /* Packet Classification Node */
 struct cne_node_register gtpu_node = {
     .process = gtpu_node_process,
-    .name    = "gtpu_input",
+    .name    = GTPU_INPUT_NODE_NAME,
 
     .nb_edges = GTPU_NEXT_MAX,
     .next_nodes =
         {
             /* Pkt drop node starts at '0' */
-            [GTPU_NEXT_PKT_DROP]  = "pkt_drop",
-            [GTPU_NEXT_IP4_INPUT] = "ip4_input",
+            [GTPU_NEXT_PKT_DROP]  = PKT_DROP_NODE_NAME,
+            [GTPU_NEXT_IP4_INPUT] = IP4_INPUT_NODE_NAME,
         },
 };
 CNE_NODE_REGISTER(gtpu_node);

--- a/lib/cnet/incs/cnet_node_names.h
+++ b/lib/cnet/incs/cnet_node_names.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Intel Corporation
+ */
+
+#ifndef __CNET_NODE_NAMES_H
+#define __CNET_NODE_NAMES_H
+
+/**
+ * @file
+ * CNET Node names
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Names of all the graph nodes in the CNET stack to eliminate unnecessary
+ * constant strings that need to be managed by the developer in all of the
+ * node files.
+ */
+#define ARP_REQUEST_NODE_NAME   "arp_request"
+#define CHNL_CALLBACK_NODE_NAME "chnl_callback"
+#define CHNL_RECV_NODE_NAME     "chnl_recv"
+#define CHNL_SEND_NODE_NAME     "chnl_send"
+#define ETH_RX_NODE_NAME        "eth_rx"
+#define ETH_TX_NODE_NAME        "eth_tx"
+#define GTPU_INPUT_NODE_NAME    "gtpu_input"
+#define IP4_FORWARD_NODE_NAME   "ip4_forward"
+#define IP4_INPUT_NODE_NAME     "ip4_input"
+#define IP4_OUTPUT_NODE_NAME    "ip4_output"
+#define IP4_PROTO_NODE_NAME     "ip4_proto"
+#define KERNEL_RECV_NODE_NAME   "kernel_recv"
+#define NULL_NODE_NAME          "null"
+#define PKT_DROP_NODE_NAME      "pkt_drop"
+#define PTYPE_NODE_NAME         "ptype"
+#define PUNT_KERNEL_NODE_NAME   "punt_kernel"
+#define TCP_INPUT_NODE_NAME     "tcp_input"
+#define TCP_OUTPUT_NODE_NAME    "tcp_output"
+#define UDP_INPUT_NODE_NAME     "udp_input"
+#define UDP_OUTPUT_NODE_NAME    "udp_output"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CNET_NODE_NAMES_H */

--- a/lib/cnet/incs/meson.build
+++ b/lib/cnet/incs/meson.build
@@ -9,5 +9,6 @@ headers += files(
     'cnet_inet4.h',
     'cnet_ip_common.h',
     'cnet_meta.h',
+    'cnet_node_names.h',
     'cnet_pkt.h',
     )

--- a/lib/cnet/ipv4/ip4_forward.c
+++ b/lib/cnet/ipv4/ip4_forward.c
@@ -36,8 +36,9 @@
 #include <cnet_inet.h>           // for _in_addr
 #include <cnet_arp.h>            // for cne_arp
 
-#include "ip4_node_api.h"            // for cne_node_ip4_forward_add
-#include "ip4_forward_priv.h"        // for ip4_forward_nh_header, ip4_rewrit...
+#include <cnet_node_names.h>
+#include "ip4_node_api.h"        // for cne_node_ip4_forward_add
+#include "ip4_forward_priv.h"
 #include "cnet_fib_info.h"
 
 struct ip4_forward_node_ctx {
@@ -297,7 +298,7 @@ ip4_forward_set_next(uint16_t port_id, uint16_t next_index)
 
 static struct cne_node_register ip4_forward_node = {
     .process = ip4_forward_node_process,
-    .name    = "ip4_forward",
+    .name    = IP4_FORWARD_NODE_NAME,
 
     .init = ip4_forward_node_init,
 
@@ -305,8 +306,8 @@ static struct cne_node_register ip4_forward_node = {
     .nb_edges = NODE_IP4_FORWARD_OUTPUT_OFFSET,
     .next_nodes =
         {
-            [NODE_IP4_FORWARD_PKT_DROP]    = "pkt_drop",
-            [NODE_IP4_FORWARD_ARP_REQUEST] = "arp_request",
+            [NODE_IP4_FORWARD_PKT_DROP]    = PKT_DROP_NODE_NAME,
+            [NODE_IP4_FORWARD_ARP_REQUEST] = ARP_REQUEST_NODE_NAME,
             /* TX outputs will be placed here */
         },
 };

--- a/lib/cnet/ipv4/ip4_input.c
+++ b/lib/cnet/ipv4/ip4_input.c
@@ -21,6 +21,7 @@
 #include <cnet_route4.h>             // for
 #include <cnet_meta.h>               // for
 
+#include <cnet_node_names.h>
 #include "ip4_node_api.h"                 // for
 #include "ip4_input_priv.h"               // for CNE_NODE_IP4_INPUT_NEXT_PKT_DROP
 #include "cne_branch_prediction.h"        // for likely, unlikely
@@ -256,16 +257,16 @@ ip4_input_node_init(const struct cne_graph *graph, struct cne_node *node)
 
 static struct cne_node_register ip4_input_node = {
     .process = ip4_input_node_process,
-    .name    = "ip4_input",
+    .name    = IP4_INPUT_NODE_NAME,
 
     .init = ip4_input_node_init,
 
     .nb_edges = CNE_NODE_IP4_INPUT_NEXT_MAX,
     .next_nodes =
         {
-            [CNE_NODE_IP4_INPUT_NEXT_PKT_DROP] = "pkt_drop",
-            [CNE_NODE_IP4_INPUT_NEXT_FORWARD]  = "ip4_forward",
-            [CNE_NODE_IP4_INPUT_NEXT_PROTO]    = "ip4_proto",
+            [CNE_NODE_IP4_INPUT_NEXT_PKT_DROP] = PKT_DROP_NODE_NAME,
+            [CNE_NODE_IP4_INPUT_NEXT_FORWARD]  = IP4_FORWARD_NODE_NAME,
+            [CNE_NODE_IP4_INPUT_NEXT_PROTO]    = IP4_PROTO_NODE_NAME,
         },
 };
 

--- a/lib/cnet/ipv4/ip4_output.c
+++ b/lib/cnet/ipv4/ip4_output.c
@@ -28,6 +28,7 @@
 #include <cnet_ipv4.h>
 #include <cnet_meta.h>
 
+#include <cnet_node_names.h>
 #include "ip4_node_api.h"                 // for CNE_NODE_IP4_OUTPUT_NEXT_PKT_DROP
 #include "ip4_output_priv.h"              // for CNE_NODE_IP4_OUTPUT_NEXT_PKT_DROP
 #include "cne_branch_prediction.h"        // for likely, unlikely
@@ -288,15 +289,15 @@ ip4_output_set_next(uint16_t port_id, uint16_t next_index)
 
 static struct cne_node_register ip4_output_node = {
     .process = ip4_output_node_process,
-    .name    = "ip4_output",
+    .name    = IP4_OUTPUT_NODE_NAME,
 
     .init = ip4_output_node_init,
 
     .nb_edges = IP4_OUTPUT_NEXT_MAX,
     .next_nodes =
         {
-            [IP4_OUTPUT_NEXT_PKT_DROP]    = "pkt_drop",    /* Drop packet node */
-            [IP4_OUTPUT_NEXT_ARP_REQUEST] = "arp_request", /* TX output nodes go here */
+            [IP4_OUTPUT_NEXT_PKT_DROP]    = PKT_DROP_NODE_NAME,    /* Drop packet node */
+            [IP4_OUTPUT_NEXT_ARP_REQUEST] = ARP_REQUEST_NODE_NAME, /* TX output nodes go here */
         },
 };
 

--- a/lib/cnet/ipv4/ip4_proto.c
+++ b/lib/cnet/ipv4/ip4_proto.c
@@ -19,6 +19,7 @@
 #include <cnet_route.h>              // for
 #include <cnet_route4.h>             // for
 
+#include <cnet_node_names.h>
 #include "ip4_proto_priv.h"               // for
 #include "cne_branch_prediction.h"        // for likely, unlikely
 #include "cne_common.h"                   // for CNE_BUILD_BUG_ON, CNE_PRIORITY_LAST
@@ -195,17 +196,17 @@ ip4_proto_node_init(const struct cne_graph *graph, struct cne_node *node)
 
 static struct cne_node_register ip4_proto_node = {
     .process = ip4_proto_node_process,
-    .name    = "ip4_proto",
+    .name    = IP4_PROTO_NODE_NAME,
 
     .init = ip4_proto_node_init,
 
     .nb_edges = CNE_NODE_IP4_INPUT_PROTO_MAX,
     .next_nodes =
         {
-            [CNE_NODE_IP4_INPUT_PROTO_DROP] = "pkt_drop",
-            [CNE_NODE_IP4_INPUT_PROTO_UDP]  = "udp_input",
+            [CNE_NODE_IP4_INPUT_PROTO_DROP] = PKT_DROP_NODE_NAME,
+            [CNE_NODE_IP4_INPUT_PROTO_UDP]  = UDP_INPUT_NODE_NAME,
 #if CNET_ENABLE_TCP
-            [CNE_NODE_IP4_INPUT_PROTO_TCP] = "tcp_input",
+            [CNE_NODE_IP4_INPUT_PROTO_TCP] = TCP_INPUT_NODE_NAME,
 #endif
         },
 };

--- a/lib/cnet/nodes/drop.c
+++ b/lib/cnet/nodes/drop.c
@@ -8,6 +8,7 @@
 #include <stdint.h>           // for uint16_t
 
 #include "cne_common.h"        // for CNE_SET_USED, CNE_PRIORITY_LAST
+#include "cnet_node_names.h"
 
 struct cne_graph;
 struct cne_node;
@@ -34,7 +35,7 @@ pkt_drop_node_init(const struct cne_graph *graph, struct cne_node *node)
 
 static struct cne_node_register pkt_drop_node = {
     .process = pkt_drop_process,
-    .name    = "pkt_drop",
+    .name    = PKT_DROP_NODE_NAME,
     .init    = pkt_drop_node_init,
 };
 

--- a/lib/cnet/nodes/null.c
+++ b/lib/cnet/nodes/null.c
@@ -7,6 +7,7 @@
 #include <stdint.h>           // for uint16_t
 
 #include "cne_common.h"        // for CNE_SET_USED, CNE_PRIORITY_LAST
+#include "cnet_node_names.h"
 
 struct cne_graph;
 struct cne_node;
@@ -22,7 +23,7 @@ null(struct cne_graph *graph, struct cne_node *node, void **objs, uint16_t nb_ob
 }
 
 static struct cne_node_register null_node = {
-    .name    = "null",
+    .name    = NULL_NODE_NAME,
     .process = null,
 };
 

--- a/lib/cnet/ptype/ptype.c
+++ b/lib/cnet/ptype/ptype.c
@@ -10,6 +10,7 @@
 #include <stdint.h>                  // for uint8_t, uint16_t, uint32_t
 #include <string.h>                  // for memcpy
 
+#include <cnet_node_names.h>
 #include "ptype_priv.h"                   // for PTYPE_NEXT_IP4_LOOKUP, PTYPE_...
 #include "cne_branch_prediction.h"        // for likely, unlikely
 #include "cne_common.h"                   // for CNE_PRIORITY_LAST, __cne_cache_al...
@@ -196,15 +197,15 @@ ptype_node_process(struct cne_graph *graph, struct cne_node *node, void **objs, 
 /* Packet Classification Node */
 struct cne_node_register ptype_node = {
     .process = ptype_node_process,
-    .name    = "ptype",
+    .name    = PTYPE_NODE_NAME,
 
     .nb_edges = PTYPE_NEXT_MAX,
     .next_nodes =
         {
             /* Pkt drop node starts at '0' */
-            [PTYPE_NEXT_PKT_DROP]   = "pkt_drop",
-            [PTYPE_NEXT_IP4_INPUT]  = "ip4_input",
-            [PTYPE_NEXT_GTPU_INPUT] = "gtpu_input",
+            [PTYPE_NEXT_PKT_DROP]   = PKT_DROP_NODE_NAME,
+            [PTYPE_NEXT_IP4_INPUT]  = IP4_INPUT_NODE_NAME,
+            [PTYPE_NEXT_GTPU_INPUT] = GTPU_INPUT_NODE_NAME,
         },
 };
 CNE_NODE_REGISTER(ptype_node);

--- a/lib/cnet/punt/kernel_recv.c
+++ b/lib/cnet/punt/kernel_recv.c
@@ -36,6 +36,7 @@
 #include <linux/if_tun.h>
 #include "ptype_priv.h"        // for PTYPE_NEXT_IP4_LOOKUP, PTYPE_...
 
+#include <cnet_node_names.h>
 #include "kernel_recv_priv.h"
 #include "tun_alloc.h"
 
@@ -223,14 +224,14 @@ kernel_recv_node_init(const struct cne_graph *graph __cne_unused, struct cne_nod
 static struct cne_node_register kernel_recv_node_base = {
     .process = kernel_recv_node_process,
     .flags   = CNE_NODE_SOURCE_F,
-    .name    = "kernel_recv",
+    .name    = KERNEL_RECV_NODE_NAME,
 
     .init = kernel_recv_node_init,
 
     .nb_edges = KERNEL_RECV_NEXT_MAX,
     .next_nodes =
         {
-            [KERNEL_RECV_NEXT_PTYPE] = "ptype",
+            [KERNEL_RECV_NEXT_PTYPE] = PTYPE_NODE_NAME,
         },
 };
 

--- a/lib/cnet/punt/punt_kernel.c
+++ b/lib/cnet/punt/punt_kernel.c
@@ -39,6 +39,7 @@
 #include <net/cne_udp.h>
 #include <hexdump.h>
 
+#include <cnet_node_names.h>
 #include "punt_kernel_priv.h"
 #include "tun_alloc.h"
 
@@ -52,13 +53,6 @@ punt_kernel_process_mbuf(struct cne_node *node, pktmbuf_t **mbufs, uint16_t cnt)
 
     if (ctx->tinfo->tun_fd >= 0) {
         for (int i = 0; i < cnt; i++) {
-#if 0 /* TODO: Fix up address if needed */
-            pktmbuf_adj_offset(mbufs[i], -mbufs[i]->l2_len);
-
-            /* update the source MAC address */
-            memcpy(pktmbuf_mtod_offset(mbufs[i], char *, 0),
-                   &ctx->tinfo->eth_addr, sizeof(struct ether_addr));
-#endif
             v[i].iov_base = pktmbuf_mtod(mbufs[i], char *);
             v[i].iov_len  = pktmbuf_data_len(mbufs[i]);
         }
@@ -142,14 +136,14 @@ punt_kernel_node_init(const struct cne_graph *graph __cne_unused, struct cne_nod
 
 static struct cne_node_register punt_kernel_node_base = {
     .process = punt_kernel_node_process,
-    .name    = "punt_kernel",
+    .name    = PUNT_KERNEL_NODE_NAME,
 
     .init = punt_kernel_node_init,
 
     .nb_edges = PUNT_KERNEL_NEXT_MAX,
     .next_nodes =
         {
-            [PUNT_KERNEL_NEXT_PKT_DROP] = "pkt_drop",
+            [PUNT_KERNEL_NEXT_PKT_DROP] = PKT_DROP_NODE_NAME,
         },
 };
 

--- a/lib/cnet/tcp/tcp_input.c
+++ b/lib/cnet/tcp/tcp_input.c
@@ -28,6 +28,7 @@
 #include <cnet_tcp.h>
 #include <cnet_meta.h>
 
+#include <cnet_node_names.h>
 #include "tcp_input_priv.h"
 
 /* The TCP/IP Pseudo header */
@@ -227,16 +228,16 @@ tcp_input_node_init(const struct cne_graph *graph __cne_unused, struct cne_node 
 
 static struct cne_node_register tcp_input_node_base = {
     .process = tcp_input_node_process,
-    .name    = "tcp_input",
+    .name    = TCP_INPUT_NODE_NAME,
 
     .init = tcp_input_node_init,
 
     .nb_edges = TCP_INPUT_NEXT_MAX,
     .next_nodes =
         {
-            [TCP_INPUT_NEXT_PKT_DROP]  = "pkt_drop",
-            [TCP_INPUT_NEXT_CHNL_RECV] = "chnl_recv",
-            [TCP_INPUT_NEXT_PKT_PUNT]  = "punt_kernel",
+            [TCP_INPUT_NEXT_PKT_DROP]  = PKT_DROP_NODE_NAME,
+            [TCP_INPUT_NEXT_CHNL_RECV] = CHNL_RECV_NODE_NAME,
+            [TCP_INPUT_NEXT_PKT_PUNT]  = PUNT_KERNEL_NODE_NAME,
         },
 };
 

--- a/lib/cnet/tcp/tcp_output.c
+++ b/lib/cnet/tcp/tcp_output.c
@@ -27,6 +27,7 @@
 #include <pktmbuf_ptype.h>
 #include <cnet_tcp.h>
 
+#include <cnet_node_names.h>
 #include "tcp_output_priv.h"
 
 static inline uint16_t
@@ -206,15 +207,15 @@ tcp_output_node_init(const struct cne_graph *graph __cne_unused, struct cne_node
 
 static struct cne_node_register tcp_output_node_base = {
     .process = tcp_output_node_process,
-    .name    = "tcp_output",
+    .name    = TCP_OUTPUT_NODE_NAME,
 
     .init = tcp_output_node_init,
 
     .nb_edges = TCP_OUTPUT_NEXT_MAX,
     .next_nodes =
         {
-            [TCP_OUTPUT_NEXT_PKT_DROP]   = "pkt_drop",
-            [TCP_OUTPUT_NEXT_IP4_OUTPUT] = "ip4_output",
+            [TCP_OUTPUT_NEXT_PKT_DROP]   = PKT_DROP_NODE_NAME,
+            [TCP_OUTPUT_NEXT_IP4_OUTPUT] = IP4_OUTPUT_NODE_NAME,
         },
 };
 

--- a/lib/cnet/udp/udp_input.c
+++ b/lib/cnet/udp/udp_input.c
@@ -28,6 +28,7 @@
 #include <cnet_udp.h>
 #include <cnet_meta.h>
 
+#include <cnet_node_names.h>
 #include "udp_input_priv.h"
 
 /* The UDP/IP Pseudo header */
@@ -230,16 +231,16 @@ udp_input_node_init(const struct cne_graph *graph __cne_unused, struct cne_node 
 
 static struct cne_node_register udp_input_node_base = {
     .process = udp_input_node_process,
-    .name    = "udp_input",
+    .name    = UDP_INPUT_NODE_NAME,
 
     .init = udp_input_node_init,
 
     .nb_edges = UDP_INPUT_NEXT_MAX,
     .next_nodes =
         {
-            [UDP_INPUT_NEXT_PKT_DROP]  = "pkt_drop",
-            [UDP_INPUT_NEXT_CHNL_RECV] = "chnl_recv",
-            [UDP_INPUT_NEXT_PKT_PUNT]  = "punt_kernel",
+            [UDP_INPUT_NEXT_PKT_DROP]  = PKT_DROP_NODE_NAME,
+            [UDP_INPUT_NEXT_CHNL_RECV] = CHNL_RECV_NODE_NAME,
+            [UDP_INPUT_NEXT_PKT_PUNT]  = PUNT_KERNEL_NODE_NAME,
         },
 };
 

--- a/lib/cnet/udp/udp_output.c
+++ b/lib/cnet/udp/udp_output.c
@@ -28,6 +28,7 @@
 #include <cnet_udp.h>
 #include <cnet_meta.h>
 
+#include <cnet_node_names.h>
 #include "udp_output_priv.h"
 
 static inline uint16_t
@@ -207,15 +208,15 @@ udp_output_node_init(const struct cne_graph *graph __cne_unused, struct cne_node
 
 static struct cne_node_register udp_output_node_base = {
     .process = udp_output_node_process,
-    .name    = "udp_output",
+    .name    = UDP_OUTPUT_NODE_NAME,
 
     .init = udp_output_node_init,
 
     .nb_edges = UDP_OUTPUT_NEXT_MAX,
     .next_nodes =
         {
-            [UDP_OUTPUT_NEXT_PKT_DROP]   = "pkt_drop",
-            [UDP_OUTPUT_NEXT_IP4_OUTPUT] = "ip4_output",
+            [UDP_OUTPUT_NEXT_PKT_DROP]   = PKT_DROP_NODE_NAME,
+            [UDP_OUTPUT_NEXT_IP4_OUTPUT] = IP4_OUTPUT_NODE_NAME,
         },
 };
 


### PR DESCRIPTION
Create single file to hold all of the CNET graph node names. This cleans
up and puts the node names in a single header file to prevent miss-typing
a node name.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>