### PR TITLE
Remove unused header file include for net/ethernet.h.

### DIFF
--- a/lib/core/osal/netdev_funcs.h
+++ b/lib/core/osal/netdev_funcs.h
@@ -5,7 +5,6 @@
 #ifndef _NETDEV_FUNCS_H_
 #define _NETDEV_FUNCS_H_
 
-#include <net/ethernet.h>
 #include <stdint.h>            // for uint32_t, uint16_t
 #include <cne_common.h>        // for CNDP_API
 

--- a/lib/core/pktdev/pktdev.h
+++ b/lib/core/pktdev/pktdev.h
@@ -6,7 +6,6 @@
 #define __PKTDEV_H
 
 #include <cne_common.h>
-#include <net/ethernet.h>
 #include <errno.h>            // for EINVAL, ENOTSUP
 #include <stddef.h>           // for NULL
 #include <stdint.h>           // for uint16_t, uint32_t, uint64_t, uint8_t

--- a/lib/core/pktdev/pktdev_api.c
+++ b/lib/core/pktdev/pktdev_api.c
@@ -1,9 +1,10 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2019-2022 Intel Corporation.
  */
-#include <string.h>           // for strcmp
-#include <stdio.h>            // for fprintf, NULL, FILE, stdout
-#include <sys/queue.h>        // for TAILQ_FOREACH, TAILQ_HEAD_INITIALIZER
+#include <string.h>              // for strcmp
+#include <stdio.h>               // for fprintf, NULL, FILE, stdout
+#include <net/ethernet.h>        // ether_addr
+#include <sys/queue.h>           // for TAILQ_FOREACH, TAILQ_HEAD_INITIALIZER
 #include <pktdev_api.h>
 
 #include "pktdev.h"               // for pktdev_info

--- a/lib/core/xskdev/xskdev.c
+++ b/lib/core/xskdev/xskdev.c
@@ -16,7 +16,6 @@
 #include <linux/bpf.h>            // for XDP_PACKET_HEADROOM
 #include <linux/if_xdp.h>         // for xdp_desc, xdp_statistics, XDP_STATISTICS
 #include <linux/if_link.h>        // for XDP_FLAGS_UPDATE_IF_NOEXIST
-#include <net/ethernet.h>
 #include <linux/ethtool.h>        // for ethtool_channels, ETHTOOL_GCHANNELS
 #include <linux/sockios.h>        // for SIOCETHTOOL
 #include <cne_common.h>           // for CNE_DEFAULT_SET, CNE_MAX_SET, CNE_PTR_SUB

--- a/lib/core/xskdev/xskdev.h
+++ b/lib/core/xskdev/xskdev.h
@@ -5,14 +5,13 @@
 #ifndef _XSKDEV_H_
 #define _XSKDEV_H_
 
-#include <net/if.h>              // for IF_NAMESIZE
-#include <poll.h>                // for pollfd
-#include <pthread.h>             // for pthread_mutex_t, pthread_mutex_init, pthre...
-#include <bpf/xsk.h>             // for XSK_RING_CONS__DEFAULT_NUM_DESCS, xsk_ring...
-#include <net/ethernet.h>        // for ether_addr
-#include <stdint.h>              // for uint16_t, uint32_t
-#include <stdio.h>               // for FILE, NULL, size_t
-#include <cne_lport.h>           // for lport_stats_t, buf_alloc_t, buf_free_t
+#include <net/if.h>           // for IF_NAMESIZE
+#include <poll.h>             // for pollfd
+#include <pthread.h>          // for pthread_mutex_t, pthread_mutex_init, pthre...
+#include <bpf/xsk.h>          // for XSK_RING_CONS__DEFAULT_NUM_DESCS, xsk_ring...
+#include <stdint.h>           // for uint16_t, uint32_t
+#include <stdio.h>            // for FILE, NULL, size_t
+#include <cne_lport.h>        // for lport_stats_t, buf_alloc_t, buf_free_t
 
 /**
  * @file
@@ -107,7 +106,6 @@ typedef struct xskdev_info {
     unsigned int if_index;         /**< If_index of the interface */
     uint32_t prog_id;              /**< BPF program ID */
     pktmbuf_info_t *pi;            /**< The pktmbuf information structure pointer */
-    struct ether_addr eth_addr;    /**< MAC address for netdev */
     xskdev_rxq_t rxq;              /**< RX queue */
     xskdev_txq_t txq;              /**< TX queue */
     lport_stats_t stats;           /**< Stats for the lport interface */

--- a/lib/include/cne_lport.h
+++ b/lib/include/cne_lport.h
@@ -13,7 +13,6 @@
 
 #include <stdint.h>        // for uint16_t, uint32_t
 #include <sys/types.h>
-#include <net/ethernet.h>
 #include <stdbool.h>
 #include <pktmbuf.h>
 


### PR DESCRIPTION
 - Remove unused header include for net/ethernet.h
 - Remove unused field "eth_addr" in "xskdev_info" structure.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>