### PR TITLE
msgchan:klocwork issue with not freeing server/client

### DIFF
--- a/test/testcne/msgchan_test.c
+++ b/test/testcne/msgchan_test.c
@@ -305,17 +305,17 @@ err_exit:
     if (sthread_inited) {
         err = pthread_join(s, NULL);
         if (err)
-            CNE_ERR_RET("join(server) failed: %s\n", strerror(err));
+            CNE_ERR("join(server) failed: %s\n", strerror(err));
     }
     if (cthread_inited) {
         err = pthread_join(c, NULL);
         if (err)
-            CNE_ERR_RET("join(client) failed: %s\n", strerror(err));
+            CNE_ERR("join(client) failed: %s\n", strerror(err));
     }
     if (barrier_inited) {
         err = pthread_barrier_destroy(&barrier);
         if (err)
-            CNE_ERR_RET("barrier destroy failed: %s\n", strerror(err));
+            CNE_ERR("barrier destroy failed: %s\n", strerror(err));
     }
     mc_destroy(client);
     mc_destroy(server);


### PR DESCRIPTION
Klocwork ID 218:
Instead of returning when an error occurs, just print out a message
and continue, which allows the mc_destroy() routines to be called.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>