### PR TITLE
core: move include directives outside extern "C"

### DIFF
--- a/lib/core/cne/uid.h
+++ b/lib/core/cne/uid.h
@@ -14,11 +14,11 @@
 #include <stdio.h>         // for FILE
 #include <stdint.h>        // for uint16_t
 
+#include <cne_common.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>
 
 #define UID_INITIAL_NAME    "Initial-UID"
 #define DEFAULT_MAX_THREADS 512 /**< Max Number of threads to support */

--- a/lib/core/events/cne_event.h
+++ b/lib/core/events/cne_event.h
@@ -10,10 +10,6 @@
 #ifndef _CNE_EVENT_H_
 #define _CNE_EVENT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -25,7 +21,11 @@ extern "C" {
 #include <errno.h>
 #include <bsd/string.h>
 
-#include "cne_common.h"        // for CNDP_API
+#include <cne_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 enum cne_ev_handle_type { CNE_EV_HANDLE_MEM, CNE_EV_HANDLE_EXT, CNE_EV_HANDLE_MAX };
 

--- a/lib/core/hash/cne_hash_crc.h
+++ b/lib/core/hash/cne_hash_crc.h
@@ -11,13 +11,13 @@
  * CNE CRC Hash
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <cne_branch_prediction.h>
 #include <cne_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // clang-format off
 /* Lookup tables for software implementation of CRC32C */

--- a/lib/core/hash/cne_jhash.h
+++ b/lib/core/hash/cne_jhash.h
@@ -11,16 +11,16 @@
  * jhash functions.
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <string.h>
 #include <limits.h>
 #include <endian.h>
 
 #include <cne_log.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* jhash.h: Jenkins hash support.
  *

--- a/lib/core/log/cne_log.h
+++ b/lib/core/log/cne_log.h
@@ -13,18 +13,17 @@
  * This file provides a log API to CNE applications.
  */
 
-#include <stdio.h>         // for NULL
-#include <stdarg.h>        // for va_list
-#include <stdint.h>        // for uint32_t
+#include <stdio.h>             // for NULL
+#include <stdarg.h>            // for va_list
+#include <stdint.h>            // for uint32_t
+#include <cne_common.h>        // for CNDP_API
 #include <cne_stdio.h>
+
+#include "cne_build_config.h"        // for CNE_ENABLE_ASSERT
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>        // for CNDP_API
-
-#include "cne_build_config.h"        // for CNE_ENABLE_ASSERT
 
 #define foreach_cndp_log_level \
     _(1, EMERG, emerg)         \

--- a/lib/core/mmap/cne_mmap.h
+++ b/lib/core/mmap/cne_mmap.h
@@ -5,8 +5,6 @@
 #ifndef _MMAP_H_
 #define _MMAP_H_
 
-#include <stddef.h>        // for size_t
-#include <stdint.h>        // for uint64_t, uint8_t
 /**
  * @file
  * CNE allocator for huge pages
@@ -14,11 +12,14 @@
  * Allocate memory using MMAP anonyuous memory using hugepages.
  */
 
+#include <stddef.h>        // for size_t
+#include <stdint.h>        // for uint64_t, uint8_t
+
+#include <cne_common.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>
 
 /**
  * Set of enums to help define HUGEPAGE sizes

--- a/lib/core/osal/cne_stdio.h
+++ b/lib/core/osal/cne_stdio.h
@@ -5,32 +5,28 @@
 #ifndef __CNE_STDIO_H_
 #define __CNE_STDIO_H_
 
+/**
+ * @file
+ * CNE cursor and color support for VT100 using ANSI color escape codes.
+ */
+
 // IWYU pragma: no_include <bits/termios-struct.h>
 
 #include <termios.h>
-#include <stdint.h>            // for int16_t
+#include <stdarg.h>        // for va_list
+#include <stdint.h>        // for int16_t
+#include <stdio.h>         // for FILE
+#include <string.h>        // for strlen
+#include <unistd.h>        // for write
+
 #include <cne_atomic.h>        // for atomic_exchange, atomic_int_least32_t, atomic...
