### PR TITLE
null pointer checks for inet_ntop4

### DIFF
--- a/lib/cnet/arp/cnet_arp.c
+++ b/lib/cnet/arp/cnet_arp.c
@@ -93,13 +93,13 @@ cnet_arp_add(int netif_idx, struct in_addr *addr, struct ether_addr *mac, int pe
         ret = fib_info_alloc(fi, entry);
         if (ret < 0)
             CNE_WARN("FIB allocate failed for %s\n",
-                     inet_ntop4(ipaddr, sizeof(ipaddr), &entry->pa, &mask));
+                     inet_ntop4(ipaddr, sizeof(ipaddr), &entry->pa, &mask) ?: "Invalid IP");
 
         idx = ret;
         if (cne_fib_add(fi->fib, addr->s_addr, 32, idx)) {
             fib_info_free(fi, idx);
             CNE_ERR("ARP add failed for %s\n",
-                    inet_ntop4(ipaddr, sizeof(ipaddr), &entry->pa, &mask));
+                    inet_ntop4(ipaddr, sizeof(ipaddr), &entry->pa, &mask) ?: "Invalid IP");
             cnet_arp_free(entry);
             return NULL;
         }
@@ -140,7 +140,7 @@ _arp_show(struct arp_entry *entry, void *arg __cne_unused)
     char ip[IP4_ADDR_STRLEN] = {0};
 
     addr.s_addr = be32toh(entry->pa.s_addr);
-    cne_printf("  [orange]%-15s[] ", inet_ntop4(ip, sizeof(ip), &addr, NULL));
+    cne_printf("  [orange]%-15s[] ", inet_ntop4(ip, sizeof(ip), &addr, NULL) ?: "Invalid IP");
     ether_format_addr(buf, sizeof(buf), &entry->ha);
     cne_printf("[yellow]%-17s[] ", buf);
 

