### PR TITLE
Echo server example using cne and libpnet.

### DIFF
--- a/lang/rs/bindings/examples/echo_server/Cargo.toml
+++ b/lang/rs/bindings/examples/echo_server/Cargo.toml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2022 Intel Corporation.
+
+[package]
+name = "echo_server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# cndp-cne package is in cndp repo.
+# Cargo will crawl the entire cndp repo looking for cndp-cne package.
+cndp-cne = {git = "https://github.com/CloudNativeDataPlane/cndp", branch = "main" }
+crossbeam-channel = "0.5.4"
+clap = "2.33.3"
+ctrlc = "3.2.2"
+env_logger = "0.9.0"
+log = "0.4"
+pnet ="0.30.0"
+

--- a/lang/rs/bindings/examples/echo_server/fwd.jsonc
+++ b/lang/rs/bindings/examples/echo_server/fwd.jsonc
@@ -1,0 +1,151 @@
+{
+    // (R) - Required entry
+    // (O) - Optional entry
+    // All descriptions are optional and short form is 'desc'
+    // The order of the entries in this file are handled when it is parsed and the
+    // entries can be in any order.
+
+    // (R) Application information
+    //    name        - (O) the name of the application
+    //    description - (O) the description of the application
+    "application": {
+        "name": "loopback",
+        "description": "A simple loopback application"
+    },
+
+    // (O) Default values
+    //    bufcnt - (O) UMEM default buffer count in 1K increments
+    //    bufsz  - (O) UMEM buffer size in 1K increments
+    //    rxdesc - (O) Number of RX ring descriptors in 1K increments
+    //    txdesc - (O) Number of TX ring descriptors in 1K increments
+    //    cache  - (O) MBUF Pool cache size in number of entries
+    //    mtype  - (O) Memory type for mmap allocations
+    "defaults": {
+        "bufcnt":  16,
+        "bufsz":    2,
+        "rxdesc":   2,
+        "txdesc":   2,
+        "cache":  256,
+        "mtype": "2MB"
+    },
+
+    // List of all UMEM's to be created
+    // key/val - (R) The 'key' is the name of the umem for later reference.
+    //               The 'val' is the object describing the UMEM buffer.
+    //               Multiple umem regions can be defined.
+    // A UMEM can support multiple lports using the regions array. Each lports can use
+    // one of the regions.
+    //    bufcnt  - (R) The number of buffers in 1K increments in the UMEM space.
+    //    bufsz   - (R) The size in 1K increments of each buffer in the UMEM space.
+    //    mtype   - (O) If missing or empty string or missing means use 4KB or default system pages.
+    //    regions - (O) Array of sizes one per region in 1K increments, total must be <= bufcnt
+    //    rxdesc  - (O) Number of RX descriptors to be allocated in 1K increments,
+    //                  if not present or zero use defaults.rxdesc, normally zero.
+    //    txdesc  - (O) Number of TX descriptors to be allocated in 1K increments,
+    //                  if not present or zero use defaults.txdesc, normally zero.
+    //    shared_umem - (O) Set to true to use xsk_socket__create_shared() API, default false
+    //    description | desc - (O) Description of the umem space.
+    "umems": {
+        "umem0": {
+            "bufcnt":   32,
+            "bufsz":     2,
+            "mtype": "2MB",
+            "regions": [16, 16],
+            "rxdesc":    0,
+            "txdesc":    0,
+            "description": "UMEM Description 0"
+        }
+    },
+
+    // List of all lports to be used in the application
+    // An lport is defined by a netdev/queue ID pair, which is a socket containing a Rx/Tx ring pair.
+    // Each queue ID is assigned to a single socket or a socket is the lport defined by netdev/qid.
+    // Note: A netdev can be shared between lports as the qid is unique per lport
+    //       If netdev is not defined or empty then it must be a virtual interface and not
+    //       associated with a netdev/queue ID.
+    // key/val - (R) The 'key' is the logical name e.g. 'eth0:0', 'eth1:0', ... to be used by the
+    //               application to reference an lport. The 'val' object contains information about
+    //               each lport.
+    //    netdev        - (R) The netdev device to be used, the part before the colon
+    //                     must reflect the netdev name
+    //    pmd           - (R) All PMDs have a name i.e. 'net_af_xdp', 'ring', ...
+    //    qid           - (R) Is the queue id to use for this lport, defined by ethtool command line
+    //    umem          - (R) The UMEM assigned to this lport
+    //    region        - (O) UMEM region index value, default region 0
+    //    busy_poll     - (O) Enable busy polling support, true or false, default false
+    //    busy_timeout  - (O) 1-65535 or 0 - use default value, values in milli-seconds
+    //    busy_budget   - (O) -1 disabled, 0 use default, >0 budget value
+    //    unprivileged  - (O) inhibit loading the BPF program if true, default false
+    //    force_wakeup  - (O) force TX wakeup calls for CVL NIC, default false
+    //    skb_mode      - (O) Enable XDP_FLAGS_SKB_MODE when creating af_xdp socket, forces copy mode, default false
+    //    description   - (O) the description, 'desc' can be used as well
+    "lports": {
+        "enp134s0:0": {
+            "pmd": "net_af_xdp",
+            "qid": 23,
+            "umem": "umem0",
+            "region": 0,
+            "description": "LAN 0 port"
+        },
+        "enp134s0:1": {
+            "pmd": "net_af_xdp",
+            "qid": 33,
+            "umem": "umem0",
+            "region": 1,
+            "description": "LAN 1 port"
+        }
+    },
+
+    // (O) Define the lcore groups for each thread to run
+    //     Can be integers or a string for a range of lcores
+    //     e.g. [10], [10-14,16], [10-12, 14-15, 17-18, 20]
+    // Names of a lcore group and its lcores assigned to the group.
+    // The initial group is for the main thread of the application.
+    // The default group is special and is used if a thread if not assigned to a group.
+    "lcore-groups": {
+        "initial": [22],
+        "group0": [25],
+        "group1": [35],
+        "default": ["22-35"]
+    },
+
+    // (O) Set of common options application defined.
+    //     The Key can be any string and value can be boolean, string, array or integer
+    //     An array must contain only a single value type, boolean, integer, string and
+    //     can't be a nested array.
+    //   pkt_api    - (O) Set the type of packet API xskdev or pktdev
+    //   no-metrics - (O) Disable metrics gathering and thread
+    //   no-restapi - (O) Disable RestAPI support
+    //   cli        - (O) Enable/Disable CLI supported
+    //   mode       - (O) Mode type [drop | rx-only], tx-only, [lb | loopback], fwd, acl-strict, acl-permissive
+    //   uds_path   - (O) Path to unix domain socket to get xsk map fd
+    "options": {
+        "pkt_api": "pktdev",
+        "no-metrics": false,
+        "no-restapi": false,
+        "cli": true,
+        "mode": "drop"
+    },
+
+    // List of threads to start and information for that thread. Application can start
+    // it's own threads for any reason and are not required to be configured by this file.
+    //
+    //   Key/Val   - (R) A unique thread name.
+    //                   The format is <type-string>[:<identifier>] the ':' and identifier
+    //                   are optional if all thread names are unique
+    //      group  - (O) The lcore-group this thread belongs to. The
+    //      lports - (O) The list of lports assigned to this thread and can not shared lports.
+    //      description | desc - (O) The description
+    // NOTE: This section is not currently used in Rust CNE binding.
+    "threads": {
+        "main": {
+            "group": "initial",
+            "description": "CLI Thread"
+        },
+        "fwd:0": {
+            "group": "group0",
+            "lports": ["enp134s0:0"],
+            "description": "Thread 0"
+        }
+    }
+}