+#include <cne_common.h>
+#include <cne_system.h>
+#include <vt100_out.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>
-#include <vt100_out.h>
-
-/**
- * @file
- * CNE simple cursor and color support for VT100 using ANSI color escape codes.
- *
- */
-
-#include <string.h>        // for strlen
-#include <stdio.h>         // for FILE
-#include <stdarg.h>        // for va_list
-#include <unistd.h>        // for write
-#include <cne_system.h>
-
-#include "cne_common.h"        // for CNDP_API
 
 /**
  * A printf like routine to output to tty file descriptor.

--- a/lib/core/osal/cne_system.h
+++ b/lib/core/osal/cne_system.h
@@ -2,20 +2,18 @@
  * Copyright (c) 2019-2022 Intel Corporation
  */
 
-#include <sys/syscall.h>
-#include <stdint.h>        // for uint16_t, uint64_t
-
 #ifndef _CNE_SYSTEM_H_
 #define _CNE_SYSTEM_H_
 
-#include <cne_common.h>        // for CNDP_API
-
 /**
  * @file
- *
  * API for lcore and socket manipulation
- *
  */
+
+#include <sys/syscall.h>
+#include <stdint.h>        // for uint16_t, uint64_t
+
+#include <cne_common.h>        // for CNDP_API
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/core/osal/cne_tty.h
+++ b/lib/core/osal/cne_tty.h
@@ -5,33 +5,30 @@
 #ifndef __CNE_TTY_H_
 #define __CNE_TTY_H_
 
-// IWYU pragma: no_include <bits/termios-struct.h>
-
-#include <termios.h>
-#include <stdint.h>            // for uint16_t
-#include <string.h>            // for strlen
-#include <stdio.h>             // for FILE
-#include <stdarg.h>            // for va_list
-#include <unistd.h>            // for read, write
-#include <signal.h>            // for sigaction
-#include <cne_atomic.h>        // for CNE_ATOMIC
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * @file
  * CNE TTY input and output support routines.
  *
- * Setup the TTY for I/O unless it is a socket instead.
- * These routines as common and used by cli and all output routines for stdin/stdout
- * as well as socket I/O handling in later changes.
+ * Setup the TTY for I/O unless it is a socket instead. These routines are used by cli and all
+ * output routines for stdin/stdout as well as socket I/O handling.
  */
 
+// IWYU pragma: no_include <bits/termios-struct.h>
+
+#include <termios.h>
+#include <signal.h>            // for sigaction
+#include <stdarg.h>            // for va_list
+#include <stdint.h>            // for uint16_t
+#include <stdio.h>             // for FILE
+#include <string.h>            // for strlen
+#include <unistd.h>            // for read, write
+#include <cne_atomic.h>        // for CNE_ATOMIC
+#include <cne_common.h>
 #include <cne_system.h>
 
-#include "cne_common.h"        // for CNDP_API
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define TTY_BUFF_SIZE    1024
 #define TTY_MAX_CMD_SIZE 16

--- a/lib/core/osal/netdev_funcs.h
+++ b/lib/core/osal/netdev_funcs.h
@@ -5,16 +5,15 @@
 #ifndef _NETDEV_FUNCS_H_
 #define _NETDEV_FUNCS_H_
 
+/**
+ * @file
+ * API for netdev modification like setting promiscuous mode, link up/down, etc.
+ */
+
 #include <stdint.h>            // for uint32_t, uint16_t
 #include <cne_common.h>        // for CNDP_API
 
 struct ether_addr;
-/**
- * @file
- *
- * API for netdev modifications like promiscuous mode, set link up/down ...
- *
- */
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/core/osal/vt100_out.h
+++ b/lib/core/osal/vt100_out.h
@@ -5,32 +5,28 @@
 #ifndef __VT100_OUT_H_
 #define __VT100_OUT_H_
 
+/**
+ * @file
+ * CNE cursor and color support for VT100 using ANSI color escape codes.
+ */
+
 // IWYU pragma  no_include <bits/termios-struct.h>
 
+#include <stdarg.h>        // for va_end, va_list, va_start
+#include <stdint.h>        // for int16_t, uint8_t
+#include <stdio.h>         // for snprintf, NULL
+#include <string.h>        // for strlen
 #include <termios.h>
-#include <stdint.h>            // for int16_t, uint8_t
+#include <unistd.h>        // for write
+
 #include <cne_atomic.h>        // for atomic_exchange, atomic_int_least32_t, atomic...