--- a/lib/cnet/ipv4/cnet_ipv4.c
+++ b/lib/cnet/ipv4/cnet_ipv4.c
@@ -77,8 +77,8 @@ cnet_ipv4_dump(const char *msg, struct cne_ipv4_hdr *ip)
 
     cne_printf("[magenta]<<<< [orange]%s [magenta]>>>>[]\n", msg);
     cne_printf("      Src %s Dst %s cksum %04x version %d hlen %d %02x\n",
-               inet_ntop4(ip1, sizeof(ip1), (struct in_addr *)&ip->src_addr, NULL),
-               inet_ntop4(ip2, sizeof(ip2), (struct in_addr *)&ip->dst_addr, NULL),
+               inet_ntop4(ip1, sizeof(ip1), (struct in_addr *)&ip->src_addr, NULL) ?: "Invalid IP",
+               inet_ntop4(ip2, sizeof(ip2), (struct in_addr *)&ip->dst_addr, NULL) ?: "Invalid IP",
                be16toh(ip->hdr_checksum), ip->version_ihl >> 4, (ip->version_ihl & 0x0f) << 2,
                ip->version_ihl);
     cne_printf("      offset %d next_proto %d id %d ttl %d tlen %d tos %d\n", ip->fragment_offset,

--- a/lib/cnet/pcb/cnet_pcb.c
+++ b/lib/cnet/pcb/cnet_pcb.c
@@ -181,7 +181,7 @@ pcb_show(mempool_t *mp __cne_unused, void *obj_cb_arg __cne_unused, void *obj,
          unsigned n __cne_unused)
 {
     struct pcb_entry *pcb = (struct pcb_entry *)obj;
-    char fbuf[128], lbuf[128];
+    char fbuf[128], lbuf[128], *ret = NULL;
     char ip1[IP4_ADDR_STRLEN] = {0};
     char ip2[IP4_ADDR_STRLEN] = {0};
 
@@ -191,15 +191,15 @@ pcb_show(mempool_t *mp __cne_unused, void *obj_cb_arg __cne_unused, void *obj,
     cne_printf("[green]%-6s [orange] %04x [red]%6s[]", pcb->closed ? "Closed" : "Open",
                pcb->opt_flag, chnl_protocol_str(pcb->ip_proto));
 
-    if (snprintf(fbuf, sizeof(fbuf), "%s:%d",
-                 inet_ntop4(ip1, sizeof(ip1), &pcb->key.faddr.cin_addr, NULL),
+    ret = inet_ntop4(ip1, sizeof(ip1), &pcb->key.faddr.cin_addr, NULL);
+    if (snprintf(fbuf, sizeof(fbuf), "%s:%d", ret ? ret : "Invalid IP",
                  ntohs(CIN_PORT(&pcb->key.faddr))) < 0)
         CNE_RET("Truncated buffer data\n");
 
     cne_printf(" [orange]%20s[]", fbuf);
 
-    if (snprintf(lbuf, sizeof(lbuf), "%s:%d",
-                 inet_ntop4(ip2, sizeof(ip2), &pcb->key.laddr.cin_addr, NULL),
+    ret = inet_ntop4(ip2, sizeof(ip2), &pcb->key.laddr.cin_addr, NULL);
+    if (snprintf(lbuf, sizeof(lbuf), "%s:%d", ret ? ret : "Invalid IP",
                  ntohs(CIN_PORT(&pcb->key.laddr))) < 0)
         CNE_RET("Truncated buffer data\n");
 

--- a/lib/cnet/pcb/cnet_pcb.c
+++ b/lib/cnet/pcb/cnet_pcb.c
@@ -161,6 +161,7 @@ pcb_show_details(mempool_t *mp, void *obj_cb_arg __cne_unused, void *obj, unsign
     struct pcb_entry *pcb     = (struct pcb_entry *)obj;
     char ip1[IP4_ADDR_STRLEN] = {0};
     char ip2[IP4_ADDR_STRLEN] = {0};
+    char *ret                 = NULL;
 
     if (pcb->closed)
         return;
@@ -169,11 +170,10 @@ pcb_show_details(mempool_t *mp, void *obj_cb_arg __cne_unused, void *obj, unsign
     cne_printf("    mempool %p", mp);
     cne_printf(" ttl %d, closed %d, tos %d, flags %04x proto %s\n", pcb->ttl, pcb->closed, pcb->tos,
                pcb->opt_flag, chnl_protocol_str(pcb->ip_proto));
-    cne_printf("    Key: faddr %s:%d ",
-               inet_ntop4(ip1, sizeof(ip1), &pcb->key.faddr.cin_addr, NULL),
-               ntohs(CIN_PORT(&pcb->key.faddr)));
-    cne_printf("laddr %s:%d\n", inet_ntop4(ip2, sizeof(ip2), &pcb->key.laddr.cin_addr, NULL),
-               ntohs(CIN_PORT(&pcb->key.laddr)));
+    ret = inet_ntop4(ip1, sizeof(ip1), &pcb->key.faddr.cin_addr, NULL);
+    cne_printf("    Key: faddr %s:%d ", ret ?: "Invalid IP", ntohs(CIN_PORT(&pcb->key.faddr)));
+    ret = inet_ntop4(ip2, sizeof(ip2), &pcb->key.laddr.cin_addr, NULL);
+    cne_printf("laddr %s:%d\n", ret ?: "Invalid IP", ntohs(CIN_PORT(&pcb->key.laddr)));
 }
 
 static void

--- a/lib/cnet/route/cnet_route4.c
+++ b/lib/cnet/route/cnet_route4.c
@@ -49,13 +49,14 @@ cnet_route4_insert(int netdev_idx, struct in_addr *dst, struct in_addr *netmask,
         idx = fib_info_alloc(fi, rt);
         if (idx < 0)
             CNE_WARN("FIB allocate failed for %s\n",
-                     inet_ntop4(ip, sizeof(ip), &rt->nexthop, &rt->netmask));
+                     inet_ntop4(ip, sizeof(ip), &rt->nexthop, &rt->netmask) ?: "Invalid IP");
 
         depth = cne_prefixbits(rt->netmask.s_addr);
         if ((rc = cne_node_ip4_add_input(fi->fib, rt->nexthop.s_addr, depth, (uint32_t)idx))) {
             (void)fib_info_free(fi, idx);
             CNE_ERR_RET("Add %s Failed: %s\n",
-                        inet_ntop4(ip, sizeof(ip), &rt->nexthop, &rt->netmask), strerror(-rc));
+                        inet_ntop4(ip, sizeof(ip), &rt->nexthop, &rt->netmask) ?: "Invalid IP",
+                        strerror(-rc));
         }
     }
 
@@ -225,13 +226,14 @@ route4_dump(struct rt4_entry *rt, void *arg __cne_unused)
     mask.s_addr = htobe32(rt->netmask.s_addr);
     gate.s_addr = htobe32(rt->gateway.s_addr);
 
-    cne_printf("  [yellow]%-17s ", inet_ntop4(ip1, sizeof(ip1), &nh, NULL));
-    cne_printf("[orange]%-17s [cyan]%3d  ", inet_ntop4(ip2, sizeof(ip2), &mask, NULL),
-               rt->netif_idx);
+    cne_printf("  [yellow]%-17s ", inet_ntop4(ip1, sizeof(ip1), &nh, NULL) ?: "Invalid IP");
+    cne_printf("[orange]%-17s [cyan]%3d  ",
+               inet_ntop4(ip2, sizeof(ip2), &mask, NULL) ?: "Invalid IP", rt->netif_idx);
 
     netif = vec_ptr_at_index(this_cnet->netifs, rt->netif_idx);
     cne_printf("[orange]%-17s [cyan]%6d %7d   [magenta]%s[]\n",
-               inet_ntop4(ip3, sizeof(ip3), &gate, NULL), rt->metric, rt->timo, netif->ifname);
+               inet_ntop4(ip3, sizeof(ip3), &gate, NULL) ?: "Invalid IP", rt->metric, rt->timo,
+               netif->ifname);
 
     return 0;
 }

--- a/lib/cnet/sbin/cnet_ifshow.c
+++ b/lib/cnet/sbin/cnet_ifshow.c
@@ -60,11 +60,11 @@ netif_show(struct netif *netif, char *ifname)
 
         addr.s_addr = be32toh(netif->ip4_addrs[j].ip.s_addr);
         cne_printf("%9s[magenta]inet.%d[]: [orange]%-15s[]", "", j,
-                   inet_ntop4(ip1, sizeof(ip1), &addr, NULL));
+                   inet_ntop4(ip1, sizeof(ip1), &addr, NULL) ?: "Invalid IP");
 
         addr.s_addr = be32toh(netif->ip4_addrs[j].netmask.s_addr);
         cne_printf(" [magenta]netmask[]: [goldenrod]%-15s[]",
-                   inet_ntop4(ip2, sizeof(ip2), &addr, NULL));
+                   inet_ntop4(ip2, sizeof(ip2), &addr, NULL) ?: "Invalid IP");
 
         if (netif->ip4_addrs[j].broadcast.s_addr) {
             addr.s_addr = be32toh(netif->ip4_addrs[j].broadcast.s_addr);

--- a/lib/cnet/tcp/cnet_tcp.c
+++ b/lib/cnet/tcp/cnet_tcp.c
@@ -357,7 +357,7 @@ tcp_send_segment(struct tcb_entry *tcb, struct seg_entry *seg)
             char ip[INET6_ADDRSTRLEN + 4] = {0};
 
             CNE_ERR("No netif match %s\n",
-                    inet_ntop4(ip, sizeof(ip), &pcb->key.faddr.cin_addr, NULL));
+                    inet_ntop4(ip, sizeof(ip), &pcb->key.faddr.cin_addr, NULL) ?: "Invalid IP");
             pktmbuf_free(mbuf);
             return -1;
         }
@@ -365,7 +365,7 @@ tcp_send_segment(struct tcb_entry *tcb, struct seg_entry *seg)
             char ip[INET6_ADDRSTRLEN + 4] = {0};
 
             CNE_WARN("Route lookup failed %s\n",
-                     inet_ntop4(ip, sizeof(ip), &pcb->key.faddr.cin_addr, NULL));
+                     inet_ntop4(ip, sizeof(ip), &pcb->key.faddr.cin_addr, NULL) ?: "Invalid IP");
             pktmbuf_free(mbuf);
             return -1;
         }
@@ -374,9 +374,10 @@ tcp_send_segment(struct tcb_entry *tcb, struct seg_entry *seg)
         if ((k = cnet_ipv4_compare(nif, (void *)&pcb->key.faddr.cin_addr.s_addr)) == -1) {
             char ip[INET6_ADDRSTRLEN + 4] = {0};
 
-            CNE_WARN("cnet_ipv4_compare(%s) failed\n",
-                     inet_ntop4(ip, sizeof(ip), (struct in_addr *)&pcb->key.faddr.cin_addr.s_addr,
-                                NULL));
+            CNE_WARN(
+                "cnet_ipv4_compare(%s) failed\n",
+                inet_ntop4(ip, sizeof(ip), (struct in_addr *)&pcb->key.faddr.cin_addr.s_addr, NULL)
+                    ?: "Invalid IP");
             pktmbuf_free(mbuf);
             return -1;
         }


### PR DESCRIPTION
The returned pointer from the call to inet_ntop4 could be NULL and would be dereferenced in a call to cne_printf. Added a NULL pointer check to ensure that the null pointer does not get dereferenced.

Signed-off-by: Elza Mathew <elza.mathew@intel.com>

