### PR TITLE
Unit test fixes

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -35,3 +35,9 @@ jobs:
 
     - name: Short test
       run: meson test -C builddir --suite short
+
+    - name: Upload testlog
+      uses: actions/upload-artifact@v3
+      with:
+        name: testlog.txt
+        path: ${{ github.workspace }}/builddir/meson-logs/testlog.txt

--- a/lib/usr/app/jcfg/jcfg_lport_group.c
+++ b/lib/usr/app/jcfg/jcfg_lport_group.c
@@ -240,6 +240,11 @@ setup_umem(jcfg_info_t *jinfo, jcfg_data_t *data, jcfg_lport_group_t *lpg)
     else
         umem->mtype = mmap_type_by_name((const char *)v);
 
+    /* All lports in the group use the same region */
+    umem->rinfo = calloc(1, sizeof(*umem->rinfo));
+    if (!umem->rinfo)
+        CNE_ERR_GOTO(err_out, "Out of memory\n");
+
     umem->region_cnt      = 1;
     umem->rinfo[0].bufcnt = umem->bufcnt;
 
@@ -256,8 +261,10 @@ setup_umem(jcfg_info_t *jinfo, jcfg_data_t *data, jcfg_lport_group_t *lpg)
     return 0;
 
 err_out:
-    if (umem)
+    if (umem) {
+        free(umem->rinfo);
         free(umem->name);
+    }
     free(umem);
     return -1;
 }

--- a/test/testcne/files/json/test-strings.jsonc
+++ b/test/testcne/files/json/test-strings.jsonc
@@ -2,3 +2,4 @@
 { "defaults": {} }
 { "defaults": { "foo": "null", "bar": 2, "foobar": 3 }}
 { "defaults": [ 10, 12, 13, "str"] }
+{ "user1-data": { "a key": "a value" }}

--- a/test/testcne/jcfg_test.c
+++ b/test/testcne/jcfg_test.c
@@ -138,18 +138,18 @@ test_json_files(const char *path, int flags)
         cne_printf("\n** Process file  : %s\n\n", pent->d_name);
         snprintf(fullpath, sizeof(fullpath), "%s/%s", path, pent->d_name);
 
-        if (strcmp(pent->d_name, "test-strings.jsonc"))
+        if (!strcmp(pent->d_name, "test-strings.jsonc"))
             TST_ASSERT_GOTO(jcfg_add_decoder(USER1_DATA_TAG, _user1_decode) >= 0,
                             "jcfg_add_decoder(%s) failed\n", err, USER1_DATA_TAG);
 
         jinfo = jcfg_parser(flags, fullpath);
         if (!jinfo)
-            break;
+            continue;
 
         if (jcfg_process(jinfo, flags, process_callback, NULL))
             CNE_ERR_RET("*** Invalid configuration ***\n");
 
-        if (strcmp(pent->d_name, "test-strings.jsonc"))
+        if (!strcmp(pent->d_name, "test-strings.jsonc"))
             TST_ASSERT_GOTO(jcfg_del_decoder(USER1_DATA_TAG) == 0, "jcfg_del_decoder(%s) failed\n",
                             err, USER1_DATA_TAG);
 

--- a/test/testcne/meson.build
+++ b/test/testcne/meson.build
@@ -130,7 +130,6 @@ test_names = [
     'mempool',
     'mmap',
     'pkt',
-    'pktcopy',
     'ring',
     'sizeof',
     'thread',
@@ -145,6 +144,7 @@ test_names_with_iface = [
 test_names_long_runtime = [
     'cthread',
     'hash_perf',
+    'pktcpy',
     'rib',
     'rib6',
     'ring_api',
@@ -155,16 +155,17 @@ test_names_long_runtime = [
 # Run each test as a separate meson 'test' so they run in parallel and have their own timeout
 # Tests in this first group are short and do not need to run as root or have a real network
 foreach n:test_names
-    test(n, testcne, suite: ['default', 'short'], timeout: 60, args: [n])
+    test(n, testcne, suite: ['default', 'short'], timeout: 60, args: ['--no-color', n])
 endforeach
 
 # Require real network interface, cannot be run in parallel, and must be root.
 # The interface must be passed as a "--test-args='-- -i <iface>'" parameter
 foreach n:test_names_with_iface
-   test(n, testcne, suite: ['root-iface-short'], is_parallel: false, timeout: 60, args: [n])
+   test(n, testcne, suite: ['root-iface-short'], is_parallel: false, timeout: 60,
+        args: ['--no-color', n])
 endforeach
 
 # These tests take a long time to run, up to 30 minutes
 foreach n:test_names_long_runtime
-   test(n, testcne, suite: ['long'], timeout: 60*30, args: [n])
+   test(n, testcne, suite: ['long'], timeout: 60*30, args: ['--no-color', n])
 endforeach


### PR DESCRIPTION
* Fix bug in lport group umem setup
* Fix bug in jcfg test that exits early if a file cannot be parsed
* Fix pktcpy test and disable color output when using meson test since it writes to a file, not a terminal
* Update the GitHub Smoke test action to upload the resulting testlog.txt to help debug errors