--- a/lang/rs/bindings/examples/echo_server/run.sh
+++ b/lang/rs/bindings/examples/echo_server/run.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Usage: ./run.sh <mode> <args>
+# if mode is pnet then
+# ./run.sh pnet <interface name>
+# eg 1: ./run.sh pnet enp134s0
+
+# if mode is cne then 
+# ./run.sh cne <json config file (optional)> <port id (optional)> <burst (optional)>
+# eg 1: ./run.sh cne -> Run using default values
+# eg 2:./run.sh cne ./fwd.jsonc 0 64 -> Run using user specified values.
+
+cargo build --release
+
+# Mode - pnet or cne. Default is cne.
+MODE=${1:-"cne"}
+
+if [[ "$MODE" == "pnet" ]]; then
+    # interface name.
+    IFACE=${2:-"enp134s0"}
+
+    sudo -E RUST_LOG=info `which cargo` run --release -- $MODE -i $IFACE
+elif [ "$MODE" == "cne" ]; then
+    # JSON file. Use default jsonc file in library crate.
+    CONFIG=${2:-"fwd.jsonc"}
+
+    # Port id. Use 0 as default port id.
+    PORT=${3:-0}
+
+    # Port id. Use 256 as default burst size.
+    BURST=${4:-256}
+
+    # Need to LD_PRELOAD libpmd_af_xdp.so since Rust binary doesn't include it and is required for applications.
+    # Including libpmd_af_xdp.so as whole-archive during linking of rust binary doesn't seem to work.
+    sudo -E LD_LIBRARY_PATH=$LD_LIBRARY_PATH LD_PRELOAD=$LD_LIBRARY_PATH/libpmd_af_xdp.so RUST_LOG=info `which cargo` run --release -- $MODE -c $CONFIG -p $PORT -b $BURST
+else
+    cargo run --release -- help
+fi
+
+stty sane

