### PR TITLE
move setlocale to a common location

### DIFF
--- a/examples/cndpfwd/main.c
+++ b/examples/cndpfwd/main.c
@@ -2,7 +2,6 @@
  * Copyright (c) 2019-2022 Intel Corporation.
  */
 
-#include <locale.h>         // for NULL, setlocale, LC_ALL
 #include <pthread.h>        // for pthread_barrier_wait, pthread_self, pthread_...
 #include <sched.h>          // for cpu_set_t
 #include <signal.h>         // for SIGUSR1, SIGINT
@@ -474,8 +473,6 @@ main(int argc, char **argv)
     int signals[]       = {SIGINT, SIGUSR1, SIGTERM};
 
     memset(&fwd_info, 0, sizeof(struct fwd_info));
-
-    setlocale(LC_ALL, "");
 
     if (cne_init() || parse_args(argc, argv, fwd))
         goto err;

--- a/examples/cnet-graph/cnet-graph.c
+++ b/examples/cnet-graph/cnet-graph.c
@@ -14,7 +14,6 @@
 #include <netinet/in.h>          // for INET6_ADDRSTRLEN, in_addr, htonl
 #include <sched.h>               // for cpu_set_t
 #include <stddef.h>              // for offsetof
-#include <locale.h>
 
 #include <cne_branch_prediction.h>        // for likely
 #include <cne_common.h>                   // for __cne_unused, CNE_MAX_ETHPORTS
@@ -386,8 +385,6 @@ main(int argc, char **argv)
     int signals[] = {SIGINT, SIGTERM, SIGUSR1};
 
     memset(&cnet_info, 0, sizeof(struct cnet_info));
-
-    setlocale(LC_ALL, "");
 
     cne_timer_subsystem_init();
 

--- a/examples/cnet-quic/cnet-quic.c
+++ b/examples/cnet-quic/cnet-quic.c
@@ -14,7 +14,6 @@
 #include <netinet/in.h>          // for INET6_ADDRSTRLEN, in_addr, htonl
 #include <sched.h>               // for cpu_set_t
 #include <stddef.h>              // for offsetof
-#include <locale.h>
 
 #include <openssl/pem.h>
 #include "picotls.h"
@@ -271,8 +270,6 @@ main(int argc, char **argv)
     int cnt, signals[] = {SIGINT, SIGTERM, SIGUSR1};
 
     memset(&cnet_info, 0, sizeof(struct cnet_info));
-
-    setlocale(LC_ALL, "");
 
     cne_timer_subsystem_init();
 

--- a/examples/l3fwd-graph/fwd.c
+++ b/examples/l3fwd-graph/fwd.c
@@ -26,7 +26,6 @@
 #include <netinet/in.h>                   // for INET6_ADDRSTRLEN, in_addr, htonl
 #include <sched.h>                        // for cpu_set_t
 #include <stddef.h>                       // for offsetof
-#include <locale.h>
 
 #include "fwd.h"
 #include "cne.h"               // for cne_id, cne_init, cne_on_exit
@@ -352,8 +351,6 @@ main(int argc, char **argv)
     int signals[] = {SIGINT, SIGTERM, SIGUSR1};
 
     memset(&fwd_info, 0, sizeof(struct fwd_info));
-
-    setlocale(LC_ALL, "");
 
     if (cne_init() < 0)
         CNE_ERR_GOTO(err, "cne_init() failed\n");

--- a/lib/core/cne/cne.c
+++ b/lib/core/cne/cne.c
@@ -8,6 +8,7 @@
 #include <cne_version.h>        // for cne_version
 #include <cne_tty.h>            // for tty_is_inited
 #include <sys/queue.h>          // for STAILQ_INIT, STAILQ_INSERT_TAIL, STAILQ_REMOVE
+#include <locale.h>
 
 #include "cne_private.h"        // for cne_private_t, cne_entry, cne_entry::(anony...
 #include "cne.h"                // for cne_id, ...
@@ -282,6 +283,8 @@ CNE_INIT_PRIO(cne_initialize, STATE)
             free(__cne.entries);
             exit(-1);
         }
+
+        setlocale(LC_ALL, "");
 
         __cne.magic_id = CNE_MAGIC_ID;
     }

--- a/test/testcne/testcne.c
+++ b/test/testcne/testcne.c
@@ -15,7 +15,6 @@
 #include <tst_info.h>           // for tst_summary
 #include <unistd.h>             // for sleep
 #include <stddef.h>             // for size_t, NULL
-#include <locale.h>
 
 #include "testcne.h"
 #include "cne_stdio.h"        // for cne_printf, cne_printf_pos
@@ -71,8 +70,6 @@ main(int argc, char **argv)
 {
     myargs_t a = {0};
     int ret, tidx;
-
-    setlocale(LC_ALL, "");
 
     signal(SIGSEGV, sig_handler);
     signal(SIGTERM, sig_handler);


### PR DESCRIPTION
To reduce the number of calls the developer needs to make in his
application we move the setlocale() call to the cne initialization
function.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>