### PR TITLE
update GitHub CI action to use libbpf v0.5.0

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -25,10 +25,10 @@ jobs:
 
     - name: Install libbpf
       run: |
-        wget -q -O - https://github.com/libbpf/libbpf/archive/refs/tags/v0.3.tar.gz \
+        wget -q -O - https://github.com/libbpf/libbpf/archive/refs/tags/v0.5.0.tar.gz \
         | tar -xzC ${GITHUB_WORKSPACE} \
-        && sudo make -j -C ${GITHUB_WORKSPACE}/libbpf-0.3/src install \
-        && sudo rm -rf ${GITHUB_WORKSPACE}/libbpf-0.3
+        && sudo make -j -C ${GITHUB_WORKSPACE}/libbpf-0.5.0/src install \
+        && sudo rm -rf ${GITHUB_WORKSPACE}/libbpf-0.5.0
 
     - name: Build
       run: make


### PR DESCRIPTION
Updated the GitHub smoke test action to use the libbpf version
0.5.0.

Signed-off-by: Elza Mathew <elza.mathew@intel.com>