### PR TITLE
cleanup node inits

### DIFF
--- a/lib/cnet/chnl/chnl_recv.c
+++ b/lib/cnet/chnl/chnl_recv.c
@@ -162,17 +162,9 @@ chnl_recv_node_process(struct cne_graph *graph, struct cne_node *node, void **ob
     return nb_objs;
 }
 
-static int
-chnl_recv_node_init(const struct cne_graph *graph __cne_unused, struct cne_node *node __cne_unused)
-{
-    return 0;
-}
-
 static struct cne_node_register chnl_recv_node_base = {
     .process = chnl_recv_node_process,
     .name    = CHNL_RECV_NODE_NAME,
-
-    .init = chnl_recv_node_init,
 
     .nb_edges = CHNL_RECV_NEXT_MAX,
     .next_nodes =

--- a/lib/cnet/ipv4/ip4_input.c
+++ b/lib/cnet/ipv4/ip4_input.c
@@ -246,20 +246,9 @@ cne_node_ip4_add_input(struct cne_fib *fib, uint32_t ip, uint8_t depth, uint32_t
     return cne_fib_add(fib, ip, depth, nh);
 }
 
-static int
-ip4_input_node_init(const struct cne_graph *graph, struct cne_node *node)
-{
-    CNE_SET_USED(graph);
-    CNE_SET_USED(node);
-
-    return 0;
-}
-
 static struct cne_node_register ip4_input_node = {
     .process = ip4_input_node_process,
     .name    = IP4_INPUT_NODE_NAME,
-
-    .init = ip4_input_node_init,
 
     .nb_edges = CNE_NODE_IP4_INPUT_NEXT_MAX,
     .next_nodes =

--- a/lib/cnet/ipv4/ip4_output.c
+++ b/lib/cnet/ipv4/ip4_output.c
@@ -265,15 +265,6 @@ ip4_output_node_process(struct cne_graph *graph, struct cne_node *node, void **o
     return nb_objs;
 }
 
-static int
-ip4_output_node_init(const struct cne_graph *graph, struct cne_node *node)
-{
-    CNE_SET_USED(graph);
-    CNE_SET_USED(node);
-
-    return 0;
-}
-
 int
 ip4_output_set_next(uint16_t port_id, uint16_t next_index)
 {
@@ -290,8 +281,6 @@ ip4_output_set_next(uint16_t port_id, uint16_t next_index)
 static struct cne_node_register ip4_output_node = {
     .process = ip4_output_node_process,
     .name    = IP4_OUTPUT_NODE_NAME,
-
-    .init = ip4_output_node_init,
 
     .nb_edges = IP4_OUTPUT_NEXT_MAX,
     .next_nodes =

--- a/lib/cnet/nodes/drop.c
+++ b/lib/cnet/nodes/drop.c
@@ -24,19 +24,9 @@ pkt_drop_process(struct cne_graph *graph, struct cne_node *node, void **objs, ui
     return nb_objs;
 }
 
-static int
-pkt_drop_node_init(const struct cne_graph *graph, struct cne_node *node)
-{
-    CNE_SET_USED(graph);
-    CNE_SET_USED(node);
-
-    return 0;
-}
-
 static struct cne_node_register pkt_drop_node = {
     .process = pkt_drop_process,
     .name    = PKT_DROP_NODE_NAME,
-    .init    = pkt_drop_node_init,
 };
 
 CNE_NODE_REGISTER(pkt_drop_node);

--- a/lib/cnet/udp/cnet_udp_chnl.c
+++ b/lib/cnet/udp/cnet_udp_chnl.c
@@ -5,7 +5,7 @@
 /* cnet_udp_chnl.c - UDP chnl support routines. */
 
 /**
- * This module is the interface between the generic sockets module and the UDP
+ * This module is the interface between the generic channels module and the UDP
  * protocol processing module.
  */
 
@@ -33,8 +33,8 @@
 #include "cnet_protosw.h"        // for
 #include "pktmbuf.h"             // for pktmbuf_free, pktmbuf_data_len, pktmbuf_t
 
-/**
- * This routine initializes the UDP-specific portions of a new socket.
+/*
+ * This routine initializes the UDP-specific portions of a new channel.
  *
  * RETURNS: 0 or -1.
  */
@@ -92,9 +92,9 @@ udp_chnl_channel2(struct chnl *ch1, struct chnl *ch2)
     return 0;
 }
 
-/**
+/*
  * This routine is the protocol-specific bind() back-end function for
- * UDP sockets.
+ * UDP channels.
  *
  * RETURNS: 0 or -1.
  */
@@ -110,9 +110,9 @@ udp_chnl_bind(struct chnl *ch, struct in_caddr *to, int tolen)
     return ret;
 }
 
-/**
+/*
  * This routine is the protocol-specific send() back-end function for
- * UDP sockets.
+ * UDP channels.
  *
  */
 static int
@@ -140,7 +140,6 @@ udp_chnl_send(struct chnl *ch, pktmbuf_t **mbufs, uint16_t nb_mbufs)
                 continue;
         }
 
-        /* When userptr is NULL we free the mbuf later */
         m->userptr = ch->ch_pcb;
     }
 
