### PR TITLE
go-bindings: add Pointer method to LocklessRing

### DIFF
--- a/lang/go/bindings/cne/lring.go
+++ b/lang/go/bindings/cne/lring.go
@@ -263,3 +263,11 @@ func (lr *LocklessRing) Empty() bool {
 	}
 	return C.cne_ring_empty(lr.ring) > 0
 }
+
+// Pointer returns the pointer to the C ring struct.
+func (lr *LocklessRing) Pointer() unsafe.Pointer {
+	if lr == nil {
+		return nil
+	}
+	return lr.ring
+}


### PR DESCRIPTION
Add Pointer method to expose the ring pointer. Allows
it to be used with CGO and have C threads communicate
with Go threads via rings.

Signed-off-by: Nicholas Waples <nwaples@gmail.com>