### PR TITLE
testcne: add functional tests for cne lib to testcne

### DIFF
--- a/test/testcne/cli_cmds.c
+++ b/test/testcne/cli_cmds.c
@@ -12,34 +12,35 @@
 #include <cli.h>             // for c_cmd, cli_path_string, cli_add_bin_path
 #include <tst_info.h>        // for tst_error
 
-#include "testcne.h"             // for init_tree, my_prompt, setup_cli
-#include "acl_test.h"            // for acl_main
-#include "cthread_test.h"        // for cthread_main
-#include "dsa_test.h"            // for dsa_main
-#include "jcfg_test.h"           // for jcfg_main
-#include "loop_test.h"           // for loop_main
-#include "mbuf_test.h"           // for mbuf_main
-#include "mempool_test.h"        // for mempool_main
-#include "mmap_test.h"           // for mmap_main
-#include "pktcpy_test.h"         // for pktcpy_main
-#include "cne_lport.h"           // for lport_stats_t
-#include "pkt_test.h"            // for pkt_main
-#include "ring_test.h"           // for ring_main
-#include "ring_api.h"            // for ring_api_main
-#include "ring_profile.h"        // for ring_profile
-#include "thread_test.h"         // for thread_main
-#include "uid_test.h"            // for uid_main
-#include "pktdev_test.h"         // for pktdev_main
-#include "kvargs_test.h"         // for kvargs_main
-#include "graph_test.h"          // for graph_main, graph_perf_main
-#include "hmap_test.h"           // for hmap_main
-#include "timer_test.h"          // for timer_main
-#include "xskdev_test.h"         // for xskdev_main
-#include "netdev_funcs.h"        // for netdev_link
-#include "log_test.h"            // for log_main
-#include "hash_test.h"           // for hash_main, hash_perf_main
-#include "rib_test.h"            // for rib_main, rib6_main
-#include "fib_test.h"            // for fib_main, fib_perf_main, fib6_main, fib6_perf_main
+#include "testcne.h"                  // for init_tree, my_prompt, setup_cli
+#include "acl_test.h"                 // for acl_main
+#include "cne_register_test.h"        // for cne_register_main
+#include "cthread_test.h"             // for cthread_main
+#include "dsa_test.h"                 // for dsa_main
+#include "jcfg_test.h"                // for jcfg_main
+#include "loop_test.h"                // for loop_main
+#include "mbuf_test.h"                // for mbuf_main
+#include "mempool_test.h"             // for mempool_main
+#include "mmap_test.h"                // for mmap_main
+#include "pktcpy_test.h"              // for pktcpy_main
+#include "cne_lport.h"                // for lport_stats_t
+#include "pkt_test.h"                 // for pkt_main
+#include "ring_test.h"                // for ring_main
+#include "ring_api.h"                 // for ring_api_main
+#include "ring_profile.h"             // for ring_profile
+#include "thread_test.h"              // for thread_main
+#include "uid_test.h"                 // for uid_main
+#include "pktdev_test.h"              // for pktdev_main
+#include "kvargs_test.h"              // for kvargs_main
+#include "graph_test.h"               // for graph_main, graph_perf_main
+#include "hmap_test.h"                // for hmap_main
+#include "timer_test.h"               // for timer_main
+#include "xskdev_test.h"              // for xskdev_main
+#include "netdev_funcs.h"             // for netdev_link
+#include "log_test.h"                 // for log_main
+#include "hash_test.h"                // for hash_main, hash_perf_main
+#include "rib_test.h"                 // for rib_main, rib6_main
+#include "fib_test.h"                 // for fib_main, fib_perf_main, fib6_main, fib6_perf_main
 #ifdef HAS_UINTR_SUPPORT
 #include "ibroker_test.h"        // for ibroker_main
 #endif
