### PR TITLE
ring:add a cne_ring_init to use external memory

### DIFF
--- a/lib/core/ring/cne_ring.c
+++ b/lib/core/ring/cne_ring.c
@@ -30,10 +30,13 @@
 #define POWEROF2(x)       ((((x)-1) & (x)) == 0)
 #define RING_DFLT_ELEM_SZ sizeof(void *) /** The default ring element size*/
 
-size_t
+ssize_t
 cne_ring_get_memsize_elem(unsigned int esize, unsigned int count)
 {
     ssize_t sz;
+
+    if (esize == 0)
+        esize = RING_DFLT_ELEM_SZ;
 
     /* Check if element size is a multiple of 4B */
     if (esize % 4 != 0)
@@ -52,10 +55,10 @@ cne_ring_get_memsize_elem(unsigned int esize, unsigned int count)
 }
 
 /* return the size of memory occupied by a ring */
-size_t
+ssize_t
 cne_ring_get_memsize(unsigned int count)
 {
-    return cne_ring_get_memsize_elem(sizeof(void *), count);
+    return cne_ring_get_memsize_elem(RING_DFLT_ELEM_SZ, count);
 }
 
 void
@@ -102,7 +105,7 @@ cne_ring_reset(cne_ring_t *r)
  *   0 on success, or a negative value on error.
  */
 static int
-cne_ring_init(cne_ring_t *r, const char *name, unsigned count, unsigned flags)
+cne_ring_setup(cne_ring_t *r, const char *name, unsigned count, unsigned flags)
 {
     struct cne_ring *_ring = r;
     int ret;
@@ -144,9 +147,10 @@ cne_ring_init(cne_ring_t *r, const char *name, unsigned count, unsigned flags)
     return 0;
 }
 
-/* Create the ring */
+/* Create the ring using supplied memory and size */
 cne_ring_t *
-cne_ring_create(const char *name, unsigned int esize, unsigned int count, unsigned int flags)
+cne_ring_init(void *addr, ssize_t size, const char *name, unsigned int esize, unsigned int count,
+              unsigned int flags)
 {
     void *ring_mem;
     struct cne_ring *r;
@@ -168,40 +172,67 @@ cne_ring_create(const char *name, unsigned int esize, unsigned int count, unsign
         CNE_NULL_RET("Ring: No elements requested\n");
     }
 
+    if (flags & ~(RING_F_EXACT_SZ | RING_F_SC_DEQ | RING_F_SP_ENQ)) {
+        errno = EINVAL;
+        CNE_NULL_RET("Flags can only have (RING_F_EXACT_SZ | RING_F_SC_DEQ | RING_F_SP_ENQ) set\n");
+    }
+
     /* For an exact size ring, round up from count to a power of two */
     if (flags & RING_F_EXACT_SZ)
         count = cne_align32pow2(count + 1);
 
-    ring_size = cne_ring_get_memsize_elem(((esize == 0) ? RING_DFLT_ELEM_SZ : esize), count);
+    ring_size = cne_ring_get_memsize_elem(esize, count);
     if (ring_size < 0) {
-        errno = EINVAL;
+        errno = -ring_size;
         return NULL;
     }
 
-    /* Reserve a memory region for this ring
-       Calloc can return pointer which is not cache aligned.
-       In that case cne_ring_init calling memset will segfault on clang compiled
-       with -O3. Tested with clang-10.0.0-4ubuntu1 and gcc-9.3.0-10ubuntu2
-    */
-    ring_mem = calloc(1, ring_size + CNE_CACHE_LINE_SIZE - 1);
-    if (ring_mem != NULL) {
-        r = ring_mem;
-        if (!cne_is_aligned(ring_mem, CNE_CACHE_LINE_SIZE)) {
-            CNE_LOG(DEBUG, "ring is not cache aligned r=%p aligned=%p\n", ring_mem,
-                    CNE_PTR_ALIGN(ring_mem, CNE_CACHE_LINE_SIZE));
-            r = CNE_PTR_ALIGN(ring_mem, CNE_CACHE_LINE_SIZE);
+    if (addr) {
+        /* Address must be aligned to a cacheline boundary */
+        if (!cne_is_aligned(addr, CNE_CACHE_LINE_SIZE)) {
+            errno = EINVAL;
+            CNE_NULL_RET("ring is not cache aligned r=%p aligned=%p\n", addr,
+                         CNE_PTR_ALIGN(addr, CNE_CACHE_LINE_SIZE));
         }
-        /* no need to check return value here, we already checked the
-         * arguments above */
-        cne_ring_init(r, name, requested_count, flags);
-        r->ring_mem = ring_mem;
+
+        /* Use the supplied buffer as the ring buffer and structure memory */
+        if (ring_size > size) {
+            errno = ENOMEM;
+            return NULL;
+        }
+        ring_mem = addr;
+        memset(ring_mem, 0, ring_size);
     } else {
-        r     = NULL;
-        errno = ENOMEM;
-        CNE_ERR("Ring: cannot reserve memory\n");
+        /* Reserve a memory region for this ring
+         * Calloc can return pointer which is not cache aligned.
+         * In that case cne_ring_setup calling memset will segfault on clang compiled
+         * with -O3. Tested with clang-10.0.0-4ubuntu1 and gcc-9.3.0-10ubuntu2
+         */
+        ring_mem = calloc(1, ring_size + CNE_CACHE_LINE_SIZE - 1);
+        if (!ring_mem) {
+            errno = ENOMEM;
+            CNE_NULL_RET("Ring: cannot reserve memory\n");
+        }
+        flags |= RING_F_ALLOCATED;
     }
 
+    r = ring_mem;
+    if (!cne_is_aligned(ring_mem, CNE_CACHE_LINE_SIZE)) {
+        CNE_DEBUG("ring is not cache aligned r=%p aligned=%p\n", ring_mem,
+                  CNE_PTR_ALIGN(ring_mem, CNE_CACHE_LINE_SIZE));
+        r = CNE_PTR_ALIGN(ring_mem, CNE_CACHE_LINE_SIZE);
+    }
+    /* no need to check return value here, we already checked the arguments above */
+    cne_ring_setup(r, name, requested_count, flags);
+    r->ring_mem = ring_mem;
+
     return r;
+}
+
+cne_ring_t *
+cne_ring_create(const char *name, unsigned int esize, unsigned int count, unsigned int flags)
+{
+    return cne_ring_init(NULL, 0, name, esize, count, flags);
 }
 
 /* free the ring */
@@ -213,7 +244,8 @@ cne_ring_free(cne_ring_t *r)
     if (!_ring || !_ring->ring_mem)
         return;
 
-    free(_ring->ring_mem);
+    if (_ring->flags & RING_F_ALLOCATED)
+        free(_ring->ring_mem);
 }
 
 /* dump the status of the ring on the console */


### PR DESCRIPTION
Add a new API cne_ring_init() to allow the caller to pass in the memory
to build the ring into for allowing the caller to supply the memory region.

The new API becomes useful when we need to share memory or the application needs
to build a ring into a already allocated memory region.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>