### PR TITLE
Fix Rust pktfwd build: Add ethernet header in rust pktfwd example.

### DIFF
--- a/lang/rs/pktfwd/jcfg_parse/rust_helper.c
+++ b/lang/rs/pktfwd/jcfg_parse/rust_helper.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2019-2022 Intel Corporation.
  */
-
+#include <net/ethernet.h>
 #include "rust_helper.h"
 
 // static linine functions are not currently supported by rust bindgen


### PR DESCRIPTION
Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>