### PR TITLE
mutex helper routines handle pthread APIs cleanly

### DIFF
--- a/lib/core/pktmbuf/pktmbuf.c
+++ b/lib/core/pktmbuf/pktmbuf.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>        // for calloc, free
 #include <pthread.h>
 
+#include <cne_mutex_helper.h>
+
 static TAILQ_HEAD(pktmbuf_info_list, pktmbuf_info_s) pinfo_list;
 static pthread_mutex_t pinfo_list_mutex;
 
@@ -681,16 +683,8 @@ pktmbuf_info_dump(void)
 
 CNE_INIT_PRIO(pinfo_constructor, START)
 {
-    pthread_mutexattr_t attr;
-
     TAILQ_INIT(&pinfo_list);
 
-    pthread_mutexattr_init(&attr);
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-
-    if (pthread_mutex_init(&pinfo_list_mutex, &attr)) {
-        pthread_mutexattr_destroy(&attr);
+    if (cne_mutex_create(&pinfo_list_mutex, PTHREAD_MUTEX_RECURSIVE) < 0)
         CNE_RET("mutex init(pinfo_list_mutex) failed\n");
-    }
-    pthread_mutexattr_destroy(&attr);
 }

--- a/lib/include/cne_mutex_helper.h
+++ b/lib/include/cne_mutex_helper.h
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Intel Corporation
+ */
+
+#ifndef __CNE_MUTEX_HELPER_H
+#define __CNE_MUTEX_HELPER_H
+
+/**
+ * @file
+ * Routines to help create a mutex.
+ */
+
+#include <pthread.h>
+#include <cne_log.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Helper routine to create a mutex with a specific type.
+ *
+ * @param mutex
+ *   The pointer to the mutex to create.
+ * @param flags
+ *   The attribute flags used to create the mutex i.e. recursive attribute
+ * @return
+ *   0 on success or -1 on failure errno is set
+ */
+static inline int
+cne_mutex_create(pthread_mutex_t *mutex, int flags)
+{
+    int ret = EFAULT;
+
+    if (mutex) {
+        pthread_mutexattr_t attr;
+
+        ret = pthread_mutexattr_init(&attr);
+        if (ret == 0) {
+            ret = pthread_mutexattr_settype(&attr, flags);
+            if (ret == 0) {
+                ret = pthread_mutex_init(mutex, &attr);
+                if (ret == 0 && pthread_mutexattr_destroy(&attr) == 0)
+                    return 0;
+            }
+        }
+    }
+
+    errno = ret;
+    return -1;
+}
+
+/**
+ * Destroy a mutex
+ *
+ * @param mutex
+ *   Pointer to mutex to destroy.
+ * @return
+ *   0 on success and -1 on error with errno set.
+ */
+static inline int
+cne_mutex_destroy(pthread_mutex_t *mutex)
+{
+    int ret = 0;
+
+    if (mutex)
+        ret = pthread_mutex_destroy(mutex);
+
+    errno = ret;
+    return (ret != 0) ? -1 : 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CNE_MUTEX_HELPER_H */

--- a/lib/include/meson.build
+++ b/lib/include/meson.build
@@ -13,6 +13,7 @@ headers = files(
     'cne_gettid.h',
     'cne_isa.h',
     'cne_lport.h',
+    'cne_mutex_helper.h',
     'cne_pause.h',
     'cne_per_thread.h',
     'cne_pktcpy.h',

--- a/lib/usr/app/metrics/metrics.c
+++ b/lib/usr/app/metrics/metrics.c
@@ -6,6 +6,7 @@
 #include <errno.h>        // for ENODEV, errno
 #include <pthread.h>
 
+#include <cne_mutex_helper.h>
 #include "metrics.h"
 
 static uds_info_t *default_info;
@@ -140,14 +141,6 @@ metrics_port_stats(metrics_client_t *c, char *name, lport_stats_t *s)
 
 CNE_INIT_PRIO(metrics_constructor, INIT)
 {
-    pthread_mutexattr_t attr;
-
-    pthread_mutexattr_init(&attr);
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-
-    if (pthread_mutex_init(&metrics_mutex, &attr)) {
-        pthread_mutexattr_destroy(&attr);
+    if (cne_mutex_create(&metrics_mutex, PTHREAD_MUTEX_RECURSIVE) < 0)
         CNE_RET("mutex init(metrics_mutex) failed\n");
-    }
-    pthread_mutexattr_destroy(&attr);
 }


### PR DESCRIPTION
The pthread creation of a mutex is difficult to get right and
have klocwork accept the many issues with error codes.

Create two routines to init and destroy mutex structures. The
helper routine allows the caller to set attributes in the mutex
i.e recursive type.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>