+#include <cne_common.h>
+#include <cne_system.h>
+#include <cne_tty.h>        // for tty_printf, tty_write
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>
-#include <cne_tty.h>        // for tty_printf, tty_write
-
-/**
- * @file
- * CNE simple cursor and color support for VT100 using ANSI color escape codes.
- *
- */
-
-#include <string.h>        // for strlen
-#include <stdio.h>         // for snprintf, NULL
-#include <stdarg.h>        // for va_end, va_list, va_start
-#include <unistd.h>        // for write
-#include <cne_system.h>
-
-#include "cne_common.h"        // for CNDP_API
 
 #define VT_DEFAULT_NAME "default"
 

--- a/lib/core/pktdev/pktdev_api.h
+++ b/lib/core/pktdev/pktdev_api.h
@@ -11,14 +11,14 @@
  * pktdev structures and APIs.
  */
 
-#include <cne_lport.h>        // for lport_cfg_t, lport_stats_t
-#include <stdbool.h>          // for bool, false, true
-#include <stdint.h>           // for uint16_t
-#include <stdio.h>            // for NULL, FILE
+#include <stdbool.h>        // for bool, false, true
+#include <stdint.h>         // for uint16_t
+#include <stdio.h>          // for NULL, FILE
 
-#include "cne_common.h"          // for CNDP_API
-#include "pktmbuf.h"             // for pktmbuf_t
-#include "netdev_funcs.h"        // for struct offloads
+#include <cne_common.h>          // for CNDP_API
+#include <cne_lport.h>           // for lport_cfg_t, lport_stats_t
+#include <netdev_funcs.h>        // for struct offloads
+#include <pktmbuf.h>             // for pktmbuf_t
 
 struct ether_addr;
 struct cne_pktdev;

--- a/lib/core/pktdev/pktdev_driver.h
+++ b/lib/core/pktdev/pktdev_driver.h
@@ -5,19 +5,17 @@
 #ifndef __PKTDEV_DRIVER_H_
 #define __PKTDEV_DRIVER_H_
 
-#include <cne_atomic.h>
-#include <sys/queue.h>
-#include <cne_common.h>
-
 /**
  * @file
  *
- * CNE Ethernet Device PMD API
+ * CNE pktdev PMD API
  *
- * These APIs for the use from Ethernet drivers, user applications shouldn't
- * use them.
- *
+ * These APIs are used by pktdev drivers. Applications should not use them.
  */
+
+#include <sys/queue.h>
+#include <cne_atomic.h>
+#include <cne_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/core/pktmbuf/pktmbuf.h
+++ b/lib/core/pktmbuf/pktmbuf.h
@@ -31,18 +31,18 @@
  * http://www.kohala.com/start/tcpipiv2.html
  */
 
+#include <errno.h>                        // for EINVAL
 #include <stdint.h>                       // for uint16_t, uint32_t, uint8_t, UINT...
+#include <stdio.h>                        // for NULL, FILE
+#include <bsd/string.h>                   // for strlcpy
 #include <cne_atomic.h>                   // for atomic_uint_least16_t
 #include <cne_common.h>                   // for CNDP_API, CNE_STD_C11, __cne_alwa...
-#include <mempool.h>                      // for mempool_t, mempool_get, mempool_g...
+#include <cne_branch_prediction.h>        // for likely, unlikely
+#include <cne_log.h>                      // for CNE_ASSERT
 #include <cne_mmap.h>                     // for mmap_type_t
 #include <cne_prefetch.h>                 // for cne_prefetch0
-#include <cne_branch_prediction.h>        // for likely, unlikely
-#include <stdio.h>                        // for NULL, FILE
-#include <errno.h>                        // for EINVAL
-#include <bsd/string.h>                   // for strlcpy
+#include <mempool.h>                      // for mempool_t, mempool_get, mempool_g...
 
-#include "cne_log.h"            // for CNE_ASSERT
 #include "pktmbuf_ops.h"        // for mbuf_ops_t
 #include "pktmbuf_offload.h"
 

--- a/lib/core/pmds/tun/tun_alloc.h
+++ b/lib/core/pmds/tun/tun_alloc.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2021-2022 Intel Corporation
  */
+
 #ifndef __INC_TUN_ALLOC_H__
 #define __INC_TUN_ALLOC_H__
 
@@ -9,11 +10,11 @@
  * TUN/TAP allocate routines, defines and structures.
  */
 
+#include <cne_common.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>
 
 #define TUN_TAP_DEV_PATH "/dev/net/tun"
 

