### PR TITLE
pktmbuf:buf_len value fixed

### DIFF
--- a/lib/core/pktmbuf/pktmbuf.c
+++ b/lib/core/pktmbuf/pktmbuf.c
@@ -65,7 +65,7 @@ __mbuf_init(pktmbuf_info_t *pi, pktmbuf_t *m, uint32_t sz, void *ud __cne_unused
 
     /* start of buffer is after pktmbuf structure */
     m->buf_addr = (char *)m + sizeof(pktmbuf_t);
-    m->buf_len  = (uint16_t)sz;
+    m->buf_len  = (uint16_t)sz - sizeof(pktmbuf_t);
 
     /* keep some headroom between start of buffer and data */
     m->data_off = CNE_MIN(CNE_PKTMBUF_HEADROOM, (uint16_t)m->buf_len);

--- a/lib/core/xskdev/xskdev.h
+++ b/lib/core/xskdev/xskdev.h
@@ -409,7 +409,9 @@ xskdev_buf_inc_ptr(xskdev_info_t *xi, void **buf)
  * @param buf
  *    The buffer to reset.
  * @param buf_len
- *    The buffer length to set the buffer to (if needed).
+ *    The max data length able to be contained in the buffer.
+ *    If the buffer is 2K and it contains a mbuf like header then
+ *    buf_len = (2K - sizeof(mbuf)).
  * @param headroom
  *    The buffer headroom to offset the data pointer by (if needed).
  */


### PR DESCRIPTION
The pktmbuf_t.buf_len should the total bytes available for packet data.
For CNDP 2K buffers we need to subtract the size of pktmbuf_t structure.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>