### PR TITLE
msgchan: ensure mc_lookup matches full name

### DIFF
--- a/lib/usr/clib/msgchan/msgchan.c
+++ b/lib/usr/clib/msgchan/msgchan.c
@@ -322,7 +322,7 @@ mc_lookup(const char *name)
         strlcpy(pname + n, name, sizeof(pname) - n);
 
         TAILQ_FOREACH (mc, &mc_list_head, next) {
-            if (!strncmp(pname, mc->name, strlen(pname))) {
+            if (!strcmp(pname, mc->name)) {
                 MC_LIST_UNLOCK();
                 return mc;
             }


### PR DESCRIPTION
mc_lookup could return the wrong channel if the supplied name was a prefix of another channel name.