### PR TITLE
cleanup some comments and spelling mistakes

### DIFF
--- a/lib/cnet/chnl/cnet_chnl.c
+++ b/lib/cnet/chnl/cnet_chnl.c
@@ -65,7 +65,7 @@ _chnl_buf_init(mempool_t *mp, void *opaque_arg __cne_unused, void *_b, unsigned 
         vec_free(ch->ch_rcv.cb_vec);
 }
 
-/**
+/*
  * This routine allocates a chnl structure from the free list,
  * and initializes it for use.
  */
@@ -104,7 +104,7 @@ chnl_alloc(void)
     return ch;
 }
 
-/**
+/*
  * This routine re-initializes a chnl structure, and returns it to the free
  * list.
  */
@@ -160,7 +160,7 @@ chnl_free(struct chnl *ch)
     mempool_put(stk->chnl_objs, (void *)ch);
 }
 
-/**
+/*
  * This routine flushes all queued data in a chnl buffer.
  */
 static void
@@ -179,18 +179,14 @@ chnl_cbflush(struct chnl_buf *cb)
         CNE_RET("Unable to release lock\n");
 }
 
-/**
- * This routine is called as the last part of the close() sequence,
- * to flush all queued data, wake up all tasks blocked on the chnl,
- * and to release all associated data structures back to their free lists.
+/*
+ * This routine is called as the last part of the close() sequence.
  */
 void
 chnl_cleanup(struct chnl *ch)
 {
-    if (!ch) {
-        CNE_ERR("Socket NULL\n");
-        return;
-    }
+    if (!ch)
+        CNE_RET("Channel NULL\n");
 
     if (ch->ch_state & _CHNL_FREE)
         CNE_RET("Already free!\n");
@@ -222,7 +218,7 @@ chnl_cleanup(struct chnl *ch)
     chnl_free(ch);
 }
 
-/**
+/*
  * This routine waits on a chnl buffer semaphore, which could mean the caller
  * is waiting for data for a read or space to write data. The CB_WAIT flag is
  * set to indicate to chnl_sbwakeup() when some thead or threads are waiting on
@@ -260,7 +256,7 @@ chnl_cb_wait(struct chnl *ch, struct chnl_buf *cb)
     return rc;
 }
 
-/**
+/*
  * The routine wakes up threads waiting on a read, write and/or select states to
  * change allowing the waiting threads to be awoken. The waiting threads are on
  * the chnl buffer condition variable for reading data or space to write
@@ -316,10 +312,10 @@ chnl_copy_data(pktmbuf_t **to, pktmbuf_t **from, int len)
     return bytes;
 }
 
-/**
+/*
  * This routine opens a chnl and returns a chnl descriptor.
  * The chnl descriptor is passed to the other chnl routines to identify the
- * packet.
+ * channel to process.
  */
 struct chnl *
 channel(int domain, int type, int proto, chnl_cb_t cb)
@@ -335,14 +331,14 @@ channel(int domain, int type, int proto, chnl_cb_t cb)
     return ch;
 }
 
-/**
+/*
  * This routine allocates and initializes a new chnl structure.
  *
  * If the <ppcb> or parent PCB is not null then use some information from
  * the parent chnl structure.
  *
  * @return
- *   struct chnl pointer, or NULL.
+ *   struct chnl pointer or NULL.
  */
 struct chnl *
 __chnl_create(int32_t dom, int32_t type, int32_t pro, struct pcb_entry *ppcb)
@@ -429,7 +425,7 @@ __chnl_create(int32_t dom, int32_t type, int32_t pro, struct pcb_entry *ppcb)
     return ch;
 }
 
-/**
+/*
  * This routine shuts down the receive and/or send side of a connection.
  *
  * On a TCP chnl, shutting down the send side initiates a protocol-level
@@ -474,7 +470,7 @@ chnl_shutdown(struct chnl *ch, int how)
     return status;
 }
 
-/**
+/*
  * This routine associates a network address (also referred to as its "name")
  * with a chnl ch that other processes can connect or send to it.
  * When a chnl is created with chnl(), it belongs to an address family
@@ -512,7 +508,7 @@ leave:
     return rs;
 }
 
-/**
+/*
  * If <ch> is a stream chnl, this routine establishes a virtual circuit
  * between <ch> and another chnl specified by <name>.  If <ch> is a datagram
  * packet, it permanently specifies the peer to which messages are sent.
@@ -599,7 +595,7 @@ chnl_connect2(struct chnl *ch1, struct chnl *ch2)
     return rs;
 }
 
-/**
+/*
  * This routine enables connections to a stream chnl. After enabling
  * connections with listen(), connections are actually accepted by accept().
  */
