### PR TITLE
Add Rust package keyword.

### DIFF
--- a/lang/rs/apis/cne/Cargo.toml
+++ b/lang/rs/apis/cne/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 version = "0.1.0"
 edition = "2021"
 license = "BSD-3-Clause"
+keywords = ["networking", "cloud native", "AF_XDP"]
 
 [lib]
 name = "cne"

--- a/lang/rs/bindings/cne-sys/Cargo.toml
+++ b/lang/rs/bindings/cne-sys/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 version = "0.1.0"
 edition = "2021"
 license = "BSD-3-Clause"
+keywords = ["networking", "cloud native", "AF_XDP"]
 
 [lib]
 name = "cne_sys"


### PR DESCRIPTION
Add keywords in Rust cne and Rust cne-sys crates which will help
to search for these crates when crates are published in crates.io

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>