### PR TITLE
fix compilation with bess upf compiler

### DIFF
--- a/lib/core/pktmbuf/pktmbuf.h
+++ b/lib/core/pktmbuf/pktmbuf.h
@@ -800,7 +800,10 @@ __pktmbuf_free_bulk(pktmbuf_pending_t *p, pktmbuf_t *m)
 static inline void
 pktmbuf_free_bulk(pktmbuf_t **mbufs, unsigned int count)
 {
-    pktmbuf_pending_t pend = {.pending_sz = PKTMBUF_PENDING_SZ};
+    pktmbuf_pending_t pend;
+
+    memset(&pend, 0, sizeof(pend));
+    pend.pending_sz = PKTMBUF_PENDING_SZ;
 
     if (count == 0)
         return;
@@ -1210,7 +1213,7 @@ pktmbuf_metadata(const pktmbuf_t *m)
     if (!m)
         return NULL;
 
-    if (((p = m->pooldata) != NULL) && p->metadata)
+    if (((p = (pktmbuf_info_t *)m->pooldata) != NULL) && p->metadata)
         return CNE_PTR_ADD(p->metadata, (m->meta_index * p->metadata_bufsz));
     else
         return CNE_PTR_ADD(m, sizeof(pktmbuf_t)); /* default to metadata in pktmbuf headroom */
@@ -1232,7 +1235,7 @@ pktmbuf_metadata_bufsz(const pktmbuf_t *m)
     if (!m)
         return -1;
 
-    if (((p = m->pooldata) != NULL) && p->metadata)
+    if (((p = (pktmbuf_info_t *)m->pooldata) != NULL) && p->metadata)
         return (int32_t)p->metadata_bufsz;
     else
         return (int32_t)pktmbuf_headroom(m);


### PR DESCRIPTION
When compiling the latest CNDP with the OMEC BESS UPF compiler,
ran into these issues:

/usr/local/include/cndp/pktmbuf.h: In function ‘void pktmbuf_free_bulk(pktmbuf_t**, unsigned int)’:
/usr/local/include/cndp/pktmbuf.h:803:63: error: missing initializer for member ‘pktmbuf_pending::nb_pending’ [-Werror=missing-field-initializers]
  803 |     pktmbuf_pending_t pend = {.pending_sz = PKTMBUF_PENDING_SZ};
      |                                                               ^
/usr/local/include/cndp/pktmbuf.h:803:63: error: missing initializer for member ‘pktmbuf_pending::pooldata’ [-Werror=missing-field-initializers]
/usr/local/include/cndp/pktmbuf.h:803:63: error: missing initializer for member ‘pktmbuf_pending::pending’ [-Werror=missing-field-initializers]
/usr/local/include/cndp/pktmbuf.h: In function ‘void* pktmbuf_metadata(const pktmbuf_t*)’:
/usr/local/include/cndp/pktmbuf.h:1213:18: error: invalid conversion from ‘void*’ to ‘pktmbuf_info_t*’ {aka ‘pktmbuf_info_s*’} [-fpermissive]
 1213 |     if (((p = m->pooldata) != NULL) && p->metadata)
      |               ~~~^~~~~~~~
      |                  |
      |                  void*
/usr/local/include/cndp/pktmbuf.h: In function ‘int32_t pktmbuf_metadata_bufsz(const pktmbuf_t*)’:
/usr/local/include/cndp/pktmbuf.h:1235:18: error: invalid conversion from ‘void*’ to ‘pktmbuf_info_t*’ {aka ‘pktmbuf_info_s*’} [-fpermissive]
 1235 |     if (((p = m->pooldata) != NULL) && p->metadata)
      |               ~~~^~~~~~~~
      |                  |
      |                  void*
cc1plus: all warnings being treated as errors

These changes are to fix the compilation.

Signed-off-by: Elza Mathew <elza.mathew@intel.com>