### PR TITLE
Set Rust application thread CPU affinity to lcore group.

### DIFF
--- a/lang/rs/apis/cne/run_loopback.sh
+++ b/lang/rs/apis/cne/run_loopback.sh
@@ -14,8 +14,9 @@ CONFIG=${1:-"./fwd.jsonc"}
 # Port id. Use default port id as 0.
 PORT=${2:-0}
 
-# Core affinity for loopback thread. Default value "-1" means core affinity not set.
-CORE=${3:-"-1"}
+# Core affinity group for loopback thread. Default value "" means core affinity will not be set.
+# group name should be present in lcore-groups in jsonc file.
+CORE=${3:-"group0"}
 
 # Need to LD_PRELOAD libpmd_af_xdp.so since Rust binary doesn't include it and is required for applications.
 # Including libpmd_af_xdp.so as whole-archive during linking of rust binary doesn't seem to work.

--- a/lang/rs/apis/cne/src/instance.rs
+++ b/lang/rs/apis/cne/src/instance.rs
@@ -198,6 +198,27 @@ impl CneInstance {
         }
     }
 
+    /// Sets current thread cpu set affinity corresponding to the group name
+    /// in JSONC file lcore-groups section.
+    ///
+    /// Returns an empty tuple or error in case of failure.
+    ///
+    /// # Arguments
+    /// * `group` - group name in JSONC file lcore-groups section.
+    ///
+    /// # Errors
+    /// Returns [CneError::ConfigError] if an error is encountered.
+    ///
+    pub fn set_current_thread_affinity(&self, group: &str) -> Result<(), CneError> {
+        let cne = self.read()?;
+
+        if let Some(cfg) = &cne.cfg {
+            cfg.set_current_thread_affinity(group)
+        } else {
+            Err(CneError::ConfigError("CNE is not configured".to_string()))
+        }
+    }
+
     pub(crate) fn get_port_details(&self, port_index: u16) -> Result<PortDetails, CneError> {
         let cne = self.read()?;
 

--- a/lang/rs/examples/echo_server/run_echo_server.sh
+++ b/lang/rs/examples/echo_server/run_echo_server.sh
@@ -32,9 +32,13 @@ elif [ "$MODE" == "cne" ]; then
     # Port id. Use 256 as default burst size.
     BURST=${4:-256}
 
+    # Core affinity group for loopback thread. Default value "" means core affinity will not be set.
+    # group name should be present in lcore-groups in jsonc file.
+    CORE=${3:-"group0"}
+
     # Need to LD_PRELOAD libpmd_af_xdp.so since Rust binary doesn't include it and is required for applications.
     # Including libpmd_af_xdp.so as whole-archive during linking of rust binary doesn't seem to work.
-    sudo -E LD_LIBRARY_PATH=$LD_LIBRARY_PATH LD_PRELOAD=$LD_LIBRARY_PATH/libpmd_af_xdp.so RUST_LOG=info `which cargo` run -p $CRATE --release -- $MODE -c $CONFIG -p $PORT -b $BURST
+    sudo -E LD_LIBRARY_PATH=$LD_LIBRARY_PATH LD_PRELOAD=$LD_LIBRARY_PATH/libpmd_af_xdp.so RUST_LOG=info `which cargo` run -p $CRATE --release -- $MODE -c $CONFIG -p $PORT -b $BURST -a $CORE
 else
     cargo run -p $CRATE --release -- help
 fi


### PR DESCRIPTION
Rust application does not use threads section in JSONC file.
Rust application starts its own thread and it can (optionally) affinitize thread to
the CPU set specified by a group name in lcore-groups section in JSONC file.

Setting CPU affinity can help to improve performance of Rust CNDP applications.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>