### PR TITLE
cnet:general cleanup and remove useless code

### DIFF
--- a/lib/cnet/chnl/cnet_chnl.c
+++ b/lib/cnet/chnl/cnet_chnl.c
@@ -1022,26 +1022,3 @@ chnl_ERROR(struct chnl *ch __cne_unused)
 {
     return __errno_set(EOPNOTSUPP);
 }
-
-static int
-_chnl_create(void *_stk)
-{
-    stk_t *stk = _stk;
-
-    CNE_DEBUG("Created chnl instance for %s\n", stk->name);
-    return 0;
-}
-
-static int
-_chnl_destroy(void *_stk)
-{
-    stk_t *stk = _stk;
-
-    CNE_DEBUG("Destroy chnl instance for %s\n", stk->name);
-    return 0;
-}
-
-CNE_INIT_PRIO(cnet_chnl_constructor, STACK)
-{
-    cnet_add_instance("chnl", CNET_CHNL_PRIO, _chnl_create, _chnl_destroy);
-}

--- a/lib/cnet/cmds/cnet_cmds.c
+++ b/lib/cnet/cmds/cnet_cmds.c
@@ -212,16 +212,12 @@ cmd_chnl(int argc __cne_unused, char **argv __cne_unused)
 }
 
 static int
-cmd_pcb(int argc, char **argv __cne_unused)
+cmd_pcb(int argc __cne_unused, char **argv __cne_unused)
 {
     stk_t *stk;
 
-    vec_foreach_ptr (stk, this_cnet->stks) {
-        if (argc > 1 && !strcmp("-l", argv[1]))
-            cnet_pcb_dump_details(stk);
-        else
-            cnet_pcb_dump(stk);
-    }
+    vec_foreach_ptr (stk, this_cnet->stks)
+        cnet_pcb_dump(stk);
 
     return 0;
 }
@@ -546,7 +542,7 @@ cmd_graph(int argc, char **argv)
 }
 
 static int
