### PR TITLE
mempool:add a couple APIs to find index of buffer

### DIFF
--- a/lib/core/mempool/mempool.c
+++ b/lib/core/mempool/mempool.c
@@ -528,3 +528,34 @@ mempool_cache_len(mempool_t *_mp, int idx)
         return -1;
     return (int)mp->cache[idx].len;
 }
+
+int
+mempool_obj_index(mempool_t *_mp, void *obj)
+{
+    struct cne_mempool *mp = _mp;
+
+    if (mp) {
+        if (obj >= mp->objmem && obj < CNE_PTR_ADD(mp->objmem, (mp->obj_cnt * mp->obj_sz))) {
+            uint64_t *addr = CNE_PTR_SUB(obj, (uintptr_t)mp->objmem);
+            uintptr_t sz   = (uintptr_t)mp->obj_sz;
+
+            return (int)((uintptr_t)addr / sz);
+        }
+    }
+    return -1;
+}
+
+void *
+mempool_obj_at_index(mempool_t *_mp, int idx)
+{
+    struct cne_mempool *mp = _mp;
+
+    if (mp) {
+        void *p = CNE_PTR_ADD(mp->objmem, (idx * mp->obj_sz));
+
+        if (p < CNE_PTR_ADD(mp->objmem, (mp->obj_sz * mp->obj_cnt)))
+            return p;
+    }
+
+    return NULL;
+}

--- a/lib/core/mempool/mempool.h
+++ b/lib/core/mempool/mempool.h
@@ -404,6 +404,30 @@ CNDP_API int mempool_cache_sz(mempool_t *mp);
  */
 CNDP_API int mempool_cache_len(mempool_t *mp, int idx);
 
+/**
+ * Determine the object index value in the mempool.
+ *
+ * @param mp
+ *   The mempool_t pointer to use to calculate the object index.
+ * @param obj
+ *   The object pointer to use in calculation
+ * @return
+ *   -1 on error or object index value.
+ */
+CNDP_API int mempool_obj_index(mempool_t *mp, void *obj);
+
+/**
+ * Return the object pointer for the given mempool_t and index value
+ *
+ * @param mp
+ *   The mempool_t pointer to use to calculate the object address.
+ * @param idx
+ *   The index value into the mempool buffer array.
+ * @return
+ *   NULL on error or pointer to object.
+ */
+CNDP_API void *mempool_obj_at_index(mempool_t *mp, int idx);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Adding two functions one to get the index value of the mempool buffer
address and another one to return the mempool buffer address based
on the index value.

The new functions are use for the CNET commit later.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>