@@ -616,7 +612,7 @@ chnl_listen(struct chnl *ch, int backlog)
     return rs;
 }
 
-/**
+/*
  * This routine accepts an incoming connection on a parent chnl <s>, and
  * returns a new child chnl created for the connection.  The parent chnl
  * must be bound to an address with bind(), and enabled for accepting new
@@ -640,7 +636,7 @@ chnl_accept(struct chnl *ch, struct sockaddr *sa, socklen_t *addrlen)
     return new_ch;
 }
 
-/**
+/*
  * This routine gets the current name for the specified chnl.
  *
  * @param ch
@@ -682,7 +678,7 @@ chnl_getchnlname(struct chnl *ch, struct sockaddr *sa, socklen_t *namelen)
     return 0;
 }
 
-/**
+/*
  * This routine gets the name of the peer connected to the specified chnl.
  *
  * @param ch
@@ -752,7 +748,7 @@ sendit(struct chnl *ch, struct sockaddr *sa, pktmbuf_t **mbufs, uint16_t nb_mbuf
     return ch->ch_proto->funcs->send_func(ch, mbufs, nb_mbufs);
 }
 
-/**
+/*
  * This routine transmits data to a previously connected chnl.
  *
  * @param ch
@@ -810,7 +806,7 @@ chnl_fcntl(struct chnl *ch __cne_unused, int cmd __cne_unused, ...)
     return 0;
 }
 
-/**
+/*
  * This routine implements the bulk of the bind() function, for all chnl
  * types.  It takes an additional argument pHd, which is a pointer to a
  * 'struct pcb_hd' structure.  There is one 'struct pcb_hd' per protocol, and it
@@ -857,7 +853,7 @@ chnl_bind_common(struct chnl *ch, struct in_caddr *addr, int32_t len, struct pcb
     in_caddr_copy(&key.laddr, &laddr);
     in_caddr_copy(&key.faddr, &zero_faddr);
 
-    /* If lport is unassigned, obtain the next ephemeral port value */
+    /* If local port is unassigned, obtain the next ephemeral port value */
     if (CIN_PORT(&laddr) == 0) {
         uint16_t prevPort = hd->lport;
 
@@ -911,7 +907,7 @@ chnl_bind_common(struct chnl *ch, struct in_caddr *addr, int32_t len, struct pcb
     return 0;
 }
 
-/**
+/*
  * This routine is the protocol-specific connect() back-end function for
  * datagram chnls.
  */
@@ -989,7 +985,7 @@ chnl_list(stk_t *stk)
     }
 }
 
-/**
+/*
  * This is a protocol back-end routine for operations that don't need to do
  * any further work.
  *
@@ -1001,7 +997,7 @@ chnl_OK(struct chnl *ch __cne_unused)
     return 0;
 }
 
-/**
+/*
  * This is a protocol back-end routine for operations that don't need to do
  * any further work.
  *
@@ -1013,7 +1009,7 @@ chnl_NULL(struct chnl *ch __cne_unused)
     return NULL;
 }
 
-/**
+/*
  * This is a protocol back-end routine for operations that are not supported
  * by the protocol.
  *

--- a/lib/cnet/chnl/cnet_chnl.h
+++ b/lib/cnet/chnl/cnet_chnl.h
@@ -417,7 +417,7 @@ ch_writeable(struct chnl *ch)
     int ret;
 
     if (!ch) {
-        CNE_ERR("Channal is NULL\n");
+        CNE_ERR("Channel is NULL\n");
         return 0;
     }
 
@@ -482,7 +482,7 @@ CNDP_API void chnl_cleanup(struct chnl *ch);
  * @param pro
  *   The proto type value
  * @param pcb
- *   The PCB structure pointer to update.
+ *   The parent PCB pointer, can be NULL.
  * @return
  *   NULL on error or pointer to channel structure.
  */

--- a/lib/cnet/chnl/cnet_chnl_opt.c
+++ b/lib/cnet/chnl/cnet_chnl_opt.c
@@ -19,7 +19,7 @@
 #include "cnet_protosw.h"        // for protosw_entry
 
 /**
- * This library provides an extension mechanism for socket option
+ * This library provides an extension mechanism for channel option
  * processing.  Protocol processing modules can register to receive
  * setsockopt() and getsockopt() calls for options that are not
  * understood by the core setsockopt() and getsockopt() functions.
@@ -27,7 +27,7 @@
 
 /**
  * Add a sockopt switch structure.  There can be multiple handlers for each
- * level (e.g. IPPROTO_IP handlers for raw socket options, multicast options,
+ * level (e.g. IPPROTO_IP handlers for raw channel options, multicast options,
  * etc).
  *
  * RETURNS: 0, or -1 if the switch table is full
@@ -355,7 +355,6 @@ chnl_optval_get(const void *optval, uint32_t optlen)
 int
 chnl_set_opt(struct chnl *ch, int level, int optname, const void *optval, int optlen)
 {
-    /*tv_t *tv; FIXME */
     uint32_t val = 0;
     int rs       = 0;
 

