### PR TITLE
jsonc file formatting

### DIFF
--- a/examples/cnet-quic/quic.jsonc
+++ b/examples/cnet-quic/quic.jsonc
@@ -126,7 +126,7 @@
         "cli": true,
 
         // Optional example application options, note the key-name needs to match the thread name
-        "graph:0": ["ip4*", "udp*", "tcp*", "pkt_drop", "chnl*", "kernel_recv*"],
+        "graph:0": ["ip4*", "udp*", "tcp*", "pkt_drop", "chnl*", "kernel_recv*"]
         // "graph:1": ["ip4*", "udp*", "tcp*", "pkt_drop", "chnl*", "kernel_recv*"]
     },
 

--- a/examples/dlb_test/dlb_test.jsonc
+++ b/examples/dlb_test/dlb_test.jsonc
@@ -124,7 +124,7 @@
     "options": {
         "no-metrics": false,
         "no-restapi": false,
-        "cli": true,
+        "cli": true
     },
 
     // List of threads to start and information for that thread. Application can start

--- a/examples/l3fwd-graph/l3fwd-graph.jsonc
+++ b/examples/l3fwd-graph/l3fwd-graph.jsonc
@@ -123,7 +123,7 @@
     "options": {
         "no-metrics": false,
         "no-restapi": false,
-        "cli": true,
+        "cli": true
     },
 
     // List of threads to start and information for that thread. Application can start

--- a/examples/phil/phil.jsonc
+++ b/examples/phil/phil.jsonc
@@ -99,7 +99,7 @@
     "options": {
         "no-metrics": false,
         "no-restapi": false,
-        "cli": true,
+        "cli": true
     },
 
     // List of threads to start and information for that thread. Application can start


### PR DESCRIPTION
When using the tools/check_json.py script to check the various jsonc
files in the repo, came across an error of the form:

file cannot be parsed (message: Expecting property name enclosed in double quotes..)

These changes get rid of the error.

Signed-off-by: Elza Mathew <elza.mathew@intel.com>