### PR TITLE
fix cndpfwd with memif pmd hang

### DIFF
--- a/examples/cndpfwd/acl-func.c
+++ b/examples/cndpfwd/acl-func.c
@@ -331,6 +331,8 @@ acl_fwd_test(jcfg_lport_t *lport, struct fwd_info *fwd)
         break;
     case PKTDEV_PKT_API:
         n_pkts = pktdev_rx_burst(pd->lport, pd->rx_mbufs, BURST_SIZE);
+        if (n_pkts == PKTDEV_ADMIN_STATE_DOWN)
+            return 0;
         break;
     default:
         n_pkts = 0;

--- a/examples/dlb_test/dlb_test.c
+++ b/examples/dlb_test/dlb_test.c
@@ -154,6 +154,9 @@ producer(void *arg)
                 continue;
 
             n_pkts = pktdev_rx_burst(pd->lport, pd->rx_mbufs, MAX_BURST);
+            if (n_pkts == PKTDEV_ADMIN_STATE_DOWN)
+                goto leave;
+
             if (n_pkts == 0)
                 continue;
             for (i = 0; i < n_pkts; i++) {

--- a/lib/cnet/eth/eth_rx.c
+++ b/lib/cnet/eth/eth_rx.c
@@ -117,6 +117,8 @@ eth_rx_node_do(struct cne_graph *graph, struct cne_node *node, eth_rx_node_ctx_t
     /* Get pkts from port */
     nb_pkts = (node->size >= CNE_GRAPH_BURST_SIZE) ? CNE_GRAPH_BURST_SIZE : node->size;
     count   = pktdev_rx_burst(ctx->port_id, (pktmbuf_t **)node->objs, nb_pkts);
+    if (count == PKTDEV_ADMIN_STATE_DOWN)
+        return count;
 
     if (count) {
         eth_pkt_parse(ctx, (pktmbuf_t **)node->objs, count);

--- a/lib/cnet/eth/eth_tx.c
+++ b/lib/cnet/eth/eth_tx.c
@@ -33,6 +33,8 @@ eth_tx_node_process(struct cne_graph *graph, struct cne_node *node, void **objs,
             int cnt;
 
             cnt = pktdev_tx_burst(port, (pktmbuf_t **)objs, nb_objs);
+            if (cnt == PKTDEV_ADMIN_STATE_DOWN)
+                return cnt;
 
             objs += cnt;
             nb_objs -= cnt;

--- a/lib/core/pktdev/pktdev.h
+++ b/lib/core/pktdev/pktdev.h
@@ -36,6 +36,7 @@ extern "C" {
 #define PKTDEV_FALLBACK_TX_RINGSIZE 512
 #define PKTDEV_FALLBACK_RX_NBQUEUES 1
 #define PKTDEV_FALLBACK_TX_NBQUEUES 1
+#define PKTDEV_ADMIN_STATE_DOWN     0xFFFF
 
 #include <cne_lport.h>
 
@@ -176,6 +177,7 @@ struct pktdev_info {
  *   The number of packets actually retrieved, which is the number
  *   of pointers to *pktmbuf* structures effectively supplied to the
  *   *rx_pkts* array.
+ *   returns 0xFFFF on admin_state_down
  */
 static inline uint16_t
 pktdev_rx_burst(uint16_t lport_id, pktmbuf_t **rx_pkts, const uint16_t nb_pkts)
@@ -190,8 +192,8 @@ pktdev_rx_burst(uint16_t lport_id, pktmbuf_t **rx_pkts, const uint16_t nb_pkts)
 
     /* Check packet stream status */
     if (!pktdev_admin_state(lport_id)) {
-        PKTDEV_LOG(ERR, "Packet stream is disabled for '%d'\n", lport_id);
-        return 0;
+        PKTDEV_LOG(DEBUG, "Packet stream is disabled for '%d'\n", lport_id);
+        return PKTDEV_ADMIN_STATE_DOWN;
     }
 
     nb_rx = (*dev->rx_pkt_burst)(dev->data->rx_queue, rx_pkts, nb_pkts);
@@ -250,6 +252,7 @@ pktdev_rx_burst(uint16_t lport_id, pktmbuf_t **rx_pkts, const uint16_t nb_pkts)
  *   The number of output packets actually stored in transmit descriptors of
  *   the transmit ring. The return value can be less than the value of the
  *   *tx_pkts* parameter when the transmit ring is full or has been filled up.
+ *   returns 0xFFFF on admin_state_down
  */
 static inline uint16_t
 pktdev_tx_burst(uint16_t lport_id, pktmbuf_t **tx_pkts, uint16_t nb_pkts)
@@ -270,8 +273,8 @@ pktdev_tx_burst(uint16_t lport_id, pktmbuf_t **tx_pkts, uint16_t nb_pkts)
 
     /* Check packet stream status */
     if (!pktdev_admin_state(lport_id)) {
-        PKTDEV_LOG(ERR, "Packet stream is disabled for '%d'\n", lport_id);
-        return 0;
+        PKTDEV_LOG(DEBUG, "Packet stream is disabled for '%d'\n", lport_id);
+        return PKTDEV_ADMIN_STATE_DOWN;
     }
 
     return (*dev->tx_pkt_burst)(dev->data->tx_queue, tx_pkts, nb_pkts);

--- a/lib/core/txbuff/txbuff.c
+++ b/lib/core/txbuff/txbuff.c
@@ -127,6 +127,8 @@ txbuff_flush(txbuff_t *buffer)
         switch (buffer->txtype) {
         case TXBUFF_PKTDEV_FLAG:
             sent = pktdev_tx_burst(buffer->lport_id, buffer->pkts, npkts);
+            if (sent == PKTDEV_ADMIN_STATE_DOWN)
+                return sent;
             break;
 
         case TXBUFF_XSKDEV_FLAG:

--- a/lib/usr/clib/nodes/pktdev_tx.c
+++ b/lib/usr/clib/nodes/pktdev_tx.c
@@ -29,6 +29,8 @@ pktdev_tx_node_process(struct cne_graph *graph, struct cne_node *node, void **ob
 
     do {
         int cnt = pktdev_tx_burst(port, (pktmbuf_t **)objs, nb_objs);
+        if (cnt == PKTDEV_ADMIN_STATE_DOWN)
+            return cnt;
 
         objs += cnt;
         nb_objs -= cnt;

--- a/test/testcne/loop_test.c
+++ b/test/testcne/loop_test.c
@@ -149,7 +149,7 @@ loop_main(int argc, char **argv)
     pktmbuf_t *mbufs[128];
     lport_cfg_t cfg;
     mmap_t *mmap = NULL;
-    int nb, num;
+    int nb, num, n;
 
     signal(SIGHUP, sig_handler);
     signal(SIGINT, sig_handler);
@@ -258,6 +258,8 @@ loop_main(int argc, char **argv)
         }
 
         num = pktdev_rx_burst(lport, mbufs, cne_countof(mbufs));
+        if (num == PKTDEV_ADMIN_STATE_DOWN)
+            goto leave;
         if (num == 0 || num > cne_countof(mbufs))
             continue;
 
@@ -266,6 +268,8 @@ loop_main(int argc, char **argv)
         else if (test_type == LOOPBACK_TEST) {
             while (num) {
                 nb = pktdev_tx_burst(lport, mbufs, num);
+                if (nb == PKTDEV_ADMIN_STATE_DOWN)
+                    goto leave;
 
                 num -= nb;
             }
@@ -285,7 +289,9 @@ loop_main(int argc, char **argv)
                     p[7]                 = 0x31307a79;
                     pktmbuf_data_len(xb) = 60;
                 }
-                pktdev_tx_burst(lport, mbufs, num);
+                n = pktdev_tx_burst(lport, mbufs, num);
+                if (n == PKTDEV_ADMIN_STATE_DOWN)
+                    goto leave;
             }
         } else if (test_type == L2FWD_TEST) {
             for (int i = 0; i < num; i++) {
@@ -304,6 +310,8 @@ loop_main(int argc, char **argv)
             }
             while (num) {
                 nb = pktdev_tx_burst(lport, mbufs, num);
+                if (nb == PKTDEV_ADMIN_STATE_DOWN)
+                    goto leave;
 
                 num -= nb;
             }

--- a/usrtools/txgen/app/txgen.c
+++ b/usrtools/txgen/app/txgen.c
@@ -164,6 +164,8 @@ txgen_send_burst(port_info_t *info)
     /* Send all of the packets before we can exit this function */
     while (cnt && txgen_tst_port_flags(info, SENDING_PACKETS)) {
         ret = pktdev_tx_burst(lport->lpid, pkts, cnt);
+        if (ret == PKTDEV_ADMIN_STATE_DOWN)
+            return;
         pkts += ret;
         cnt -= ret;
     }
@@ -501,7 +503,8 @@ txgen_main_receive(port_info_t *info __cne_unused, pktmbuf_t *pkts_burst[], uint
     /*
      * Read packet from RX queues and free the mbufs
      */
-    if ((nb_rx = pktdev_rx_burst(lport->lpid, pkts_burst, nb_pkts)) == 0)
+    nb_rx = pktdev_rx_burst(lport->lpid, pkts_burst, nb_pkts);
+    if ((nb_rx == 0) || (nb_rx == PKTDEV_ADMIN_STATE_DOWN))
         return;
 
     /* packets are not freed in the next call. */


### PR DESCRIPTION
cndpfwd running in client/server mode with memif pmd, after the
client instance is stopped, when server instance is tried to stop,
would hang. When the client instance exited, lport was down. But,
since the admin_state flag was not set to false, the server would
continue to tx packets and never exit.

-In pktdev_rx_burst() and pktdev_tx_burst(), packet stream state flag
was always returning true even in the case where an lport was down
and packet stream wasn't available. Now, in the case where lport is
down, 0xFFFF is returned indicating admin_state_down. Changes are
made to cndpfwd app to correctly handle the case where 0xFFFF is
returned.

-Closing of ports for all threads which was previously done during
thread_cleanup is now separated into a separate function, before
check_thread_quit.

-Handling of the admin_state_down return value in all the
tests/examples/lib that reference pktdev_rx_burst and pktdev_tx_burst
functions.

Signed-off-by: Sushma Sitaram <sushma.sitaram@intel.com>