### PR TITLE
mempool dump cleanup

### DIFF
--- a/lib/cnet/cmds/cnet_cmds.c
+++ b/lib/cnet/cmds/cnet_cmds.c
@@ -254,7 +254,7 @@ __obj_dump(const char *msg, struct cne_mempool *mp)
     if (mp == NULL)
         return;
     cne_printf("[magenta]=== [cyan]%s[]\n", msg);
-    mempool_dump(NULL, mp);
+    mempool_dump(mp);
 }
 
 static int

--- a/lib/core/mempool/mempool.c
+++ b/lib/core/mempool/mempool.c
@@ -436,32 +436,46 @@ mempool_empty(const mempool_t *_mp)
 
 /* dump the status of the mempool on the console */
 void
-mempool_dump(FILE *f, mempool_t *_mp)
+mempool_dump(mempool_t *_mp)
 {
     struct cne_mempool *mp = _mp;
     unsigned common_count;
 
-    if (!f)
-        f = stdout;
-
     if (mp == NULL)
         return;
 
-    cne_fprintf(f, "mempool @ %p", (void *)mp);
-    cne_fprintf(f, " ring=%p\n", mp->objring);
-    cne_fprintf(f, "   obj_cnt=%" PRIu32, mp->obj_cnt);
-    cne_fprintf(f, " obj_sz=%" PRIu32, mp->obj_sz);
+    cne_printf("[orange]mempool @ [cyan]%p [magenta]ring [cyan]%p[]\n", (void *)mp, mp->objring);
+    cne_printf("   [magenta]obj_cnt [cyan]%" PRIu32 "[]", mp->obj_cnt);
+    cne_printf(" [magenta]obj_sz [cyan]%" PRIu32 "[]", mp->obj_sz);
 
     common_count = mempool_ring_get_count(mp);
-    cne_fprintf(f, " free ring_cnt=%u\n", common_count);
+    cne_printf(" [magenta]free ring_cnt [cyan]%" PRIu32 " [magenta]cache size [cyan]%" PRIu32
+               "[]\n",
+               common_count, mp->cache_sz);
+
+    if (mp->stats) {
+        cne_printf("   [magenta]Put         Bulk[]: [cyan]%12" PRIu64 "[]\n", mp->stats->put_bulk);
+        cne_printf("   [magenta]Put         Objs[]: [cyan]%12" PRIu64 "[]\n", mp->stats->put_objs);
+        cne_printf("   [magenta]Get Success Bulk[]: [cyan]%12" PRIu64 "[]\n",
+                   mp->stats->get_success_bulk);
+        cne_printf("   [magenta]Get Success Objs[]: [cyan]%12" PRIu64 "[]\n",
+                   mp->stats->get_success_objs);
+        cne_printf("   [magenta]Get failed  Bulk[]: [cyan]%12" PRIu64 "[]\n",
+                   mp->stats->get_fail_bulk);
+        cne_printf("   [magenta]Get failed  Objs[]: [cyan]%12" PRIu64 "[]\n",
+                   mp->stats->get_fail_objs);
+    }
 
     if (!mp->cache_sz)
         return;
 
-    for (int i = 0; i < cne_max_threads(); i++) {
+    cne_printf("   [orange]Cache Info[]:\n");
+    for (uint32_t i = 0; i < (uint32_t)cne_max_threads(); i++) {
         struct mempool_cache *cache = &mp->cache[i];
         if (cache && cache->len)
-            cne_fprintf(f, "  cache %3d: len %4d\n", i, cache->len);
+            cne_printf("     [magenta]cache [cyan]%3" PRIu32 "[]: [magenta]len [cyan]%4" PRIu32
+                       "[]\n",
+                       i, cache->len);
     }
 }
 

--- a/lib/core/mempool/mempool.h
+++ b/lib/core/mempool/mempool.h
@@ -181,12 +181,10 @@ CNDP_API uint32_t mempool_obj_iter(mempool_t *mp, mempool_obj_cb_t *obj_cb, void
 /**
  * Dump the status of the mempool to a file.
  *
- * @param f
- *   A pointer to a file for output
  * @param mp
  *   A pointer to the mempool structure.
  */
-CNDP_API void mempool_dump(FILE *f, mempool_t *mp);
+CNDP_API void mempool_dump(mempool_t *mp);
 
 /**
  * Get a pointer to the per-thread default mempool cache.

--- a/lib/core/mempool/mempool_private.h
+++ b/lib/core/mempool/mempool_private.h
@@ -43,8 +43,6 @@ struct mempool_stats {
     uint64_t get_success_objs; /**< Objects successfully allocated. */
     uint64_t get_fail_bulk;    /**< Failed allocation number. */
     uint64_t get_fail_objs;    /**< Objects that failed to be allocated. */
-    uint64_t get_success_blks; /**< Successful allocation number of contiguous blocks. */
-    uint64_t get_fail_blks;    /**< Failed allocation number of contiguous blocks. */
 } __cne_cache_aligned;
 
 /**

--- a/lib/core/pktmbuf/pktmbuf.c
+++ b/lib/core/pktmbuf/pktmbuf.c
@@ -666,7 +666,7 @@ __info_dump(pktmbuf_info_t *pi)
         "[cyan]%'d [magenta]cache[]: [cyan]%'d [magenta]pool[]: [cyan]%p[]\n  ",
         name, pi->addr, pi->bufcnt, pi->bufsz, pi->cache_sz, pi->pd);
     if (pi->pd)
-        mempool_dump(NULL, pi->pd);
+        mempool_dump(pi->pd);
 }
 
 void

--- a/test/testcne/mempool_test.c
+++ b/test/testcne/mempool_test.c
@@ -125,7 +125,7 @@ mempool_main(int argc, char **argv)
 
         if (verbose) {
             vt_color(VT_BLUE, VT_NO_CHANGE, VT_OFF);
-            mempool_dump(NULL, mp);
+            mempool_dump(mp);
             vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
             cne_printf("\n");
         }


### PR DESCRIPTION
Remove the need to pass a file pointer to mempool_dump() it is not used.
Also add some color to the output and remove two statistics not being used.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>