### PR TITLE
change punt node from TUN to Raw socket

### DIFF
--- a/lib/cnet/punt/kernel_recv_priv.h
+++ b/lib/cnet/punt/kernel_recv_priv.h
@@ -13,7 +13,16 @@ extern "C" {
 struct kernel_recv_node_elem;
 struct kernel_recv_node_ctx;
 
-#define KERN_RECV_MBUF_COUNT (4 * 1024) /**< Number of mbufs for kernel receive */
+#define KERN_RECV_MBUF_COUNT  (4 * 1024) /**< Number of mbufs for kernel receive */
+#define KERN_RECV_CACHE_COUNT 64
+
+typedef struct kernel_recv_info {
+    pktmbuf_info_t *pi;
+    mmap_t *mm;
+    uint16_t idx;
+    uint16_t cnt;
+    pktmbuf_t *rx_bufs[KERN_RECV_CACHE_COUNT];
+} kernel_recv_info_t;
 
 /**
  * @internal
@@ -21,8 +30,8 @@ struct kernel_recv_node_ctx;
  * Kernel Recv node context structure.
  */
 typedef struct kernel_recv_node_ctx {
-    struct tap_info *tinfo;
-    pktmbuf_info_t *pi;
+    int sock;
+    kernel_recv_info_t *recv_info;
 } kernel_recv_node_ctx_t;
 
 /**

--- a/lib/cnet/punt/punt_kernel_priv.h
+++ b/lib/cnet/punt/punt_kernel_priv.h
@@ -21,7 +21,7 @@ typedef struct punt_kernel_node_elem punt_kernel_node_elem_t;
  * PUNT Kernel node context structure.
  */
 typedef struct punt_kernel_node_ctx {
-    struct tap_info *tinfo;
+    int sock;
 } punt_kernel_node_ctx_t;
 
 /**


### PR DESCRIPTION
The original code used a TUN interface to sent/recv traffic with the kernel
stack. This turned out to not work in all cases as a TUN is a point-2-point
type interface and sending traffic from CNDP to Linux stack would not get
sent to a host application waiting for packets not handled by CNET.

When redirecting say all UDP packets to CNDP to a destination port not handled
by CNDP these should be punted to the Linux stack for processing. This allows host
applications waiting on the destination port to process the packets. If not it should
discard the packets.

Let say we have CNET stack listening for UDP destination port 1234 and a packet arrives
for say dest-port 6666 then these packets must me punted to the Linux stack. Using
ethtool all UDP frames are redirected to CNDP. In the case of dest-port 6666,
we punt the packets to the linux kernel stack via a raw socket to handle.

Here is one way to setup for testing on two machines one running CNDP(DUT) and the
other one a normal machine. Start up cnet-graph with listening to 1234 or some port,
then using socat on both machines we can do this:

DUT:
$ socat -b 1400 - UDP-RECV:6666

Remote:
$ xxd /boot/vmlinuz > testfile.txt
$ cat testfile.txt | socat UDP-SENDTO:198.18.2.2:6666 -

On the DUT you should see the testfile.txt printed to the screen. Note the -b 1400 is
to force Linux to not support jumbo frames as af_xdp does not support it.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>