### PR TITLE
Rust API to get thread details in JSONC file.

### DIFF
--- a/lang/rs/apis/cne/src/instance.rs
+++ b/lang/rs/apis/cne/src/instance.rs
@@ -2,6 +2,7 @@
  * Copyright (c) 2020-2022 Intel Corporation.
  */
 
+use std::collections::HashMap;
 use std::mem::MaybeUninit;
 use std::sync::Once;
 use std::sync::RwLock;
@@ -235,6 +236,25 @@ impl CneInstance {
             cfg.set_current_thread_affinity(group)
         } else {
             Err(CneError::ConfigError("CNE is not configured".to_string()))
+        }
+    }
+
+    /// Get thread details in threads section of JSONC configuration file.
+    ///
+    /// Returns thread details or error in case of failure.
+    ///
+    /// # Errors
+    /// Returns [CneError::ConfigError] if an error is encountered.
+    ///
+    pub fn get_thread_details(&self) -> Result<HashMap<String, Thread>, CneError> {
+        let cne = self.read()?;
+
+        if let Some(cfg) = &cne.cfg {
+            cfg.get_thread_details()
+        } else {
+            Err(CneError::ConfigError(
+                "Cannot find thread details. CNE is not configured".to_string(),
+            ))
         }
     }
 

--- a/lang/rs/apis/cne/src/lib.rs
+++ b/lang/rs/apis/cne/src/lib.rs
@@ -19,7 +19,7 @@
 //! Checkout [examples](https://github.com/CloudNativeDataPlane/cndp/tree/main/lang/rs/apis/cne/examples)
 //! Also see the crate documentation.
 
-pub(crate) mod config;
+pub mod config;
 pub mod error;
 pub mod instance;
 pub mod packet;


### PR DESCRIPTION
Provide API to get thread details in JSONC file threads section.
Rust applications can use thread details if required to create threads.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>