--- a/lib/cnet/cnet/cnet.h
+++ b/lib/cnet/cnet/cnet.h
@@ -55,7 +55,7 @@ enum {
 };
 
 /**
- * @brief Get the currect cnet structure pointer.
+ * @brief Get the current cnet structure pointer.
  *
  * @return
  *   Pointer to struct cnet* or NULL on error.

--- a/lib/cnet/netif/cnet_netif.h
+++ b/lib/cnet/netif/cnet_netif.h
@@ -82,7 +82,7 @@ struct netif {
     uint16_t mtu;                              /**< Max Transmission Unit */
     char ifname[IF_NAMESIZE + 1];              /**< ifname of interface */
     char netdev_name[IF_NAMESIZE + 1];         /**< netdev name of interface */
-    struct drv_entry *drv;                     /**< Device interface structure */
+    struct drv_entry *drv;                     /**< Driver interface structure */
     struct rt4_entry *rt_cached;               /**< Route Cache */
     struct inet4_addr ip4_addrs[NUM_IP_ADDRS]; /**< Multiple IP addresses for Interface */
     struct ether_addr mac;                     /**< MAC address of interface */

--- a/lib/cnet/pcb/cnet_pcb.h
+++ b/lib/cnet/pcb/cnet_pcb.h
@@ -144,10 +144,10 @@ CNDP_API struct pcb_entry *cnet_pcb_lookup(struct pcb_hd *hd, struct pcb_key *ke
 CNDP_API void cnet_pcb_dump(stk_t *stk);
 
 /**
- * @brief Dump out the details information for the stack PCB list.
+ * Dump out the details information for the stack PCB list.
  *
  * @param stk
- *   The stack instance pointer to use for dumping the data.
+ *   The stack instance pointer to use for dumping all PCBs in instance.
  * @return
  *   N/A
  */

--- a/lib/cnet/protosw/cnet_protosw.c
+++ b/lib/cnet/protosw/cnet_protosw.c
@@ -15,7 +15,7 @@
 
 /**
  * This module manages the list of "protocol switch" structures, each of which
- * corresponds to a socket type, e.g. {AF_INET, SOCK_DGRAM, IPPROTO_UDP}.
+ * corresponds to a channel type, e.g. {AF_INET, SOCK_DGRAM, IPPROTO_UDP}.
  */
 static struct protosw_entry *ipproto_table[CNET_MAX_IPPROTO];
 

--- a/lib/core/pktmbuf/pktmbuf.h
+++ b/lib/core/pktmbuf/pktmbuf.h
@@ -759,9 +759,7 @@ __pktmbuf_free_bulk(pktmbuf_pending_t *p, pktmbuf_t *m)
 static inline void
 pktmbuf_free_bulk(pktmbuf_t **mbufs, unsigned int count)
 {
-    pktmbuf_pending_t pend;
-    memset(&pend, 0, sizeof(pend));
-    pend.pending_sz = PKTMBUF_PENDING_SZ;
+    pktmbuf_pending_t pend = {.pending_sz = PKTMBUF_PENDING_SZ};
 
     if (count == 0)
         return;

--- a/lib/core/xskdev/xskdev.c
+++ b/lib/core/xskdev/xskdev.c
@@ -680,7 +680,7 @@ xskdev_recv_xsk_fd(xskdev_info_t *xi)
     len = strlcat(xsk_map_fd_msg, xi->ifname, sizeof(xsk_map_fd_msg));
 
     if (send(xi->uds_info->sock, xsk_map_fd_msg, len, 0) <= 0)
-        CNE_ERR_RET("Failed to send /xsk_map_fd mesg\n");
+        CNE_ERR_RET("Failed to send /xsk_map_fd message\n");
     else
         CNE_DEBUG("Sent %s msg\n", xsk_map_fd_msg);
 

--- a/usrtools/txgen/app/cmds.c
+++ b/usrtools/txgen/app/cmds.c
@@ -19,7 +19,7 @@
 #include "txgen.h"        // for txgen_packet_ctor, txgen, txgen_t, txgen_c...
 #include "cmds.h"
 #include "display.h"              // for display_resume, display_pause, ...
-#include "cne_inet.h"             // for ip4addr, ip4addr::(anonymous), inet_ntop4
+#include "cne_inet.h"             // for inet_ntop4
 #include "_pcap.h"                // for pcap_info_t
 #include "capture.h"              // for txgen_set_capture
 #include "cli.h"                  // for cli_quit

--- a/usrtools/txgen/app/ipv4.c
+++ b/usrtools/txgen/app/ipv4.c
@@ -7,7 +7,7 @@
 
 #include "txgen.h"        // for txgen, txgen_t
 #include "ipv4.h"
-#include "cne_inet.h"          // for ip4addr, ip4addr::(anonymous), IPv4_VERSION
+#include "cne_inet.h"          // for IPv4_VERSION
 #include "net/cne_ip.h"        // for cne_ipv4_hdr, cne_ipv4_cksum
 
 /**

--- a/usrtools/txgen/app/stats.c
+++ b/usrtools/txgen/app/stats.c
@@ -16,7 +16,7 @@
 #include "cmds.h"                 // for txgen_flags_string, txgen_link_state, txge...
 #include "display.h"              // for display_set_color, display_dashline
 #include "txgen.h"                // for COLUMN_WIDTH_0, COLUMN_WIDTH_1, txgen, txg...
-#include "cne_inet.h"             // for inet_ntop4, ip4addr, ip4addr::(anonymous)
+#include "cne_inet.h"             // for inet_ntop4
 #include <net/cne_ether.h>        // for inet_mtoa
 #include "cne_lport.h"            // for lport_stats_t
 #include "cne_log.h"

--- a/usrtools/txgen/app/tcp.c
+++ b/usrtools/txgen/app/tcp.c
@@ -7,7 +7,7 @@
 
 #include "txgen.h"        // for DEFAULT_ACK_NUMBER, DEFAULT_PKT_NUMBER, DEF...
 #include "tcp.h"
-#include "cne_inet.h"           // for ip4addr, ip4addr::(anonymous), TCP_ACK_FLAG
+#include "cne_inet.h"           // for TCP_ACK_FLAG
 #include "cne_common.h"         // for __cne_unused
 #include "net/cne_ip.h"         // for cne_ipv4_hdr, cne_ipv4_udptcp_cksum
 #include "net/cne_tcp.h"        // for cne_tcp_hdr

--- a/usrtools/txgen/app/txgen.c
+++ b/usrtools/txgen/app/txgen.c
@@ -12,14 +12,14 @@
 #include <string.h>            // for memset, memcpy
 
 #include "txgen.h"
-#include "tcp.h"                          // for txgen_tcp_hdr_ctor
-#include "ipv4.h"                         // for txgen_ipv4_ctor
-#include "udp.h"                          // for txgen_udp_hdr_ctor
-#include "display.h"                      // for display_set_color
-#include "port-cfg.h"                     // for port_info_t, port_sizes_t, mbuf_t...
-#include "pcap.h"                         // for txgen_page_pcap, txgen_pcap_mbuf_...
-#include "cmds.h"                         // for txgen_force_update
-#include "cne_inet.h"                     // for ip4addr, ip4addr::(anonymous)
+#include "tcp.h"             // for txgen_tcp_hdr_ctor
+#include "ipv4.h"            // for txgen_ipv4_ctor
+#include "udp.h"             // for txgen_udp_hdr_ctor
+#include "display.h"         // for display_set_color
+#include "port-cfg.h"        // for port_info_t, port_sizes_t, mbuf_t...
+#include "pcap.h"            // for txgen_page_pcap, txgen_pcap_mbuf_...
+#include "cmds.h"            // for txgen_force_update
+#include "cne_inet.h"
 #include "_pcap.h"                        // for pcap_info_t
 #include "cne_branch_prediction.h"        // for unlikely, likely
 #include "cne_common.h"                   // for __cne_unused

--- a/usrtools/txgen/app/udp.c
+++ b/usrtools/txgen/app/udp.c
@@ -6,7 +6,7 @@
 #include <stdint.h>            // for uint16_t
 
 #include "udp.h"
-#include "cne_inet.h"           // for ip4addr, ip4addr::(anonymous)
+#include "cne_inet.h"
 #include "cne_common.h"         // for __cne_unused
 #include "net/cne_ip.h"         // for cne_ipv4_hdr, cne_ipv4_udptcp_cksum
 #include "net/cne_udp.h"        // for cne_udp_hdr


### PR DESCRIPTION
Most of the changes are around spelling or incorrect words, plus a few
comments updated to not use '/**' in C files. Does contain one minor cleanup
on how a structure is inited by removing the memset() call in pktmbuf routine.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>