### PR TITLE
pmds:remove unused defines

### DIFF
--- a/lib/core/pmds/net/af_xdp/pmd_af_xdp.c
+++ b/lib/core/pmds/net/af_xdp/pmd_af_xdp.c
@@ -37,9 +37,6 @@
 
 #define ETH_AF_XDP_MBUF_MASK ~(ETH_AF_XDP_FRAME_SIZE - 1)
 
-#define AF_XDP_IFNAME_ARG "iface"
-#define AF_XDP_QCNT_ARG   "qcnt"
-
 struct xsk_umem_info {
     struct xsk_ring_prod fq;
     struct xsk_ring_cons cq;

--- a/lib/core/pmds/net/ring/pmd_ring.c
+++ b/lib/core/pmds/net/ring/pmd_ring.c
@@ -30,9 +30,6 @@
 #define CNE_PMD_RING_MAX_RX_RINGS 16
 #define CNE_PMD_RING_MAX_TX_RINGS 16
 
-#define CNE_PMD_RING_IFNAME_ARG "iface"
-#define CNE_PMD_RING_QCNT_ARG   "qcnt"
-
 struct ring_internal_args {
     cne_ring_t *rxq;
     cne_ring_t *txq;


### PR DESCRIPTION
Two pmds af_packet and ring had a couple defines where were not used anymore.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>