### PR TITLE
Testcne skipped

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -38,6 +38,7 @@ jobs:
 
     - name: Upload testlog
       uses: actions/upload-artifact@v3
+      if: success() || failure()
       with:
         name: testlog.txt
         path: ${{ github.workspace }}/builddir/meson-logs/testlog.txt

--- a/test/common/tst_info.h
+++ b/test/common/tst_info.h
@@ -20,14 +20,30 @@ extern "C" {
 
 #include <cne_log.h>
 
-#define TST_PASSED true  /**< used for tst_end() when a test passes */
-#define TST_FAILED false /**< used for tst_end() when a test fails */
+/** An exit code of 77 indicates a test is skipped */
+#define EXIT_SKIPPED 77
+
+enum {
+    TST_FAILED = 0, /**< used for tst_end() when a test fails */
+    TST_PASSED,     /**< used for tst_end() when a test passes */
+    TST_SKIPPED,    /**< used for tst_end() when a test is skipped */
+};
 
 typedef struct {
     char *name; /**< Name of the test cne_strdup'ed */
     int lid;    /**< lcore id */
     int sid;    /**< socket id */
 } tst_info_t;
+
+/**
+ * Get an appropriate exit code used by a test application
+ *
+ * @return
+ *   EXIT_FAILURE if any test fails
+ *   EXIT_SKIPPED if any test is skipped, but none fail
+ *   EXIT_SUCCESS if all tests pass
+ */
+int tst_exit_code(void);
 
 /**
  * Print a summary of test results
@@ -54,19 +70,21 @@ tst_info_t *tst_start(const char *name);
 /**
  * End a test
  *
- * This function records the pass/fail status and frees the tst_info structure.
+ * This function records the pass/fail/skip status and frees the tst_info structure.
  *
  * @param tst
  *   pointer to tst_info structure
- * @param passed
- *   TST_PASSED if the test passed or TST_FAILED if the test failed
+ * @param result
+ *   TST_PASSED if the test passed
+ *   TST_FAILED if the test failed
+ *   TST_SKIPPED if the test was skipped
  */
-void tst_end(tst_info_t *tst, bool passed);
+void tst_end(tst_info_t *tst, int result);
 
 /**
  * The following functions are used for colorful logging
  *
- * Also prepend the message with one of PASS/FAIL/INFO strings.
+ * Also prepend the message with one of PASS/FAIL/INFO/SKIP strings.
  *
  * @param fmt
  *   printf like format
@@ -76,6 +94,7 @@ void tst_end(tst_info_t *tst, bool passed);
 void tst_ok(const char *fmt, ...) __attribute__((__format__(__printf__, 1, 0)));
 void tst_error(const char *fmt, ...) __attribute__((__format__(__printf__, 1, 0)));
 void tst_info(const char *fmt, ...) __attribute__((__format__(__printf__, 1, 0)));
+void tst_skip(const char *fmt, ...) __attribute__((__format__(__printf__, 1, 0)));
 
 #define TST_ASSERT_RETURN(cond, msg, ...)                                                   \
     do {                                                                                    \

--- a/test/testcne/meson.build
+++ b/test/testcne/meson.build
@@ -128,12 +128,15 @@ test_names = [
     'log',
     'mbuf',
     'mempool',
+    'meter',
+    'metrics',
     'mmap',
     'pkt',
     'ring',
     'sizeof',
     'thread',
     'uid',
+    'vec',
 ]
 
 test_names_with_iface = [

--- a/test/testcne/metrics_test.c
+++ b/test/testcne/metrics_test.c
@@ -37,8 +37,8 @@ metrics_test(void)
         ret = errno;
         tst_error("Unable to initialize metrics library, %s\n", strerror(errno));
         free(client);
-        /* return EPERM if this test fails due to permission error */
-        return ret == EPERM ? ret : -1;
+        /* return errno if this test fails due to permission error */
+        return (ret == EPERM) || (ret == EACCES) ? ret : -1;
     }
 
     tst_ok("PASS --- TEST: Metrics library initialized\n");
@@ -102,7 +102,7 @@ metrics_main(int argc __cne_unused, char **argv __cne_unused)
     err = metrics_test();
     if (err < 0)
         tst_end(tst, TST_FAILED);
-    else if (err == EPERM)
+    else if (err == EPERM || err == EACCES)
         tst_end(tst, TST_SKIPPED);
     else
         tst_end(tst, TST_PASSED);

--- a/test/testcne/metrics_test.c
+++ b/test/testcne/metrics_test.c
@@ -34,9 +34,11 @@ metrics_test(void)
 
     ret = metrics_init(NULL);
     if (ret < 0) {
+        ret = errno;
         tst_error("Unable to initialize metrics library, %s\n", strerror(errno));
         free(client);
-        return -1;
+        /* return EPERM if this test fails due to permission error */
+        return ret == EPERM ? ret : -1;
     }
 
     tst_ok("PASS --- TEST: Metrics library initialized\n");
@@ -93,15 +95,17 @@ int
 metrics_main(int argc __cne_unused, char **argv __cne_unused)
 {
     tst_info_t *tst;
+    int err;
 
     tst = tst_start("Metrics");
 
-    if (metrics_test() < 0)
-        goto err;
+    err = metrics_test();
+    if (err < 0)
+        tst_end(tst, TST_FAILED);
+    else if (err == EPERM)
+        tst_end(tst, TST_SKIPPED);
+    else
+        tst_end(tst, TST_PASSED);
 
-    tst_end(tst, TST_PASSED);
-    return 0;
-err:
-    tst_end(tst, TST_FAILED);
-    return -1;
+    return err < 0 ? -1 : 0;
 }

--- a/test/testcne/testcne.c
+++ b/test/testcne/testcne.c
@@ -126,5 +126,6 @@ main(int argc, char **argv)
     if (cne_unregister(tidx) < 0)
         CNE_ERR("cne_unregister(%d) failed\n", tidx);
 
-    return tst_summary() ? EXIT_FAILURE : EXIT_SUCCESS;
+    tst_summary();
+    return tst_exit_code();
 }


### PR DESCRIPTION
* add ability to mark tests as "skipped". This is useful to denote tests that don't pass or fail, they simply cannot be run. This is helpful when running `meson test` since the result will still be `0` if no test fails
* skip the metrics test if we run into a permissions error, which is not really a failure of the test, but rather a failure of running without adequate permission
* add some missing tests to the `meson test` command

Thanks @eli-schwartz for the tip about skipping tests.