### PR TITLE
lib/usr: move include directives outside extern "C"

### DIFF
--- a/lib/usr/app/cli/cli_env.h
+++ b/lib/usr/app/cli/cli_env.h
@@ -2,22 +2,20 @@
  * Copyright (c) <2019-2021> Intel Corporation.
  */
 
-#include <sys/queue.h>        // for TAILQ_ENTRY, TAILQ_HEAD
-
 #ifndef _CLI_ENV_H_
 #define _CLI_ENV_H_
 
 /**
  * @file
  * CNE Command line interface
- *
  */
+
+#include <sys/queue.h>         // for TAILQ_ENTRY, TAILQ_HEAD
+#include <cne_common.h>        // for CNDP_API
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>        // for CNDP_API
 
 struct cli;
 

--- a/lib/usr/app/cli/cli_map.h
+++ b/lib/usr/app/cli/cli_map.h
@@ -12,12 +12,11 @@
 #define _CLI_MAP_H_
 
 #include <netinet/in.h>
+#include <cne_common.h>        // for CNDP_API
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>        // for CNDP_API
 
 struct cli_map {
     int index;

--- a/lib/usr/app/cli/cli_vt100.h
+++ b/lib/usr/app/cli/cli_vt100.h
@@ -5,32 +5,29 @@
 #ifndef __CLI_VT100_H_
 #define __CLI_VT100_H_
 
+/**
+ * @file
+ * CNE cursor and color support for VT100 using ANSI color escape codes.
+ */
+
 // IWYU pragma: no_include <bits/termios-struct.h>
 
+#include <stdarg.h>        // for va_end, va_list, va_start
+#include <stdint.h>        // for uint8_t
+#include <stdio.h>         // for fileno, fprintf, stderr, stdin, stdout
+#include <string.h>        // for strlen
 #include <termios.h>
-#include <stdint.h>            // for uint8_t
+#include <unistd.h>            // for read, write
 #include <cne_atomic.h>        // for atomic_exchange, atomic_int_least32_t, atomic...
+#include <cne_common.h>        // for CNDP_API
+#include <cne_stdio.h>         // for ESC
+#include <cne_system.h>
+#include <cne_tty.h>
+#include <vt100_out.h>        // for ESC
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @file
- * CNE simple cursor and color support for VT100 using ANSI color escape codes.
- *
- ***/
-
-#include <string.h>        // for strlen
-#include <stdio.h>         // for fileno, fprintf, stderr, stdin, stdout
-#include <stdarg.h>        // for va_end, va_list, va_start
-#include <unistd.h>        // for read, write
-#include <cne_system.h>
-#include <cne_tty.h>
-
-#include "cne_common.h"        // for CNDP_API
-#include "cne_stdio.h"         // for ESC
-#include "vt100_out.h"         // for ESC
 
 #define VT100_INITIALIZE -1
 

--- a/lib/usr/app/jcfg/jcfg.h
+++ b/lib/usr/app/jcfg/jcfg.h
@@ -10,32 +10,31 @@
  * JSON configuration using json-c
  */
 
+#include <pthread.h>           // for pthread_t
+#include <sched.h>             // for cpu_set_t
+#include <stdint.h>            // for uint16_t, uint32_t, uint64_t, int64_t
 #include <sys/socket.h>        // for accept, bind, listen, socket, AF_UNIX
-#include <sys/un.h>            // for sockaddr_un
 #include <sys/queue.h>         // for STAILQ_ENTRY, STAILQ_HEAD
+#include <sys/un.h>            // for sockaddr_un
 #include <bsd/sys/bitstring.h>
 #include <json-c/json_object.h>
 #include <json-c/json_tokener.h>
 #include <json-c/json_util.h>
 #include <json-c/json_visit.h>        // for json_c_visit_userfunc
 #include <json-c/linkhash.h>
-#include <pthread.h>        // for pthread_t
-#include <sched.h>          // for cpu_set_t
-#include <stdint.h>         // for uint16_t, uint32_t, uint64_t, int64_t
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <cne_common.h>        // for CNDP_API, CNE_STD_C11
+#include <cne_log.h>
+#include <cne_mmap.h>        // for mmap_t
+#include <cne_thread.h>
+#include <pktmbuf.h>        // for pktmbuf_info_t
 
 #define DEFAULT_CHUNK_SIZE   1024
 #define UMEM_MAX_REGIONS     128
 #define JCFG_MAX_STRING_SIZE 32
 
-#include <cne_common.h>        // for CNDP_API, CNE_STD_C11
-#include <cne_log.h>
-#include <cne_thread.h>
-#include <cne_mmap.h>        // for mmap_t
-#include <pktmbuf.h>         // for pktmbuf_info_t
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct json_object;
 

--- a/lib/usr/app/metrics/metrics.h
+++ b/lib/usr/app/metrics/metrics.h
@@ -13,14 +13,13 @@
 
 #include <stdint.h>
 
-#include "cne_common.h"        // for CNDP_API
+#include <cne_common.h>        // for CNDP_API
+#include <cne_lport.h>
+#include <uds.h>        // for uds_client_t, uds_info_t
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_lport.h>
-#include "uds.h"        // for uds_client_t, uds_info_t
 
 typedef uds_info_t metrics_info_t;
 typedef uds_client_t metrics_client_t;

--- a/lib/usr/clib/meter/cne_meter.h
+++ b/lib/usr/clib/meter/cne_meter.h
@@ -5,29 +5,26 @@
 #ifndef __INCLUDE_CNE_METER_H__
 #define __INCLUDE_CNE_METER_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * @file
  * CNDP Traffic Metering
  *
  * Traffic metering algorithms:
- *    1. Single Rate Three Color Marker (srTCM): defined by IETF RFC 2697
- *    2. Two Rate Three Color Marker (trTCM): defined by IETF RFC 2698
- *    3. Two Rate Three Color Marker (trTCM): defined by IETF RFC 4115
- *
- ***/
+ * 1. Single Rate Three Color Marker (srTCM): defined by IETF RFC 2697
+ * 2. Two Rate Three Color Marker (trTCM): defined by IETF RFC 2698
+ * 3. Two Rate Three Color Marker (trTCM): defined by IETF RFC 4115
+ */
 
 #include <stdint.h>
+#include <cne_common.h>
 
-#include "cne_common.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*
  * Application Programmer's Interface (API)
- *
- ***/
+ */
 
 /**
  * Color
@@ -39,18 +36,22 @@ enum cne_color {
     CNE_COLORS           /**< Number of colors */
 };
 
