### PR TITLE
fix klocwork issues

### DIFF
--- a/lib/core/cne/uid.c
+++ b/lib/core/cne/uid.c
@@ -135,6 +135,7 @@ uid_register(const char *name, uint16_t cnt)
         __uid.list_cnt++;
         uid_list_unlock();
     } else {
+        free(e->bitmap);
         free(e);
         return NULL;
     }


### PR DESCRIPTION
ID-167 - Convert to use the new mutex routines.
ID 225 and 226 were also fixed to free 'attr' and use the helper routines.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>