### PR TITLE
Make Rust Cne Packet type to be safely used across threads.

### DIFF
--- a/lang/rs/bindings/cne/examples/loopback/src/main.rs
+++ b/lang/rs/bindings/cne/examples/loopback/src/main.rs
@@ -179,12 +179,10 @@ fn loopback(port: &Port) -> Result<(), CneError> {
 
     if pkts_read > 0 {
         for i in 0..pkts_read {
-            let pkt = &rx_pkts[i as usize];
-            let data = pkt.get_data_mut();
-            if let Some(data) = data {
-                // Swap mac address.
-                swap_mac_address(data);
-            }
+            let pkt = &mut rx_pkts[i as usize];
+            let data = pkt.get_data_mut()?;
+            // Swap mac address.
+            swap_mac_address(data);
         }
 
         let mut pkts_sent = 0;
@@ -198,7 +196,7 @@ fn loopback(port: &Port) -> Result<(), CneError> {
         log::debug!("Number of packets sent = {}", pkts_sent);
         // Free packets which are not sent.
         if pkts_sent < pkts_read {
-            Packet::free_packet_buffer(&mut rx_pkts[pkts_sent..pkts_read]);
+            Packet::free_packet_buffer(&mut rx_pkts[pkts_sent..pkts_read])?;
         }
     }
 

--- a/lang/rs/bindings/cne/src/error.rs
+++ b/lang/rs/bindings/cne/src/error.rs
@@ -9,6 +9,7 @@ use std::fmt::Result;
 pub enum CneError {
     BufferAllocError(String),
     ConfigError(String),
+    PacketError(String),
     PortError(String),
     PortStatsError(String),
     RegisterError(String),
@@ -21,6 +22,7 @@ impl Display for CneError {
         let s = match self {
             CneError::BufferAllocError(s) => format!("CneError::BufferAllocError({})", s),
             CneError::ConfigError(s) => format!("CneError::ConfigError({})", s),
+            CneError::PacketError(s) => format!("CneError::PacketError({})", s),
             CneError::PortError(s) => format!("CneError::PortError({})", s),
             CneError::PortStatsError(s) => format!("CneError::PortStatsError({})", s),
             CneError::RegisterError(s) => format!("CneError::RegisterError({})", s),

--- a/lang/rs/bindings/cne/src/lib.rs
+++ b/lang/rs/bindings/cne/src/lib.rs
@@ -177,10 +177,11 @@ mod tests {
                 let pkt = &rx_pkts[0];
 
                 let data_len = pkt.get_data_len();
-                assert!(data_len.is_some());
+                assert!(data_len.is_ok());
                 log::debug!("packet data length = {}", data_len.unwrap());
 
-                Packet::free_packet_buffer(&mut rx_pkts[..pkts_read as usize]);
+                let ret = Packet::free_packet_buffer(&mut rx_pkts[..pkts_read as usize]);
+                assert!(ret.is_ok());
                 break;
             } else {
                 // If there are no packets read then thread can (optionally) sleep for sometime.
@@ -231,7 +232,8 @@ mod tests {
         for i in 0..alloc_pkts {
             let pkt = &mut tx_pkts[i as usize];
 
-            pkt.set_data(&p);
+            let ret = pkt.set_data(&p);
+            assert!(ret.is_ok());
         }
 
         let pkts_sent = port.tx_burst(&mut tx_pkts[..]);
@@ -285,10 +287,10 @@ mod tests {
 
         if pkts_read > 0 {
             for i in 0..pkts_read {
-                let pkt = &rx_pkts[i];
+                let pkt = &mut rx_pkts[i];
 
                 let p = pkt.get_data_mut();
-                assert!(p.is_some());
+                assert!(p.is_ok());
 
                 let p = p.unwrap();
 
@@ -307,7 +309,8 @@ mod tests {
             log::debug!("Number of packets sent = {}", pkts_sent);
             // Free packets which are not sent.
             if pkts_sent < pkts_read {
-                Packet::free_packet_buffer(&mut rx_pkts[pkts_sent..pkts_read]);
+                let ret = Packet::free_packet_buffer(&mut rx_pkts[pkts_sent..pkts_read]);
+                assert!(ret.is_ok());
             }
         }
 

--- a/lang/rs/bindings/cne/src/packet.rs
+++ b/lang/rs/bindings/cne/src/packet.rs
@@ -2,6 +2,7 @@
  * Copyright (c) 2020-2022 Intel Corporation.
  */
 
+use super::error::*;
 use cne_sys::bindings::{_pktmbuf_free_bulk, _pktmbuf_write, pktmbuf_t};
 use std::os::raw::c_void;
 use std::slice;
@@ -15,108 +16,147 @@ impl Default for Packet {
     }
 }
 
+unsafe impl Send for Packet {}
+unsafe impl Sync for Packet {}
+
 pub trait PacketInterface<'a> {
     const MAX_BURST: usize = 256;
-    fn get_data_len(&self) -> Option<u16>;
-    fn set_data_len(&mut self, data_len: u16);
-    fn get_data(&self) -> Option<&'a [u8]>;
-    fn get_data_mut(&self) -> Option<&'a mut [u8]>;
-    fn set_data(&mut self, data: &[u8]) -> Option<&'a [u8]>;
-    fn free_packet_buffer(pkts: &mut [Packet]);
+    fn get_data_len(&self) -> Result<u16, CneError>;
+    fn set_data_len(&mut self, data_len: u16) -> Result<(), CneError>;
+    fn get_data(&self) -> Result<&'a [u8], CneError>;
+    fn get_data_mut(&mut self) -> Result<&'a mut [u8], CneError>;
+    fn set_data(&mut self, data: &[u8]) -> Result<(), CneError>;
+    fn free_packet_buffer(pkts: &mut [Packet]) -> Result<(), CneError>;
 }
 
 impl<'a> PacketInterface<'a> for Packet {
-    fn get_data_len(&self) -> Option<u16> {
+    fn get_data_len(&self) -> Result<u16, CneError> {
         let pkt = self.0 as *const pktmbuf_t;
         if pkt.is_null() {
-            None
+            let err_msg = "Packet data is null".to_string();
+            Err(CneError::PacketError(err_msg))
         } else {
-            unsafe { Some((*pkt).data_len) }
+            unsafe { Ok((*pkt).data_len) }
         }
     }
 
-    fn set_data_len(&mut self, data_len: u16) {
+    fn set_data_len(&mut self, data_len: u16) -> Result<(), CneError> {
         let pkt = self.0 as *mut pktmbuf_t;
-        unsafe {
-            (*pkt).data_len = data_len;
-        }
-    }
-
-    fn get_data(&self) -> Option<&'a [u8]> {
-        unsafe {
-            let (data_addr, data_len) = self.get_data_addr_and_len();
-            if data_addr.is_none() || data_len.is_none() {
-                return None;
+        if pkt.is_null() {
+            let err_msg = "Packet data is null".to_string();
+            Err(CneError::PacketError(err_msg))
+        } else {
+            unsafe {
+                (*pkt).data_len = data_len;
             }
-
-            let p: &'a [u8] = slice::from_raw_parts(data_addr.unwrap(), data_len.unwrap() as usize);
-            Some(p)
+            Ok(())
         }
     }
 
-    fn get_data_mut(&self) -> Option<&'a mut [u8]> {
+    fn get_data(&self) -> Result<&'a [u8], CneError> {
         unsafe {
-            let (data_addr, data_len) = self.get_data_addr_and_len();
-            if data_addr.is_none() || data_len.is_none() {
-                return None;
+            let data_len = self.get_data_len()?;
+            let data_addr = self.get_data_addr()?;
+            if data_addr.is_null() {
+                let err_msg = "Packet data is null".to_string();
+                Err(CneError::PacketError(err_msg))
+            } else {
+                let p: &'a [u8] = slice::from_raw_parts(data_addr, data_len as usize);
+                Ok(p)
             }
-            let p: &'a mut [u8] =
-                slice::from_raw_parts_mut(data_addr.unwrap(), data_len.unwrap() as usize);
-            Some(p)
         }
     }
 
-    fn set_data(&mut self, data: &[u8]) -> Option<&'a [u8]> {
+    fn get_data_mut(&mut self) -> Result<&'a mut [u8], CneError> {
+        unsafe {
+            let data_len = self.get_data_len()?;
+            let data_addr = self.get_data_addr_mut()?;
+            if data_addr.is_null() {
+                let err_msg = "Packet data is null".to_string();
+                Err(CneError::PacketError(err_msg))
+            } else {
+                let p: &'a mut [u8] = slice::from_raw_parts_mut(data_addr, data_len as usize);
+                Ok(p)
+            }
+        }
+    }
+
+    fn set_data(&mut self, data: &[u8]) -> Result<(), CneError> {
         let pkt = self.0 as *mut pktmbuf_t;
         unsafe {
             if pkt.is_null() {
-                return None;
+                let err_msg = "Packet data is null".to_string();
+                return Err(CneError::PacketError(err_msg));
             }
             if data.is_empty() {
-                return None;
+                let err_msg = "Data passed is empty".to_string();
+                return Err(CneError::PacketError(err_msg));
             }
             let data_ptr = &data[0] as *const u8;
             let addr = _pktmbuf_write(data_ptr as *const c_void, data.len() as u32, pkt, 0);
             if addr.is_null() {
-                return None;
+                let err_msg = "Set data failed".to_string();
+                return Err(CneError::PacketError(err_msg));
             }
-            let p: &'a [u8] = slice::from_raw_parts(addr as *const u8, data.len() as usize);
-            Some(p)
+            Ok(())
         }
     }
 
-    fn free_packet_buffer(pkts: &mut [Packet]) {
-        if pkts.is_empty() {
-            return;
+    fn free_packet_buffer(pkts: &mut [Packet]) -> Result<(), CneError> {
+        if !pkts.is_empty() {
+            let rx_pkts = &mut pkts[0].0 as *mut *mut _;
+            unsafe {
+                _pktmbuf_free_bulk(rx_pkts, pkts.len() as u32);
+            }
         }
-
-        let rx_pkts = &mut pkts[0].0 as *mut *mut _;
-        unsafe { _pktmbuf_free_bulk(rx_pkts, pkts.len() as u32) }
+        Ok(())
     }
 }
 
 impl Packet {
-    fn get_data_addr_and_len(&self) -> (Option<*mut u8>, Option<u16>) {
+    fn get_data_addr(&self) -> Result<*const u8, CneError> {
         let pkt = self.0 as *const pktmbuf_t;
         unsafe {
             if pkt.is_null() {
-                return (None, None);
+                let err_msg = "Packet data is null".to_string();
+                return Err(CneError::PacketError(err_msg));
             }
-            let buff_addr = (*pkt).buf_addr as *mut u8;
+            let buff_addr = (*pkt).buf_addr as *const u8;
             if buff_addr.is_null() {
-                return (None, None);
-            }
-            let data_len = self.get_data_len();
-            if data_len.is_none() {
-                return (None, None);
+                let err_msg = "Packet buffer address is null".to_string();
+                return Err(CneError::PacketError(err_msg));
             }
             let data_off = (*pkt).data_off;
             let data_addr = buff_addr.offset(data_off as isize);
             if data_addr.is_null() {
-                return (None, None);
+                let err_msg = "Packet data address is null".to_string();
+                return Err(CneError::PacketError(err_msg));
             }
 
-            (Some(data_addr), data_len)
+            Ok(data_addr)
+        }
+    }
+
+    fn get_data_addr_mut(&mut self) -> Result<*mut u8, CneError> {
+        let pkt = self.0 as *const pktmbuf_t;
+        unsafe {
+            if pkt.is_null() {
+                let err_msg = "Packet data is null".to_string();
+                return Err(CneError::PacketError(err_msg));
+            }
+            let buff_addr = (*pkt).buf_addr as *mut u8;
+            if buff_addr.is_null() {
+                let err_msg = "Packet buffer address is null".to_string();
+                return Err(CneError::PacketError(err_msg));
+            }
+            let data_off = (*pkt).data_off;
+            let data_addr = buff_addr.offset(data_off as isize);
+            if data_addr.is_null() {
+                let err_msg = "Packet data address is null".to_string();
+                return Err(CneError::PacketError(err_msg));
+            }
+
+            Ok(data_addr)
         }
     }
 }

--- a/lang/rs/bindings/examples/echo_server/src/main.rs
+++ b/lang/rs/bindings/examples/echo_server/src/main.rs
@@ -266,7 +266,7 @@ fn cne_macswap_and_send(port: &Port, burst_size: usize) -> Result<(), CneError> 
 
     if pkts_read > 0 {
         for i in 0..pkts_read {
-            let pkt = &rx_pkts[i as usize];
+            let pkt = &mut rx_pkts[i as usize];
             let data = pkt.get_data_mut();
             if let Some(data) = data {
                 // Swap mac address.


### PR DESCRIPTION
- Add Send/Sync marker trait for Packet type.
- Refactor Packet APIs to be safely used across threads.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>