-cmd_netlink(int argc __cne_unused, char **argv __cne_unused)
+cmd_netlink(int argc, char **argv)
 {
     if (argc > 1)
         netlink_debug = atoi(argv[1]);
@@ -653,7 +649,7 @@ static struct cli_tree cnet_tree[] = {
     c_bin("/cnet"),
     c_cmd("info",       cmd_info,       "CNET information [show|size|mbuf]"),
     c_cmd("chnl",       cmd_chnl,       "Channel information"),
-    c_cmd("pcb",        cmd_pcb,        "pcb [-l] dump"),
+    c_cmd("pcb",        cmd_pcb,        "pcb dump"),
     c_cmd("proto",      cmd_proto,      "Protosw dump"),
     c_cmd("ip",         cmd_ip,         "Show IP interface information [link|route|neigh|stats]"),
     c_cmd("hmap",       cmd_hmap,       "dump out the hashmap data"),

--- a/lib/cnet/cnet/cnet.c
+++ b/lib/cnet/cnet/cnet.c
@@ -157,34 +157,38 @@ CNE_INIT_PRIO(cnet_initialize, STACK)
 {
     struct cnet *cnet = &cnet_data;
 
-    if (pthread_spin_init(&__cnet_lock, PTHREAD_PROCESS_PRIVATE))
-        CNE_ERR("Unable to initialize spinlock\n");
-
     memset(cnet, 0, sizeof(struct cnet));
 
-    cnet->flags = CNET_PUNT_ENABLED;
+    if (pthread_spin_init(&__cnet_lock, PTHREAD_PROCESS_PRIVATE))
+        CNE_RET("Unable to initialize spinlock\n");
+
+    cnet->flags = ((CNET_ENABLE_PUNTING) ? CNET_PUNT_ENABLED : 0);
     cnet->flags |= ((CNET_ENABLE_TCP) ? CNET_TCP_ENABLED : 0);
 
     cnet->num_chnls = CNET_NUM_CHANNELS;
 
     cnet->stks = vec_alloc(cnet->stks, STK_VEC_COUNT);
     if (!cnet->stks)
-        CNE_RET("Unable to allocate stk vector\n");
+        CNE_ERR_GOTO(err, "Unable to allocate stk vector\n");
 
     cnet->netifs = vec_alloc(cnet->netifs, CNE_MAX_ETHPORTS);
-    if (!cnet->netifs) {
-        vec_free(cnet->stks);
-        cnet->stks = NULL;
-        CNE_RET("Unable to allocate netif vector\n");
-    }
+    if (!cnet->netifs)
+        CNE_ERR_GOTO(err, "Unable to allocate netif vector\n");
 
     cnet->drvs = vec_alloc(cnet->drvs, CNE_MAX_ETHPORTS);
-    if (!cnet->drvs) {
-        vec_free(cnet->netifs);
-        cnet->netifs = NULL;
-        vec_free(cnet->stks);
-        cnet->stks = NULL;
-        CNE_RET("Unable to allocate driver vector\n");
-    }
+    if (!cnet->drvs)
+        CNE_ERR_GOTO(err, "Unable to allocate driver vector\n");
+
     __cnet = cnet;
+    return;
+
+err:
+    vec_free(cnet->netifs);
+    vec_free(cnet->drvs);
+    vec_free(cnet->stks);
+
+    if (pthread_spin_destroy(&__cnet_lock))
+        CNE_ERR("Unable to destroy spinlock\n");
+
+    memset(cnet, 0, sizeof(struct cnet));
 }

--- a/lib/cnet/cnet/cnet.h
+++ b/lib/cnet/cnet/cnet.h
@@ -30,14 +30,13 @@ struct cne_mempool;
 struct fib_info;
 
 struct cnet {
-    void *netlink_info;                  /**< Netlink information structure */
-    uint16_t nb_lcores;                  /**< Number of lcores in the system */
+    CNE_ATOMIC(uint_fast16_t) stk_order; /**< Order of the stack initializations */
     uint16_t nb_ports;                   /**< Number of ports in the system */
     uint32_t num_chnls;                  /**< Number of channels in system */
     uint32_t num_routes;                 /**< Number of routes */
     uint32_t num_arps;                   /**< Number of ARP entries */
-    uint16_t flags;                      /**< Flags */
-    CNE_ATOMIC(uint_fast16_t) stk_order; /**< Order of the stack initializations */
+    uint16_t flags;                      /**< Flags enable Punting, TCP, ... */
+    void *netlink_info;                  /**< Netlink information structure */
     struct stk_s **stks;                 /**< Vector list of stk_entry pointers */
     struct drv_entry **drvs;             /**< Vector list of drv_entry pointers */
     struct netif **netifs;               /**< List of active netif structures */
@@ -50,7 +49,7 @@ struct cnet {
 } __cne_cache_aligned;
 
 enum {
-    CNET_PUNT_ENABLED = 0x0001, /**< Enable Punting packets to linux network */
+    CNET_PUNT_ENABLED = 0x0001, /**< Enable Punting packets to Linux stack */
     CNET_TCP_ENABLED  = 0x0002, /**< Enable TCP packet processing */
 };
 

--- a/lib/cnet/eth/eth_rx.c
+++ b/lib/cnet/eth/eth_rx.c
@@ -57,6 +57,9 @@ mbuf_update(pktmbuf_t *m, uint16_t lpid)
     m->l3_len     = hdr_lens.l3_len;
     m->l4_len     = hdr_lens.l4_len;
     m->lport      = lpid;
+
+    /* Skip past the L2 header */
+    pktmbuf_adj_offset(m, m->l2_len);
 }
 
 static uint16_t

--- a/lib/cnet/incs/cnet_const.h
+++ b/lib/cnet/incs/cnet_const.h
@@ -60,11 +60,8 @@ extern "C" {
 #endif
 
 enum {
-    CNET_MAX_INITS      = 64,
-    CNET_NB_TCB_ENTRIES = 128,
-    CNET_NUM_CHANNELS   = 128,
-    CNET_NUM_ROUTES     = 128,
-    PROTOSW_MAX_SIZE    = 64,
+    CNET_MAX_INITS   = 64,
+    PROTOSW_MAX_SIZE = 64,
 };
 
 enum {

--- a/lib/cnet/incs/cnet_fib_info.h
+++ b/lib/cnet/incs/cnet_fib_info.h
@@ -276,7 +276,7 @@ fib_info_foreach(fib_info_t *fi, fib_func_t func, void *arg)
  * @param objs
  *   An array to return the objects for the given index values.
  * @param n
- *   The number of indexs in the idxs array and must match the size for the objs array.
+ *   The number of indexes in the idxs array and must match the size for the objs array.
  * @return
  *   -1 on error or the number of objects found and returned in objs array
  */

--- a/lib/cnet/ipv4/cnet_ipv4.c
+++ b/lib/cnet/ipv4/cnet_ipv4.c
@@ -72,18 +72,22 @@ cnet_ipv4_stats_dump(stk_t *stk)
 void
 cnet_ipv4_dump(const char *msg, struct cne_ipv4_hdr *ip)
 {
+    struct in_addr daddr, saddr;
     char ip1[IP4_ADDR_STRLEN] = {0};
     char ip2[IP4_ADDR_STRLEN] = {0};
 
-    cne_printf("[magenta]<<<< [orange]%s [magenta]>>>>[]\n", msg);
-    cne_printf("      Src %s Dst %s cksum %04x version %d hlen %d %02x\n",
-               inet_ntop4(ip1, sizeof(ip1), (struct in_addr *)&ip->src_addr, NULL) ?: "Invalid IP",
-               inet_ntop4(ip2, sizeof(ip2), (struct in_addr *)&ip->dst_addr, NULL) ?: "Invalid IP",
-               be16toh(ip->hdr_checksum), ip->version_ihl >> 4, (ip->version_ihl & 0x0f) << 2,
-               ip->version_ihl);
-    cne_printf("      offset %d next_proto %d id %d ttl %d tlen %d tos %d\n", ip->fragment_offset,
-               ip->next_proto_id, ip->packet_id, ip->time_to_live, be16toh(ip->total_length),
-               ip->type_of_service);
+    cne_printf("%s [cyan]IPv4 Header[] @ %p\n", (msg == NULL) ? "" : msg, ip);
+    daddr.s_addr = ip->dst_addr;
+    saddr.s_addr = ip->src_addr;
+    cne_printf("   [cyan]Src [orange]%s [cyan]Dst [orange]%s [cyan]cksum [orange]%04x "
+               "[cyan]version [orange]%d [cyan]hlen [orange]%d  [cyan]ver [orange]%02x[]\n",
+               inet_ntop4(ip1, sizeof(ip1), &saddr, NULL),
+               inet_ntop4(ip2, sizeof(ip2), &daddr, NULL), be16toh(ip->hdr_checksum),
+               ip->version_ihl >> 4, (ip->version_ihl & 0x0f) << 2, ip->version_ihl);
+    cne_printf("   [cyan]offset [orange]%d [cyan]next_proto [orange]%d [cyan]id [orange]%d "
+               "[cyan]ttl [orange]%d [cyan]tlen [orange]%d [cyan]tos [orange]%d[]\n",
+               ip->fragment_offset, ip->next_proto_id, be16toh(ip->packet_id), ip->time_to_live,
+               be16toh(ip->total_length), ip->type_of_service);
 }
 
 static int

--- a/lib/cnet/pcb/cnet_pcb.h
+++ b/lib/cnet/pcb/cnet_pcb.h
@@ -25,14 +25,9 @@
 extern "C" {
 #endif
 
-enum {
-    PCB_ENTRIES      = 255,
-    PCB_MBUF_ENTRIES = 256,
-};
-
 struct pcb_key {
-    struct in_caddr faddr;
-    struct in_caddr laddr;
+    struct in_caddr faddr; /**< foreign IP address */
+    struct in_caddr laddr; /**< local IP address */
 } __cne_aligned(sizeof(void *));
 
 struct netif;
@@ -52,8 +47,8 @@ struct pcb_entry {
 } __cne_cache_aligned;
 
 struct pcb_hd {
-    struct pcb_entry **vec;
-    uint16_t lport;
+    struct pcb_entry **vec; /**< PCB entries */
+    uint16_t lport;         /**< Local port number i.e. IP local port ID */
 };
 
 static inline void
@@ -144,14 +139,12 @@ CNDP_API struct pcb_entry *cnet_pcb_lookup(struct pcb_hd *hd, struct pcb_key *ke
 CNDP_API void cnet_pcb_dump(stk_t *stk);
 
 /**
- * Dump out the details information for the stack PCB list.
+ * Print out the given PCB entry.
  *
- * @param stk
- *   The stack instance pointer to use for dumping all PCBs in instance.
- * @return
- *   N/A
+ * @param pcb
+ *   The PCB entry to dump out
  */
-CNDP_API void cnet_pcb_dump_details(stk_t *stk);
+CNDP_API void cnet_pcb_show(struct pcb_entry *pcb);
 
 /**
  * @brief Return the PCB entry matching the given information.

--- a/lib/cnet/sbin/cnet_rtshow.c
+++ b/lib/cnet/sbin/cnet_rtshow.c
@@ -70,20 +70,3 @@ cnet_rtshow(stk_t *stk, int argc, char **argv)
 
     return 0;
 }
-
-static int
-cnet_rtshow_create(void *_stk __cne_unused)
-{
-    return 0;
-}
-
-static int
-cnet_rtshow_destroy(void *_stk __cne_unused)
-{
-    return 0;
-}
-
-CNE_INIT_PRIO(cnet_nstat_constructor, STACK)
-{
-    cnet_add_instance("rtshow", CNET_UTILS_PRIO, cnet_rtshow_create, cnet_rtshow_destroy);
-}

--- a/lib/cnet/stk/cnet_stk.c
+++ b/lib/cnet/stk/cnet_stk.c
@@ -26,8 +26,6 @@
 
 #include <cne_spinlock.h>
 
-static int stk_destroy(void *_stk);
-
 static int
 _stk_create(struct cnet *cnet)
 {
@@ -108,12 +106,6 @@ cnet_stk_stop(void)
 }
 
 static int
-stk_create(void *_stk __cne_unused)
-{
-    return 0;
-}
-
-static int
 stk_destroy(void *_stk)
 {
     stk_t *stk = _stk;
@@ -132,5 +124,5 @@ stk_destroy(void *_stk)
 
 CNE_INIT_PRIO(cnet_stk_constructor, STACK)
 {
-    cnet_add_instance("stk", CNET_STK_PRIO, stk_create, stk_destroy);
+    cnet_add_instance("stk", CNET_STK_PRIO, NULL, stk_destroy);
 }

--- a/lib/cnet/tcp/cnet_tcp.c
+++ b/lib/cnet/tcp/cnet_tcp.c
@@ -3752,7 +3752,7 @@ err_exit:
 static int
 tcp_create(void *stk __cne_unused)
 {
-    return tcp_init(CNET_NB_TCB_ENTRIES, 1, 1);
+    return tcp_init(CNET_NUM_TCBS, 1, 1);
 }
 
 static int

--- a/lib/cnet/tcp/tcp_output.c
+++ b/lib/cnet/tcp/tcp_output.c
@@ -198,17 +198,9 @@ tcp_output_node_process(struct cne_graph *graph, struct cne_node *node, void **o
     return nb_objs;
 }
 
-static int
-tcp_output_node_init(const struct cne_graph *graph __cne_unused, struct cne_node *node __cne_unused)
-{
-    return 0;
-}
-
 static struct cne_node_register tcp_output_node_base = {
     .process = tcp_output_node_process,
     .name    = TCP_OUTPUT_NODE_NAME,
-
-    .init = tcp_output_node_init,
 
     .nb_edges = TCP_OUTPUT_NEXT_MAX,
     .next_nodes =

--- a/lib/cnet/udp/cnet_udp.h
+++ b/lib/cnet/udp/cnet_udp.h
@@ -12,7 +12,6 @@
 
 #include <stdint.h>        // for uint32_t
 
-#include "cnet_chnl.h"         // for _IPPORT_RESERVED
 #include "cnet_const.h"        // for bool_t
 #include "cnet_pcb.h"          // for pcb_hd
 

--- a/lib/cnet/udp/cnet_udp_chnl.c
+++ b/lib/cnet/udp/cnet_udp_chnl.c
@@ -193,13 +193,7 @@ udp_chnl_create(void *_stk __cne_unused)
     return 0;
 }
 
-static int
-udp_chnl_destroy(void *_stk __cne_unused)
-{
-    return 0;
-}
-
 CNE_INIT_PRIO(cnet_udp_chnl_constructor, STACK)
 {
-    cnet_add_instance("UDP chnl", CNET_UDP_CHNL_PRIO, udp_chnl_create, udp_chnl_destroy);
+    cnet_add_instance("UDP chnl", CNET_UDP_CHNL_PRIO, udp_chnl_create, NULL);
 }

--- a/lib/cnet/udp/udp_input.c
+++ b/lib/cnet/udp/udp_input.c
@@ -13,6 +13,7 @@
 #include <netinet/in.h>           // for ntohs
 #include <stddef.h>               // for NULL
 
+#include <cnet_chnl.h>
 #include <cne_graph.h>               // for
 #include <cne_graph_worker.h>        // for
 #include <cne_common.h>              // for __cne_unused

--- a/lib/core/pktmbuf/pktmbuf.h
+++ b/lib/core/pktmbuf/pktmbuf.h
@@ -117,7 +117,7 @@ struct pktmbuf_s {
             union {
                 uint8_t inner_esp_next_proto;
                 /**< ESP next protocol type, valid if
-                 * CNEE_PTYPE_TUNNEL_ESP tunnel type is set
+                 * CNE_PTYPE_TUNNEL_ESP tunnel type is set
                  * on both Tx and Rx.
                  */
                 CNE_STD_C11

--- a/meson.build
+++ b/meson.build
@@ -330,12 +330,42 @@ foreach f:avx512_flags
     endif
 endforeach
 
+# ----
+# CNET Stack configuration
+#
+cne_conf.set10('CNET_IP4_DUMP_ENABLED', get_option('enable_ip4_dump'))
+if get_option('enable_ip4_dump')
+    message('*** IPv4 dump output enabled')
+else
+    message('*** IPv4 dump output disabled')
+endif
+
 cne_conf.set10('CNET_ENABLE_TCP', get_option('enable_tcp'))
 if get_option('enable_tcp')
-    message('*** TCP support enabled')
+    message('*** TCP support enabled (experimental)')
 else
     message('*** TCP support disabled')
 endif
+
+cne_conf.set10('CNET_ENABLE_PUNTING', get_option('enable_punting'))
+if get_option('enable_punting')
+    message('*** Enable support for punting to Linux kernel stack')
+else
+    message('*** Punting to Linux kernel stack is disabled')
+endif
+
+cne_conf.set10('CNET_TCP_DUMP_ENABLED', get_option('enable_tcp_dump'))
+if get_option('enable_tcp_dump')
+    message('*** TCP dump output enabled')
+else
+    message('*** TCP dump output disabled')
+endif
+
+cne_conf.set('CNET_NUM_TCBS', get_option('cnet_num_tcbs'))
+cne_conf.set('CNET_NUM_CHANNELS', get_option('cnet_num_channels'))
+cne_conf.set('CNET_NUM_ROUTES', get_option('cnet_num_routes'))
+
+# ----
 
 # write the build config into the cndp include directory
 configure_file(output: build_cfg_file,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,8 +12,30 @@ option('enable_asserts', type: 'boolean', value: false,
 option('enable_docs', type: 'boolean', value: false,
     description: 'build documentation')
 
+# ----
+# CNET Configuration
+#
+option('enable_ip4_dump', type: 'boolean', value: 'false',
+    description: 'enable IPv4 dump header')
+
 option('enable_tcp', type: 'boolean', value: 'false',
-    description: 'enable TCP in CNET')  # Not working yet
+    description: 'enable TCP in CNET (experimental)')
+
+option('enable_punting', type: 'boolean', value: 'true',
+    description: 'enable punting to Linux kernel stack')
+
+option('enable_tcp_dump', type: 'boolean', value: 'false',
+    description: 'enable TCP dump header')
+
+option('cnet_num_tcbs', type: 'integer', value: '512',
+    description: 'Max number of TCBs')
+
+option('cnet_num_channels', type: 'integer', value: '512',
+    description: 'Max number of TCBs,Channels,Routes')
+
+option('cnet_num_routes', type: 'integer', value: '512',
+    description: 'Max number of Routes')
+# ------
 
 option('json_test_dir', type: 'string',
 	value:'', # '/work/projects/json/tests',


### PR DESCRIPTION
A number of small changes to reduce the number of changes in the next
CNET TCP updates.

- Add some meson options to set the max number or PCB, TCB and channel entries.
- In a number of locations the constructor routine would register both create/destroy
  function with cnet_add_instance() removed the routines that did nothing.
  - Other files cnet_rtshow.c, cnet_stk.c, cnet_upd_chnl.c, tcp_output.c
- Changes in files like cnet.c init routine was to simplfy the routine and make sure
  the things were cleaned up on error exit.
- The eth_rx.c node should skip L3 headers by adjusting mbuf offset before moving to
  the next node, which then means the IP input routine does not need to do the adjustment.
- The pcb routine to dump out details of the pcb was removed and the output routine
  now adds some color to the output information.
- A couple minor mis-spelling were corrected.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>