### PR TITLE
cmon:add panel for netstat -s information

### DIFF
--- a/lang/go/tools/cmon/cmon.go
+++ b/lang/go/tools/cmon/cmon.go
@@ -22,7 +22,8 @@ import (
 
 const (
 	// cmtVersion string
-	cmtVersion = "20.11.0"
+	cmtVersion = "22.04.0"
+	timerSteps = 4
 )
 
 // PanelInfo for title and primitive
@@ -123,13 +124,14 @@ func main() {
 
 	app := cmon.app
 
-	cmon.timers = etimers.New(time.Second/4, 4)
+	cmon.timers = etimers.New(time.Second/timerSteps, timerSteps)
 	cmon.timers.Start()
 
 	panels := []Panels{
 		SysInfoPanelSetup,
 		ProcessPanelSetup,
 		IRQPanelSetup,
+		NetstatPanelSetup,
 	}
 
 	// The bottom row has some info on where we are.

--- a/lang/go/tools/cmon/go.mod
+++ b/lang/go/tools/cmon/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/CloudNativeDataPlane/cndp/lang/go/tools/pkgs/taborder v0.0.0-00010101000000-000000000000
 	github.com/CloudNativeDataPlane/cndp/lang/go/tools/pkgs/ttylog v0.0.0-00010101000000-000000000000
 	github.com/CloudNativeDataPlane/cndp/lang/go/tools/pkgs/utils v0.0.0-00010101000000-000000000000
-	github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1
+	github.com/gdamore/tcell/v2 v2.5.1
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/rivo/tview v0.0.0-20220307222120-9994674d60a8
 	github.com/shirou/gopsutil v3.21.11+incompatible
@@ -44,5 +44,5 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
-	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/text v0.3.7 // indirect
 )

--- a/lang/go/tools/cmon/go.sum
+++ b/lang/go/tools/cmon/go.sum
@@ -1,8 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
-github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1 h1:QqwPZCwh/k1uYqq6uXSb9TRDhTkfQbO80v8zhnIe5zM=
 github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1/go.mod h1:Az6Jt+M5idSED2YPGtwnfJV0kXohgdCBPmHGSYc1r04=
+github.com/gdamore/tcell/v2 v2.5.1 h1:zc3LPdpK184lBW7syF2a5C6MV827KmErk9jGVnmsl/I=
+github.com/gdamore/tcell/v2 v2.5.1/go.mod h1:wSkrPaXoiIWZqW/g7Px4xc79di6FTcpB8tvaKJ6uGBo=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
@@ -30,13 +31,15 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220318055525-2edf467146b5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f h1:rlezHXNlxYWvBCzNses9Dlc7nGFaNMJeqLolcmQSSZY=
 golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/lang/go/tools/cmon/helpers_tview.go
+++ b/lang/go/tools/cmon/helpers_tview.go
@@ -68,7 +68,7 @@ func CreateTextView(flex *tview.Flex, msg string, align, fixedSize, proportion i
 func CreateTableView(flex *tview.Flex, msg string, align, fixedSize, proportion int, focus bool) *tview.Table {
 	table := tview.NewTable().
 		SetFixed(1, 0).
-		SetSelectable(true, false)
+		SetEvaluateAllRows(true)
 
 	table.SetBorder(true).
 		SetTitle(TitleColor(msg)).

--- a/lang/go/tools/cmon/panel_netstat.go
+++ b/lang/go/tools/cmon/panel_netstat.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2019-2022 Intel Corporation
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	cz "github.com/CloudNativeDataPlane/cndp/lang/go/tools/pkgs/colorize"
+
+	tab "github.com/CloudNativeDataPlane/cndp/lang/go/tools/pkgs/taborder"
+	tlog "github.com/CloudNativeDataPlane/cndp/lang/go/tools/pkgs/ttylog"
+
+	"github.com/rivo/tview"
+)
+
+const (
+	netstatPanelName string = "Netstat"
+)
+
+// NetstatData - Hold the stats name and counter data
+type NetstatData struct {
+	Names    []string
+	Counters []uint64
+}
+
+type NetstatInfo struct {
+	Data map[string]*NetstatData
+}
+
+type dInfo struct {
+	filename string
+	sections []string
+	prev     *NetstatInfo
+}
+
+// NetstatPanel - Data for main page information
+type NetstatPanel struct {
+	tabOrder *tab.Tab
+	topFlex  *tview.Flex
+
+	netstat1       *tview.Table
+	netstat2       *tview.Table
+	changed        bool
+	redraw         bool
+	displaySeconds uint64
+
+	nInfo []*dInfo
+}
+
+// Setup and create the netstat panel structure
+func setupNetstatPanel() *NetstatPanel {
+
+	pg := &NetstatPanel{changed: true, redraw: true}
+
+	pg.nInfo = append(pg.nInfo, &dInfo{
+		filename: "/proc/net/snmp",
+		sections: []string{"IP", "UDP", "TCP", "ICMP", "ICMPMSG"},
+		prev:     &NetstatInfo{}})
+	pg.nInfo = append(pg.nInfo, &dInfo{
+		filename: "/proc/net/netstat",
+		sections: []string{"TCPEXT", "IPEXT", "MPTCPEXT"},
+		prev:     &NetstatInfo{}})
+
+	return pg
+}
+
+// NetstatPanelSetup setup the main event page
+func NetstatPanelSetup(nextSlide func()) (pageName string, content tview.Primitive) {
+
+	pg := setupNetstatPanel()
+
+	to := tab.New(netstatPanelName, cmon.app)
+	pg.tabOrder = to
+
+	flex0 := tview.NewFlex().SetDirection(tview.FlexRow)
+	flex1 := tview.NewFlex().SetDirection(tview.FlexRow)
+
+	TitleBox(flex0)
+
+	pg.netstat1 = CreateTableView(flex1, "SNMP (s) Update 3sec", tview.AlignLeft, 0, 1, true).
+		SetSeparator(tview.Borders.Vertical).
+		SetEvaluateAllRows(true)
+
+	pg.netstat2 = CreateTableView(flex1, "Netstat (n) Update 3sec", tview.AlignLeft, 0, 1, true).
+		SetSeparator(tview.Borders.Vertical).
+		SetEvaluateAllRows(true)
+
+	flex0.AddItem(flex1, 0, 2, true)
+
+	to.Add(pg.netstat1, 's')
+	to.Add(pg.netstat2, 'n')
+
+	to.SetInputDone()
+
+	pg.topFlex = flex0
+
+	pg.displayNetstatSNMP(pg.netstat1)
+	pg.displayNetstat(pg.netstat2)
+	pg.netstat1.ScrollToBeginning()
+	pg.netstat2.ScrollToBeginning()
+
+	cmon.timers.Add(netstatPanelName, func(step int, ticks uint64) {
+		if pg.topFlex.HasFocus() {
+			cmon.app.QueueUpdateDraw(func() {
+				pg.displayNetstatPanel(step, ticks)
+			})
+		} else {
+			pg.redraw = true
+		}
+	})
+
+	return netstatPanelName, pg.topFlex
+}
+
+// Display the netstat panel data
+func (pg *NetstatPanel) displayNetstatPanel(step int, ticks uint64) {
+
+	switch step {
+	case 0:
+		if pg.topFlex.HasFocus() {
+			pg.displaySeconds++
+			if pg.displaySeconds%3 == 0 {
+				pg.displayNetstatSNMP(pg.netstat1)
+				pg.displayNetstat(pg.netstat2)
+
+				if pg.changed {
+					pg.netstat1.ScrollToBeginning()
+					pg.netstat2.ScrollToBeginning()
+					pg.changed = false
+				}
+			}
+		}
+	}
+}
+
+func (pg *NetstatPanel) readData(filename string) (*NetstatInfo, error) {
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+
+	nInfo := &NetstatInfo{}
+	nInfo.Data = make(map[string]*NetstatData)
+
+	for {
+		ln, err := reader.ReadString('\n')
+		if err != nil || err == io.EOF {
+			break
+		}
+		lineData := strings.Fields(ln)
+
+		s := lineData[0]
+		s = s[0 : len(s)-1]
+		s = strings.ToUpper(s)
+
+		ni, ok := nInfo.Data[s]
+		if !ok {
+			ni := &NetstatData{Names: lineData[1:]}
+			nInfo.Data[s] = ni
+		} else {
+			for _, v := range lineData[1:] {
+				n, _ := strconv.ParseUint(v, 10, 64)
+				ni.Counters = append(ni.Counters, n)
+			}
+		}
+	}
+
+	return nInfo, nil
+}
+
+// Get the netstat information
+func (pg *NetstatPanel) netstatDisplay(table *tview.Table, displayType int) {
+
+	di := pg.nInfo[displayType]
+	nInfo, err := pg.readData(di.filename)
+	if err != nil {
+		tlog.DoPrintf("Reading %s failed\n", di.filename)
+		return
+	}
+
+	row := 0
+	col := 0
+	for _, v := range di.sections {
+		_, ok := nInfo.Data[v]
+		if !ok {
+			continue
+		}
+		SetCell(table, row, col, cz.SkyBlue(v)).SetAlign(tview.AlignCenter)
+		SetCell(table, row, col+1, cz.GoldenRod("Counters")).SetAlign(tview.AlignRight)
+		col += 2
+	}
+	row++
+	col = 0
+	for _, v := range di.sections {
+		ni, ok := nInfo.Data[v]
+		if !ok {
+			continue
+		}
+
+		pni, pok := di.prev.Data[v]
+		for i, s := range ni.Names {
+			SetCell(table, row, col, cz.MediumSpringGreen(s)).SetAlign(tview.AlignLeft)
+
+			n := fmt.Sprintf("%v", ni.Counters[i])
+			if pok && ni.Counters[i] != pni.Counters[i] {
+				SetCell(table, row, col+1, cz.Red(n)).SetAlign(tview.AlignRight)
+			} else {
+				SetCell(table, row, col+1, cz.CornSilk(n)).SetAlign(tview.AlignRight)
+			}
+			row++
+		}
+		col += 2
+		row = 1
+	}
+
+	di.prev = nInfo
+
+	if pg.redraw {
+		table.ScrollToBeginning()
+		pg.redraw = false
+	}
+}
+
+// Display the netstat information
+func (pg *NetstatPanel) displayNetstatSNMP(table *tview.Table) {
+
+	pg.netstatDisplay(table, 0)
+}
+
+// Display the next set of data points for the netstat
+func (pg *NetstatPanel) displayNetstat(table *tview.Table) {
+
+	pg.netstatDisplay(table, 1)
+}

--- a/lang/go/tools/pkgs/graphdata/go.mod
+++ b/lang/go/tools/pkgs/graphdata/go.mod
@@ -12,7 +12,6 @@ require (
 )
 
 require (
-	github.com/CloudNativeDataPlane/cndp/lang/go/tools/pkgs/ttylog v0.0.0-00010101000000-000000000000 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect


### PR DESCRIPTION
Add a panel to display the netstat -s information for easier reference.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>