--- a/lib/core/ring/cne_ring.h
+++ b/lib/core/ring/cne_ring.h
@@ -32,18 +32,15 @@
  *
  */
 
+#include <cne_common.h>        // for CNE_NAME_LEN
+#include <cne_ring_api.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** The maximum length of a ring name. */
 #define CNE_RING_NAMESIZE CNE_NAME_LEN
-
-typedef void cne_ring_t;
-
-#include <cne_ring_api.h>
-
-#include "cne_common.h"        // for CNE_NAME_LEN
 
 #ifdef __cplusplus
 }

--- a/lib/core/ring/cne_ring_api.h
+++ b/lib/core/ring/cne_ring_api.h
@@ -36,13 +36,15 @@
  *
  */
 
+#include <errno.h>
+#include <stdio.h>
+#include <cne_common.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stdio.h>
-#include <errno.h>
-#include <cne_common.h>
+typedef void cne_ring_t;
 
 #define RING_F_SP_ENQ    0x0001 /**< The default enqueue is "single-producer". */
 #define RING_F_SC_DEQ    0x0002 /**< The default dequeue is "single-consumer". */

--- a/lib/core/txbuff/txbuff.h
+++ b/lib/core/txbuff/txbuff.h
@@ -7,21 +7,21 @@
 
 /**
  * @file
- *   Routines and structures to allow an application to send single mbufs or packets
- *   while enqueuing the packets to an array and flush the packets to the output port
- *   when the number of packets fills the array.
+ * Routines and structures to allow an application to send single mbufs or packets
+ * while enqueuing the packets to an array and flush the packets to the output port
+ * when the number of packets fills the array.
  *
- *   Using this method allows for buffered packet to be sent in bulk and not one at a
- *   time.
+ * Using this method allows for buffered packet to be sent in bulk and not one at a
+ * time.
  */
+
+#include <stdint.h>            // for uint16_t, uint32_t
+#include <cne_common.h>        // for CNDP_API, CNE_STD_C11
+#include <pktmbuf.h>           // for pktmbuf_t
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>        // for CNDP_API, CNE_STD_C11
-#include <pktmbuf.h>           // for pktmbuf_t
-#include <stdint.h>            // for uint16_t, uint32_t
 
 struct txbuff;
 

--- a/lib/core/xskdev/xskdev.h
+++ b/lib/core/xskdev/xskdev.h
@@ -5,14 +5,6 @@
 #ifndef _XSKDEV_H_
 #define _XSKDEV_H_
 
-#include <net/if.h>           // for IF_NAMESIZE
-#include <poll.h>             // for pollfd
-#include <pthread.h>          // for pthread_mutex_t, pthread_mutex_init, pthre...
-#include <bpf/xsk.h>          // for XSK_RING_CONS__DEFAULT_NUM_DESCS, xsk_ring...
-#include <stdint.h>           // for uint16_t, uint32_t
-#include <stdio.h>            // for FILE, NULL, size_t
-#include <cne_lport.h>        // for lport_stats_t, buf_alloc_t, buf_free_t
-
 /**
  * @file
  *
@@ -21,14 +13,21 @@
  * This file provides a low-level abstraction for applications to XSK APIs.
  */
 
+#include <poll.h>           // for pollfd
+#include <pthread.h>        // for pthread_mutex_t, pthread_mutex_init, pthre...
+#include <stdint.h>         // for uint16_t, uint32_t
+#include <stdio.h>          // for FILE, NULL, size_t
+#include <bpf/xsk.h>        // for XSK_RING_CONS__DEFAULT_NUM_DESCS, xsk_ring...
+#include <net/if.h>         // for IF_NAMESIZE
+
+#include <cne_common.h>        // for CNDP_API, CNE_STD_C11
+#include <cne_lport.h>         // for lport_stats_t, buf_alloc_t, buf_free_t
+#include <pktmbuf.h>           // for pktmbuf_t
+#include <uds.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <uds.h>
-
-#include "cne_common.h"        // for CNDP_API, CNE_STD_C11
-#include "pktmbuf.h"           // for pktmbuf_t
 
 #ifndef SOL_XDP
 #define SOL_XDP 283


### PR DESCRIPTION
Moved the includes outside the extern "C" block to fix potential errors
with C++ compiler.

Signed-off-by: Jeff Shaw <jeffrey.b.shaw@intel.com>