### PR TITLE
CI: Add docker image push to GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: Docker Image Build
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -16,5 +18,57 @@ jobs:
     - name: Check out repository code
       uses: actions/checkout@v2
 
-    - name: Build Docker Image
-      run: make docker-image
+    # Set an output parameter `arch` for use in subsequent steps
+    - name: Get processor architecture
+      id: system
+      run: |
+        echo ::set-output name=arch::$(uname -m)
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create tags and labels
+      id: image_meta
+      uses: docker/metadata-action@v3
+      with:
+        sep-tags: ","
+        sep-labels: ","
+        # list of names to use as base name for tags
+        images: |
+          ghcr.io/${{ github.repository_owner }}/cndp-ubuntu-${{ steps.system.outputs.arch }}
+        # Docker tags based on the following events/attributes
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
+
+    - name: Build Ubuntu Docker Image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: true
+        tags: "${{ steps.image_meta.outputs.tags }}"
+        file: containerization/docker/ubuntu/Dockerfile
+
+    - name: Build Fedora Docker Image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: true
+        tags: "${{ steps.image_meta.outputs.tags }}"
+        file: containerization/docker/fedora/Dockerfile


### PR DESCRIPTION
This makes use of the docker build-push-action [1] GitHub Action to push
docker images to GitHub Container Registry. Merges to master trigger
both docker builds and pushes to GHCR. Also, images for pull requests are
pushed to allow for testing of docker images for those PRs.

[1] https://github.com/docker/build-push-action

Signed-off-by: Kyle Mestery <mestery@mestery.com>