### PR TITLE
uid:add mutex locking to fix race conditions

### DIFF
--- a/lib/core/cne/cne.c
+++ b/lib/core/cne/cne.c
@@ -158,8 +158,7 @@ cne_unregister(int tidx)
     if (e->magic_id != CNE_MAGIC_ID || e->uid != tidx)
         return -1;
 
-    if (uid_free(__cne.pool, e->uid) < 0)
-        return -1;
+    uid_free(__cne.pool, e->uid);
 
     e->uid      = -1;
     e->magic_id = 0;

--- a/lib/core/cne/uid.h
+++ b/lib/core/cne/uid.h
@@ -94,10 +94,8 @@ CNDP_API int uid_alloc(u_id_t _e);
  *   The UID to free the index value to
  * @param idx
  *   The index value to free or release
- * @return
- *   -1 on error or 0 on success
  */
-CNDP_API int uid_free(u_id_t _e, int idx);
+CNDP_API void uid_free(u_id_t _e, int idx);
 
 /**
  * Dump out all of the UID structures.

--- a/lib/core/cne/uid_private.h
+++ b/lib/core/cne/uid_private.h
@@ -27,6 +27,7 @@ typedef struct uid_entry {
     uint16_t max_ids;             /**< Max number of IDs */
     int32_t bitmap_sz;            /**< Size of bitmap array in bits */
     bitstr_t *bitmap;             /**< Pointer to the bitmap array */
+    pthread_mutex_t mutex;        /**< Mutex for alloc/free operations */
 } uid_entry_t;
 
 typedef struct uid_s {

--- a/test/testcne/uid_test.c
+++ b/test/testcne/uid_test.c
@@ -126,10 +126,7 @@ uid_main(int argc, char **argv)
 
             uid = rand() % t->cnt;
 
-            if (uid_free(t->e, uid) < 0) {
-                tst_error("Failed to free UID for %s:%d\n", t->name, uid);
-                goto err;
-            }
+            uid_free(t->e, uid);
         }
     }
 


### PR DESCRIPTION
UID code did not use mutex locks and I noticed a race condition with
multiple threads. Add a list lock and UID alloc/free locks.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>