### PR TITLE
cndpgo ipv4 checksum verify example, module name changes

### DIFF
--- a/lang/go/cndp.org/cndpgo/const.go
+++ b/lang/go/cndp.org/cndpgo/const.go
@@ -17,6 +17,7 @@ const (
 // is not determined inside packet. Only default minimum size is used.
 const (
 	EtherLen = 14
+	IPv4Len  = 20
 	IPv6Len  = 40
 )
 

--- a/lang/go/cndp.org/cndpgo/go.mod
+++ b/lang/go/cndp.org/cndpgo/go.mod
@@ -1,3 +1,3 @@
-module github.com/intel/cndp
+module github.com/CloudNativeDataPlane/cndp/cndpgo
 
 go 1.16

--- a/lang/go/cndp.org/examples/fwd/go.mod
+++ b/lang/go/cndp.org/examples/fwd/go.mod
@@ -1,10 +1,10 @@
-module github.com/intel/cndp/examples/fwd
+module github.com/CloudNativeDataPlane/cndp/cndpgo/examples/fwd
 
 go 1.16
 
-replace github.com/intel/cndp => ../../cndpgo
+replace github.com/CloudNativeDataPlane/cndp/cndpgo => ../../cndpgo
 
 require (
-	github.com/intel/cndp v0.0.0-00010101000000-000000000000
+	github.com/CloudNativeDataPlane/cndp/cndpgo v0.0.0-00010101000000-000000000000
 	github.com/jessevdk/go-flags v1.5.0
 )


### PR DESCRIPTION
Signed-off-by: Dakshina Ilangovan <dakshina.ilangovan@intel.com>

Two changes 
1. Added a flow to receive packets, compute and verify checksum in packet if ipv4 and drop
The summation loop reduces performance
2. Changed cndpgo module names