--- a/lang/rs/bindings/examples/echo_server/src/main.rs
+++ b/lang/rs/bindings/examples/echo_server/src/main.rs
@@ -1,0 +1,300 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020-2022 Intel Corporation.
+ */
+
+use clap::{App, Arg};
+use crossbeam_channel::{bounded, select, tick, Receiver};
+
+use cne::error::CneError;
+use cne::instance::CneInstance;
+use cne::packet::PacketInterface;
+use cne::port::Port;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use pnet::datalink::Channel::Ethernet;
+use pnet::datalink::{self, NetworkInterface};
+use pnet::packet::ethernet::MutableEthernetPacket;
+
+
+// Example echo server implementation using cne and libpnet library.
+// CNE based echo server receives and sends layer 2 packets using AF-XDP socket.
+// libpnet based echo server receives and sends layer 2 packets using AF_PACKET.
+// This application requires an external load generator (s/w or h/w) to send packets
+// to required n/w interface. The performance of CNE/libpnet echo server can be checked
+// at load generator end by observing packets per sec (pps) of echoed packets.
+// An example script run.sh is provided to build and run the application. Please refer
+// the script for descrption on how to run the application with command line parameters.
+fn main() {
+    // Parse command line arguments.
+    let matches = App::new("echo_server")
+        .version("0.1.0")
+        .about("Echo server application using pnet and cne.")
+        .subcommand(
+            App::new("pnet").about("pnet based echo server").arg(
+                Arg::with_name("interface")
+                    .short("i")
+                    .long("interface")
+                    .required(true)
+                    .takes_value(true)
+                    .help("Network interface name"),
+            ),
+        )
+        .subcommand(
+            App::new("cne")
+                .about("cne based echo server")
+                .arg(
+                    Arg::with_name("config")
+                        .short("c")
+                        .long("config")
+                        .required(true)
+                        .takes_value(true)
+                        .help("CNE JSONC config file"),
+                )
+                .arg(
+                    Arg::with_name("port")
+                        .short("p")
+                        .long("port")
+                        .required(true)
+                        .takes_value(true)
+                        .help("port index in JSON file"),
+                )
+                .arg(
+                    Arg::with_name("burst")
+                        .short("b")
+                        .long("burst")
+                        .required(false)
+                        .takes_value(true)
+                        .help("packet burst size. Default is 256"),
+                ),
+        )
+        .get_matches();
+
+    // Start logging.
+    env_logger::builder()
+        .try_init()
+        .expect("Failed to initialize event logger");
+
+    log::info!("Echo server example application. Press ctrl-c to exit");
+
+    // Parse sub command parameters.
+    match matches.subcommand() {
+        ("pnet", Some(pnet_matches)) => {
+            // Parse interface name.
+            let interface_name = pnet_matches
+                .value_of("interface")
+                .unwrap()
+                .parse::<String>()
+                .expect("Invalid interface name");
+
+            pnet_echo_server(&interface_name);
+        }
+        ("cne", Some(cne_matches)) => {
+            // Parse CNE JSONC config file.
+            let jsonc_file = cne_matches
+                .value_of("config")
+                .unwrap()
+                .parse::<String>()
+                .expect("Invalid CNE JSON file name");
+
+            // Parse port id.
+            let port_id = cne_matches
+                .value_of("port")
+                .unwrap()
+                .parse::<u16>()
+                .expect("Invalid port number");
+
+            // Burst size.
+            let mut burst_size = cne::packet::Packet::MAX_BURST;
+            if cne_matches.is_present("burst") {
+                burst_size = cne_matches
+                    .value_of("burst")
+                    .unwrap()
+                    .parse::<usize>()
+                    .expect("Invalid burst size");
+            }
+
+            cne_echo_server(&jsonc_file, port_id, burst_size);
+        }
+        _ => {
+            log::error!("Invalid mode. Mode should be either pnet or cne");
+        }
+    }
+}
+
+// Echo server based on libpnet library.
+// Uses AF_PACKET to receive/send layer 2 packets. It receives/sends only one packet at a time.
+fn pnet_echo_server(interface_name: &str) {
+    // Find the network interface matching the iface name.
+    let interfaces = datalink::interfaces();
+    let interface = interfaces
+        .into_iter()
+        .find(|iface: &NetworkInterface| iface.name == interface_name)
+        .unwrap();
+
+    // Create datalink channel. Sends and receives data link layer packets using Linux's AF_PACKET.
+    let (mut tx, mut rx) = match datalink::channel(&interface, Default::default()) {
+        Ok(Ethernet(tx, rx)) => (tx, rx),
+        Ok(_) => {
+            panic!("channel type not supported")
+        }
+        Err(e) => panic!("Error creating the datalink channel: {}", e),
+    };
+
+    loop {
+        match rx.next() {
+            Ok(packet) => {
+                // Constructs a packet of same length as the the one received, using the provided closure.
+                // The packet is sent once the closure has finished executing.
+                tx.build_and_send(1, packet.len(), &mut |new_packet| {
+                    // Create a clone of the original packet.
+                    new_packet.clone_from_slice(packet);
+                    // Swap the source and destination mac addresses.
+                    swap_mac_address(new_packet);
+
+                });
+            }
+            Err(e) => {
+                // If an error occurs, we can handle it here
+                log::error!("An error occurred while reading: {}", e);
+                return;
+            }
+        }
+    }
+}
+
+// Echo server based on CNE library.
+// Uses AF_XDP socket to receive/send layer 2 packets. It receives/sends packets in burst.
+// Burst size is configurable.
+fn cne_echo_server(jsonc_file: &str, port_id: u16, burst_size: usize) {
+    // Get CNE instance.
+    let cne = CneInstance::get_instance();
+
+    // Configure CNE.
+    if let Err(e) = cne.configure(jsonc_file) {
+        log::error!("Error configuring CNE: {}", e.to_string());
+        return;
+    }
+
+    // Get CNE port to receive/send packets.
+    let port = cne.get_port(port_id);
+
+    // Check if port is valid.
+    if let Err(ref e) = port {
+        log::error!("{}", e.to_string());
+        // Cleanup and exit.
+        if let Err(e) = cne.cleanup() {
+            log::error!("{}", e.to_string());
+        }
+        return;
+    }
+    let port = port.unwrap();
+
+    // Create ctrl-c channel to check for ctrl-c event.
+    let ctrl_c_events = ctrl_channel().unwrap();
+
+    // Create channel for periodic logging.
+    let ticks = tick(Duration::from_secs(1));
+
+    // Variable to check if application is running.
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+
+    // Spawn thread to receive/send packets.
+    let port_clone = port.clone();
+    let handle = thread::spawn(move || {
+        // Register thread with CNE.
+        let cne = CneInstance::get_instance();
+        let tid = cne.register_thread("echo").unwrap();
+
+        while r.load(Ordering::SeqCst) {
+            if let Err(e) = cne_macswap_and_send(&port_clone, burst_size) {
+                log::error!("cne echo server error: {}", e.to_string());
+                break;
+            }
+        }
+        // Unregister thread.
+        cne.unregister_thread(tid).unwrap();
+    });
+
+    // Get port stats. Wait for ctrl-c event from user.
+    loop {
+        select! {
+            recv(ticks) -> _ => {
+                if running.load(Ordering::SeqCst) {
+                    let port_stats = port.get_port_stats().unwrap();
+                    log::debug!("CNE Port Stats = {:?}", port_stats);
+                }
+            }
+            recv(ctrl_c_events) -> _ => {
+                log::info!("Got ctrl-c event");
+                running.store(false, Ordering::SeqCst);
+                break;
+            }
+        }
+    }
+
+    // Wait for echo thread to finish.
+    handle.join().unwrap();
+
+    // Cleanup CNE.
+    let ret = cne.cleanup();
+    if let Err(e) = ret {
+        log::error!("{}", e.to_string());
+    }
+}
+
+// Channel to handle ctrl-c input from user.
+fn ctrl_channel() -> Result<Receiver<()>, ctrlc::Error> {
+    let (sender, receiver) = bounded(16);
+    ctrlc::set_handler(move || {
+        let _ = sender.send(());
+    })?;
+
+    Ok(receiver)
+}
+
+// Receives burst of packets from port, swaps mac addresses and send packets on same port.
+fn cne_macswap_and_send(port: &Port, burst_size: usize) -> Result<(), CneError> {
+    let mut rx_pkts = vec![cne::packet::Packet::default(); burst_size];
+
+    let pkts_read = port.rx_burst(&mut rx_pkts[..burst_size])? as usize;
+    log::debug!("Number of packets read = {}", pkts_read);
+
+    if pkts_read > 0 {
+        for i in 0..pkts_read {
+            let pkt = &rx_pkts[i as usize];
+            let data = pkt.get_data_mut();
+            if let Some(data) = data {
+                // Swap mac address.
+                swap_mac_address(data);
+            }
+        }
+
+        let mut pkts_sent = 0;
+        let mut max_tries = 10;
+        // Try sending back all the packets in a loop with threshold on number of tries.
+        while pkts_sent < pkts_read && max_tries > 0 {
+            let tx_sent = port.tx_burst(&mut rx_pkts[pkts_sent..pkts_read])? as usize;
+            pkts_sent += tx_sent;
+            max_tries -= 1;
+        }
+        log::debug!("Number of packets sent = {}", pkts_sent);
+        // Free packets which are not sent.
+        if pkts_sent < pkts_read {
+            cne::packet::Packet::free_packet_buffer(&mut rx_pkts[pkts_sent..pkts_read]);
+        }
+    }
+
+    Ok(())
+}
+
+fn swap_mac_address(p: &mut [u8]) {
+    let mut packet = MutableEthernetPacket::new(p).unwrap();
+    let src = packet.get_source();
+    packet.set_source(packet.get_destination());
+    packet.set_destination(src);
+}


### PR DESCRIPTION
- Example echo server implementation using cne and libpnet library.
- CNE receives and sends layer 2 packets using AF-XDP socket.
- libpnet receives and sends layer 2 packets using AF_PACKET.
- This application requires a load generator (s/w or h/w) to send packets
  to required n/w interface.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>