@@ -156,12 +155,9 @@ udp_shutdown(struct chnl *ch __cne_unused, int how __cne_unused)
 }
 
 static struct chnl *
-udp_accept(struct chnl *ch, struct in_caddr *addr, int *addrlen)
+udp_accept(struct chnl *ch __cne_unused, struct in_caddr *addr __cne_unused,
+           int *addrlen __cne_unused)
 {
-    CNE_SET_USED(ch);
-    CNE_SET_USED(addr);
-    CNE_SET_USED(addrlen);
-
     return NULL;
 }
 
@@ -172,7 +168,7 @@ udp_listen(struct chnl *ch __cne_unused, int backlog __cne_unused)
 }
 
 static struct proto_funcs udpFuncs = {
-    .channel_func  = udp_chnl_channel,     /**< Socket Initialize routine */
+    .channel_func  = udp_chnl_channel,     /**< Channel Initialize routine */
     .channel2_func = udp_chnl_channel2,    /**< Channel2 Initialize routine */
     .close_func    = chnl_OK,              /**< close routine */
     .send_func     = udp_chnl_send,        /**< send routine */

--- a/lib/cnet/udp/udp_output.c
+++ b/lib/cnet/udp/udp_output.c
@@ -58,8 +58,7 @@ udp_output_header(pktmbuf_t *m, uint16_t nxt)
 }
 
 static uint16_t
-udp_output_node_process(struct cne_graph *graph, struct cne_node *node, void **objs,
-                        uint16_t nb_objs)
+udp_output_node_do(struct cne_graph *graph, struct cne_node *node, void **objs, uint16_t nb_objs)
 {
     pktmbuf_t *mbuf0, *mbuf1, *mbuf2, *mbuf3, **pkts;
     cne_edge_t next0, next1, next2, next3;
@@ -199,17 +198,16 @@ udp_output_node_process(struct cne_graph *graph, struct cne_node *node, void **o
     return nb_objs;
 }
 
-static int
-udp_output_node_init(const struct cne_graph *graph __cne_unused, struct cne_node *node __cne_unused)
+static uint16_t
+udp_output_node_process(struct cne_graph *graph, struct cne_node *node, void **objs,
+                        uint16_t nb_objs)
 {
-    return 0;
+    return udp_output_node_do(graph, node, objs, nb_objs);
 }
 
 static struct cne_node_register udp_output_node_base = {
     .process = udp_output_node_process,
     .name    = UDP_OUTPUT_NODE_NAME,
-
-    .init = udp_output_node_init,
 
     .nb_edges = UDP_OUTPUT_NEXT_MAX,
     .next_nodes =


### PR DESCRIPTION
Some of the nodes contained a init function and they are not required.
Cleanup some comments to be correct.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>