### PR TITLE
pmd memif fix overwriting mbuf header.

### DIFF
--- a/lib/core/pmds/net/memif/pmd_memif_socket.c
+++ b/lib/core/pmds/net/memif/pmd_memif_socket.c
@@ -544,13 +544,13 @@ cne_pmd_memif_socket_rx(void *queue, pktmbuf_t **bufs, uint16_t nb_pkts)
             goto no_free_bufs;
         mbuf        = mbuf_head;
         mbuf->lport = mq->in_port;
+        dst_off     = 0;
 
     next_slot:
         s0 = cur_slot & mask;
         d0 = &ring->desc[s0];
 
         src_len = d0->length;
-        dst_off = 0;
         src_off = 0;
 
         do {


### PR DESCRIPTION
This change came from DPDK and the following commit message.

   "The 'dst_off' was reset in multi segment case.
   This caused memif buffer segment to write to
   beginning of mbuf, overwriting previous data.
   Fix it with this patch.

   Fixes: 09c7e63a71f9 ("net/memif: introduce memory interface PMD")
   Cc: stable@dpdk.org

   Reported-by: Ferruh Yigit <ferruh.yigit@xilinx.com>
   Signed-off-by: Joyce Kong <joyce.kong@arm.com>
   Reviewed-by: Ruifeng Wang <ruifeng.wang@arm.com>"

Signed-off-by: Keith Wiles <keith.wiles@intel.com>