@@ -97,6 +98,7 @@ static int
 all_tests(int argc, char **argv)
 {
     acl_main(argc, argv);
+    cne_register_main(argc, argv);
     cthread_main(argc, argv);
     dsa_main(argc, argv);
     fib_main(argc, argv);
@@ -141,6 +143,7 @@ static struct cli_tree default_tree[] = {
 
     c_cmd("acl", acl_main, "Run the ACL tests"),
     c_cmd("all", all_tests, "Run all tests"),
+    c_cmd("cne", cne_register_main, "Run the CNE registration tests"),
     c_cmd("cthread", cthread_main, "Run the cthread API test"),
     c_cmd("dsa", dsa_main, "Run the dsa API test"),
     c_cmd("fib", fib_main, "Run the FIB test"),

--- a/test/testcne/cne_register_test.c
+++ b/test/testcne/cne_register_test.c
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2019-2022 Intel Corporation
+ */
+
+// IWYU pragma: no_include <bits/getopt_core.h>
+
+#include <stdio.h>             // for NULL, EOF
+#include <stdint.h>            // for uint16_t, uint32_t
+#include <cne.h>               // for cne_register, cne_unregister
+#include <tst_info.h>          // for tst_error, tst_end, tst_start, TST_FAILED
+#include <getopt.h>            // for getopt_long, option
+#include <cne_common.h>        // for CNE_SET_USED
+
+#include "cne_register_test.h"
+
+static void
+__on_exit(int sig __cne_unused, void *arg __cne_unused, int exit_type __cne_unused)
+{
+    return;
+}
+
+static int
+cne_register_test(void)
+{
+    int tuid, cuid, tcnt, ret = 0;
+    int v = 1234, vv = 0;
+    void *setv  = &v;
+    void *tempv = &vv;
+    void **getv = &tempv;
+
+    tuid = cne_register("TestCNERegister");
+    if (tuid)
+        tst_ok("PASS --- TEST: New thread registered, uid %d\n", tuid);
+
+    cuid = cne_entry_uid();
+    if (tuid != cuid) {
+        tst_error("Invalid uid\n");
+        goto err;
+    } else
+        tst_ok("PASS --- TEST: Current uid retrieved, %d\n", tuid);
+
+    ret = cne_set_private(tuid, setv);
+    if (ret < 0) {
+        tst_error("Unable to set a private value for uid = %d\n", tuid);
+        goto err;
+    } else
+        tst_ok("PASS --- TEST: Set private value, %d\n", *(int *)setv);
+
+    ret = cne_get_private(tuid, getv);
+    if (ret < 0) {
+        tst_error("Unable to get the private value for uid = %d\n", tuid);
+        goto err;
+    } else
+        tst_ok("PASS --- TEST: Retrieved private value, %d\n", *(int *)*getv);
+
+    if (*(int *)setv != *(int *)*getv) {
+        tst_error("Incorrect private value for uid = %d\n", tuid);
+        goto err;
+    } else
+        tst_ok("PASS --- TEST: The set private value was retrieved\n");
+
+    tcnt = cne_active_threads();
+    if (tcnt < 0) {
+        tst_error("Error retrieving total active threads\n");
+        goto err;
+    } else
+        tst_ok("PASS --- TEST: Total number of active threads, %d\n", tcnt);
+
+    if (tuid) {
+        if (cne_unregister(tuid) < 0) {
+            tst_error("cne_unregister(%d) failed\n", tuid);
+            return -1;
+        } else
+            tst_ok("PASS --- TEST: uid %d unregistered\n", tuid);
+    }
+
+    ret = cne_on_exit(__on_exit, NULL, NULL, 0);
+    if (ret < 0) {
+        tst_error("Error on exit\n");
+        goto err;
+    } else
+        tst_ok("PASS --- TEST: Exit CNE Registration test\n");
+
+    return 0;
+
+err:
+    if (tuid)
+        cne_unregister(tuid);
+    return -1;
+}
+
+int
+cne_register_main(int argc, char **argv)
+{
+    tst_info_t *tst;
+    int verbose = 0, opt;
+    char **argvopt;
+    int option_index;
+    static const struct option lgopts[] = {{NULL, 0, 0, 0}};
+
+    argvopt = argv;
+    while ((opt = getopt_long(argc, argvopt, "V", lgopts, &option_index)) != EOF) {
+        switch (opt) {
+        case 'V':
+            verbose = 1;
+            break;
+        default:
+            break;
+        }
+    }
+    CNE_SET_USED(verbose);
+
+    tst = tst_start("CNE Registration");
+
+    if (cne_register_test() < 0)
+        goto err;
+
+    tst_end(tst, TST_PASSED);
+    return 0;
+err:
+    tst_end(tst, TST_FAILED);
+    return -1;
+}

--- a/test/testcne/cne_register_test.h
+++ b/test/testcne/cne_register_test.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Intel Corporation
+ */
+
+#ifndef _CNE_REGISTER_TEST_H_
+#define _CNE_REGISTER_TEST_H_
+
+/**
+ * @file
+ * CNE Setup Test
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int cne_register_main(int argc, char **argv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CNE_REGISTER_TEST_H_ */

--- a/test/testcne/meson.build
+++ b/test/testcne/meson.build
@@ -16,6 +16,7 @@ subdir('files/json') # Copy files for jcfg test
 # Keep lists sorted
 sources = files(
     'acl_test.c',
+    'cne_register_test.c',
     'cli_cmds.c',
     'cthread_test.c',
     'dsa_test.c',
@@ -108,6 +109,7 @@ testcne = executable('test-cne',
 
 test_names = [
     'acl',
+    'cne',
     'dsa',
     'fib',
     'fib_perf',


### PR DESCRIPTION
Add functional tests relevant to lib/core/cne/cne.[ch]
to testcne. Functions which are covered by other testcne
tests are not covered.

Signed-off-by: Sushma Sitaram <sushma.sitaram@intel.com>