### PR TITLE
fix heap buffer overflow

### DIFF
--- a/lib/core/ring/cne_ring.c
+++ b/lib/core/ring/cne_ring.c
@@ -46,7 +46,7 @@ cne_ring_get_memsize_elem(unsigned int esize, unsigned int count)
             "Requested number of elements is invalid, must be power of 2, and not exceed %u\n",
             CNE_RING_SZ_MASK);
 
-    sz = sizeof(struct cne_ring) + count * esize;
+    sz = sizeof(struct cne_ring) + (ssize_t)count * esize;
     sz = CNE_ALIGN(sz, CNE_CACHE_LINE_SIZE);
     return sz;
 }


### PR DESCRIPTION
By fuzzing mempool_create(), a heap buffer overflow was detected in
ring[] while in the ENQUEUE_PTRS macro of the __cne_ring_do_enqueue function.
This was because the actual memory that was allocated for the ring was only the size
of the struct cne_ring. This happened because of an integer overflow
error in the calculation of ring size in cne_ring_get_memsize_elem. The multiplication
of count * esize was evaluating to zero.

Typecasting the unsigned int count to be ssize_t ensured that the multiplication
of count and esize did not evaluate to zero (because of the integer overflow), the
correct ring size memory was allocated and the heap buffer overflow was fixed.

Signed-off-by: Elza Mathew <elza.mathew@intel.com>