### PR TITLE
build:update the install instructions for libbpf

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,16 +7,9 @@ instructions to run CNDP applications. For more information, refer to the CNDP d
 
 ## Prerequisites
 
-### apt proxy
-
-If required, create a proxy.conf and configure the apt proxy settings.
-
-```bash
-cat << EOF | sudo tee -a /etc/apt/apt.conf.d/proxy.conf
-Acquire::http::Proxy "http://user:password@proxy.server:port/";
-Acquire::https::Proxy "https://user:password@proxy.server:port/";
-EOF
-```
+If behind a proxy server you may need to setup a number of configurations to allow access via the server.
+Some commands i.e. apt-get, git, ssh, curl, wget and others will need configuration to work correctly.
+Please refer to apt-get, git and other documentations to enable access through a proxy server.
 
 ### dependencies
 
@@ -40,7 +33,15 @@ The [libbpf](https://github.com/libbpf/libbpf) is a dependency of CNDP. Starting
 it can be installed using apt. For earlier Ubuntu versions, or for users who want the latest code,
 it can be installed from source.
 
-### Install libbpf from package manager
+#### _Note:_
+
+Newer versions of libbpf greater than or equal to v0.7.0 require _libxdp_ to be installed. For now we
+can checkout a previous version v0.5.0 or v0.6.1 instead of installing _libxdp_.
+
+### Install libbpf-dev from package manager
+
+Use the following command on Ubuntu 20.10 and later to install the headers and libraries to build
+and run CNDP applications. If using an earlier Ubuntu version, you need to build libbpf from source.
 
 ```bash
 sudo apt-get install -y libbpf-dev
@@ -49,20 +50,24 @@ sudo apt-get install -y libbpf-dev
 ### Install libbpf from source
 
 ```bash
-https_proxy="https://user:password@proxy.server:port" git clone https://github.com/libbpf/libbpf.git
+git clone https://github.com/libbpf/libbpf.git
 cd libbpf
-git checkout ...
-make -C src
-sudo make -C src install
+git checkout v0.5.0  # or v0.6.1 if needing a newer version
+make -C src && sudo make -C src install
 ```
 
 The library and pkgconfig file is installed to /usr/lib64, which is not where the loader or
-pkg-config look. Fix this by editing the ldconfig and exporting the PKG_CONFIG_PATH.
+pkg-config looks. Fix this by editing the ldconfig file as suggested below.
 
 ```bash
 sudo vim /etc/ld.so.conf.d/x86_64-linux-gnu.conf
-# add /usr/lib64 line to the bottom of the file, save and exit.
+# add a line with /usr/lib64 to the bottom of the file, save and exit.
 sudo ldconfig
+```
+
+The following statement may be necessary if libbpf is installed from source instead of the package manager.
+
+```bash
 export PKG_CONFIG_PATH=/usr/lib64/pkgconfig
 ```
 

--- a/ansible/cndp-ansible/roles/install_libbpf/tasks/main.yml
+++ b/ansible/cndp-ansible/roles/install_libbpf/tasks/main.yml
@@ -27,7 +27,7 @@
 
 - name: Unarchive libbpf
   unarchive:
-    src: https://github.com/libbpf/libbpf/archive/refs/tags/v0.3.tar.gz
+    src: https://github.com/libbpf/libbpf/archive/refs/tags/v0.5.0.tar.gz
     dest: /tmp
     remote_src: yes
   when: bpf_static_installed.stat.exists == False or bpf_shared_installed.stat.exists == False
@@ -37,7 +37,7 @@
 
 - name: Install libbpf
   make:
-    chdir: /tmp/libbpf-0.3/src
+    chdir: /tmp/libbpf-0.5.0/src
     target: install
     params:
       NUM_THREADS: "{{ num_threads }}"

--- a/containerization/docker/Dockerfile
+++ b/containerization/docker/Dockerfile
@@ -19,12 +19,12 @@ RUN apt-get update && apt-get install -y \
     libpcap-dev \
     wget
 
-# Build and install libbpf
+# Build and install libbpf version >=0.3.0 and <=0.6.1
 SHELL ["/bin/bash", "-c"]
 RUN set -o pipefail \
-    && wget -q -O - https://github.com/libbpf/libbpf/archive/refs/tags/v0.3.tar.gz \
+    && wget -q -O - https://github.com/libbpf/libbpf/archive/refs/tags/v0.5.0.tar.gz \
     | tar -xzC / \
-    && make -j -C /libbpf-0.3/src install
+    && make -j -C /libbpf-0.5.0/src install
 
 # Copy CNDP sources, build, and install
 RUN mkdir /cndp

--- a/doc/guides/linux_gsg/linux_gsg.rst
+++ b/doc/guides/linux_gsg/linux_gsg.rst
@@ -145,35 +145,28 @@ On a NUMA machine with two nodes, pages should be allocated explicitly on separa
    For 1GB pages, it is not possible to reserve the hugepage memory after the system has booted.
 
 Prerequisites
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
-apt proxy
-^^^^^^^^^^
-If required, create a proxy.conf and configure the apt proxy settings.
+If behind a proxy server you may need to setup a number of configurations to allow access via the server.
+Some commands i.e. apt-get, git, ssh, curl, wget and others will need configuration to work correctly.
+Please refer to apt-get, git and other documentations to enable access through a proxy server.
 
-.. code-block:: console
-
-   cat << EOF | sudo tee -a /etc/apt/apt.conf.d/proxy.conf
-   Acquire::http::Proxy "http://user:password@proxy.server:port/";
-   Acquire::https::Proxy "https://user:password@proxy.server:port/";
-   EOF
-
-Optionally update apt.
+Optionally update apt-get.
 
 .. code-block:: console
 
-   sudo apt update
+   sudo apt-get update
 
 Apt-get is used to install the required packages to build CNDP and its dependencies.
 
-libbpf
-^^^^^^^
+Build libbpf
+~~~~~~~~~~~~
 
 The `libbpf <https://github.com/libbpf/libbpf>`_ is a dependency of CNDP. Starting with Ubuntu 20.10
-it can be installed using apt. For earlier Ubuntu versions, or for users who want the latest code,
-it can be installed from source.
+the libbpf libraries can be installed using apt-get. For earlier Ubuntu versions, or for users who
+want the latest code, it can be installed from source.
 
-**Install using apt**
+**Install using apt-get**
 
 .. code-block:: console
 
@@ -185,20 +178,30 @@ Install packages to build libbpf
 
 .. code-block:: console
 
-   sudo apt install -y build-essential pkg-config libelf-dev
+   sudo apt-get install -y build-essential pkg-config libelf-dev
 
 Clone, build, and install libbpf
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
    git clone https://github.com/libbpf/libbpf.git
-   cd libbpf/src
-   make
-   sudo make install
+   cd libbpf
+   git checkout v0.5.0   # or you can use v0.6.1 if needing a newer version
+   make -C src
+   sudo make -C src install
+   export PKG_CONFIG_PATH=/usr/lib64/pkgconfig
+
+Edit the file /etc/ld.so.conf.d/x86_64-linux-gnu.conf and add the line /usr/lib64 to the
+bottom of the file.
+
+.. code-block:: console
+
+   sudo vim /etc/ld.so.conf.d/x86_64-linux-gnu.conf   # add /usr/lib64 to file
+   sudo ldconfig     # force ldconfig to detect changes
 
 Build CNDP
-~~~~~~~~~~~
+~~~~~~~~~~
 
 Install packages to build CNDP
 
@@ -211,10 +214,10 @@ Optionally install packages to build documentation
 
 .. code-block:: console
 
-   sudo apt install -y doxygen python3-sphinx
+   sudo apt-get install -y doxygen python3-sphinx
 
 Clone and build CNDP
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
@@ -248,10 +251,10 @@ or to build the docs
 
 
 Run CNDP examples
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 helloworld
-"""""""""""
+""""""""""
 
 The most basic example is ``helloworld``.
 
@@ -303,18 +306,6 @@ updated from the package manager to one which natively supports many AF_XDP feat
 Prerequisites
 ~~~~~~~~~~~~~
 
-apt proxy
-^^^^^^^^^
-
-If required, create a proxy.conf and configure the apt proxy settings.
-
-.. code-block:: console
-
-   cat << EOF | sudo tee -a /etc/apt/apt.conf.d/proxy.conf
-   Acquire::http::Proxy "http://user:password@proxy.server:port/";
-   Acquire::https::Proxy "https://user:password@proxy.server:port/";
-   EOF
-
 dependencies
 ^^^^^^^^^^^^
 
@@ -322,7 +313,7 @@ apt-get should now work to install the packages needed to use ansible.
 
 .. code-block:: console
 
-   sudo apt update
+   sudo apt-get update
    sudo apt-get install -y ansible
 
 .. note::

--- a/lib/include/cne_common.h
+++ b/lib/include/cne_common.h
@@ -46,7 +46,7 @@ extern "C" {
 
 /**
  * Enable the use of shared UMEM if the kernel version >= 5.10 and we detect
- * in the top-level meson.build we have the correct libbpf version >= 0.3.0
+ * in the top-level meson.build we have the correct libbpf version >= 0.3.0 <= 0.6.1
  */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0) && HAS_XSK_UMEM_SHARED == 1
 #define CAN_USE_XSK_UMEM_SHARED 1

--- a/meson.build
+++ b/meson.build
@@ -163,17 +163,10 @@ if nl_cli_dep.found()
 endif
 
 cne_conf.set10('HAS_XSK_UMEM_SHARED', false)
-bpf_dep = dependency('libbpf', required: false, method: 'pkg-config')
-if not bpf_dep.found()
-    bpf_dep = cc.find_library('bpf', required: false)
-endif
-
+bpf_dep = dependency('libbpf', version: ['>=0.3.0', '<=0.6.1'], required: true, method: 'pkg-config')
 if bpf_dep.found() and cc.has_header('bpf/xsk.h') and cc.has_header('linux/if_xdp.h')
     extra_ldflags += '-lbpf'
-    bpf_ver_dep = dependency('libbpf', version: '>=0.3.0', required: false, method: 'pkg-config')
-    if bpf_ver_dep.found()
-        cne_conf.set10('HAS_XSK_UMEM_SHARED', true)
-    endif
+    cne_conf.set10('HAS_XSK_UMEM_SHARED', true)
 endif
 
 cne_conf.set('HAS_UINTR_SUPPORT', false)


### PR DESCRIPTION
Update the libbpf instructions when building from source or using
apt-get to install libbpf-dev package.

- CNDP needs libbpf version >=0.3.0 and <=0.6.1 to build.
- Make sure the install instructions give the correct build process for
  building v0.5.0 or v0.6.1.
- Updated the ansible main.yml file to pull and install the correct version
   of libbpf source code.
- Update the Dockerfile to pull and build v0.5.0.
- Update the linux_gsg guide to be inline with the install text.
- Change meson.build to require a libbpf version >=0.3.0 and <=0.6.1

Signed-off-by: Keith Wiles <keith.wiles@intel.com>