### PR TITLE
golang dependabot alert fixes

### DIFF
--- a/lang/go/tools/cmon/go.sum
+++ b/lang/go/tools/cmon/go.sum
@@ -42,4 +42,4 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=

--- a/lang/go/tools/pkgs/irq/go.mod
+++ b/lang/go/tools/pkgs/irq/go.mod
@@ -22,3 +22,4 @@ require (
 	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+require gopkg.in/yaml.v3 v3.0.0

--- a/lang/go/tools/pkgs/utils/go.mod
+++ b/lang/go/tools/pkgs/utils/go.mod
@@ -3,6 +3,7 @@ module github.com/CloudNativeDataPlane/cndp/lang/go/tools/pkgs/utils
 go 1.18
 
 require github.com/shirou/gopsutil v3.21.11+incompatible
+require gopkg.in/yaml.v3 v3.0.0
 
 require (
 	github.com/go-ole/go-ole v1.2.6 // indirect


### PR DESCRIPTION
Require gopkg.in/yaml.v3 or later. An issue in the Unmarshal function in
Go-Yaml v3 causes the program to crash when attempting to
deserialize invalid input. Reported by Dependabot on GitHub.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>