### PR TITLE
build:update deprecated functions

### DIFF
--- a/doc/api/meson.build
+++ b/doc/api/meson.build
@@ -24,7 +24,7 @@ htmldir = join_paths(get_option('datadir'), 'doc', 'cndp')
 # So use a configure option for now.
 example = custom_target('examples.dox',
 	output: 'examples.dox',
-	command: [generate_examples, join_paths(meson.source_root(), 'examples'), '@OUTPUT@'],
+	command: [generate_examples, join_paths(cndp_source_root, 'examples'), '@OUTPUT@'],
 	depfile: 'examples.dox.d',
 	install: get_option('enable_docs'),
 	install_dir: htmldir,
@@ -32,11 +32,11 @@ example = custom_target('examples.dox',
 
 cdata = configuration_data()
 cdata.set('VERSION', meson.project_version())
-cdata.set('API_EXAMPLES', join_paths(meson.build_root(), 'doc', 'api', 'examples.dox'))
-cdata.set('OUTPUT', join_paths(meson.build_root(), 'doc', 'api'))
+cdata.set('API_EXAMPLES', join_paths(cndp_build_root, 'doc', 'api', 'examples.dox'))
+cdata.set('OUTPUT', join_paths(cndp_build_root, 'doc', 'api'))
 cdata.set('HTML_OUTPUT', 'api')
-cdata.set('TOPDIR', meson.source_root())
-cdata.set('STRIP_FROM_PATH', meson.source_root())
+cdata.set('TOPDIR', cndp_source_root)
+cdata.set('STRIP_FROM_PATH', cndp_source_root)
 
 doxy_conf = configure_file(input: 'doxy-api.conf.in',
 	output: 'doxy-api.conf',

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,8 @@ project('CNDP', 'C', 'cpp',
 cc = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
 
+cndp_source_root = meson.current_source_dir()
+cndp_build_root = meson.current_build_dir()
 enable_asserts = get_option('enable_asserts')
 cne_verbose = get_option('verbose')
 cndp_libs = []


### PR DESCRIPTION
Starting in meson build 0.56 meson.build_root() and meson.source_root() are
being deprecated. This was found with Ubuntu 22.04 and meson version 0.61.2

Meson build reports the following.
NOTICE: Future-deprecated features used:
 * 0.56.0: {'meson.build_root', 'meson.source_root'}

It appears that meson.current_source_root() and meson.current_build_root() is
not deprecated and we can convert to using these.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>