-/** srTCM parameters per metered traffic flow. The CIR, CBS and EBS parameters only
-count bytes of IP packets and do not include link specific headers. At least one of
-the CBS or EBS parameters has to be greater than zero. */
+/**
+ * srTCM parameters per metered traffic flow. The CIR, CBS and EBS parameters only
+ * count bytes of IP packets and do not include link specific headers. At least one of
+ * the CBS or EBS parameters has to be greater than zero.
+ */
 struct cne_meter_srtcm_params {
     uint64_t cir; /**< Committed Information Rate (CIR). Measured in bytes per second. */
     uint64_t cbs; /**< Committed Burst Size (CBS).  Measured in bytes. */
     uint64_t ebs; /**< Excess Burst Size (EBS).  Measured in bytes. */
 };
 
-/** trTCM parameters per metered traffic flow. The CIR, PIR, CBS and PBS parameters
-only count bytes of IP packets and do not include link specific headers. PIR has to
-be greater than or equal to CIR. Both CBS or EBS have to be greater than zero. */
+/**
+ * trTCM parameters per metered traffic flow. The CIR, PIR, CBS and PBS parameters
+ * only count bytes of IP packets and do not include link specific headers. PIR has to
+ * be greater than or equal to CIR. Both CBS or EBS have to be greater than zero.
+ */
 struct cne_meter_trtcm_params {
     uint64_t cir; /**< Committed Information Rate (CIR). Measured in bytes per second. */
     uint64_t pir; /**< Peak Information Rate (PIR). Measured in bytes per second. */
@@ -58,10 +59,12 @@ struct cne_meter_trtcm_params {
     uint64_t pbs; /**< Peak Burst Size (PBS). Measured in bytes. */
 };
 
-/** trTCM parameters per metered traffic flow. The CIR, EIR, CBS and EBS
-parameters only count bytes of IP packets and do not include link specific
-headers. The CBS and EBS need to be greater than zero if CIR and EIR are
-none-zero respectively.*/
+/**
+ * trTCM parameters per metered traffic flow. The CIR, EIR, CBS and EBS
+ * parameters only count bytes of IP packets and do not include link specific
+ * headers. The CBS and EBS need to be greater than zero if CIR and EIR are
+ * none-zero respectively.
+ */
 struct cne_meter_trtcm_rfc4115_params {
     uint64_t cir; /**< Committed Information Rate (CIR). Measured in bytes per second. */
     uint64_t eir; /**< Excess Information Rate (EIR). Measured in bytes per second. */
@@ -294,8 +297,7 @@ cne_meter_trtcm_rfc4115_color_aware_check(struct cne_meter_trtcm_rfc4115 *m,
 
 /*
  * Inline implementation of run-time methods
- *
- ***/
+ */
 
 struct cne_meter_srtcm_profile {
     uint64_t cbs;

--- a/lib/usr/clib/nodes/node_eth_api.h
+++ b/lib/usr/clib/nodes/node_eth_api.h
@@ -14,15 +14,14 @@
  *
  * This API allows to setup pktdev_rx and pktdev_tx nodes
  * and its queue associations.
- *
  */
+
+#include <cne_common.h>
+#include <mempool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>
-#include <mempool.h>
 
 /**
  * Port config for pktdev_rx and pktdev_tx node.

--- a/lib/usr/clib/nodes/node_ip4_api.h
+++ b/lib/usr/clib/nodes/node_ip4_api.h
@@ -14,13 +14,13 @@
  *
  * This API allows to do control path functions of ip4_* nodes
  * like ip4_lookup, ip4_rewrite.
- *
  */
+
+#include <cne_common.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cne_common.h>
 
 /**
  * IP4 lookup next nodes.


### PR DESCRIPTION
Moved the includes outside the extern "C" block to fix potential
errors with C++ compiler.

Signed-off-by: Jeff Shaw <jeffrey.b.shaw@intel.com>