### PR TITLE
Add support for buffered TX port.

### DIFF
--- a/lang/rs/apis/cne/src/config.rs
+++ b/lang/rs/apis/cne/src/config.rs
@@ -205,12 +205,20 @@ impl Config {
         port
     }
 
+    #[allow(dead_code)]
+    // Keep this for future use.
     pub(crate) fn get_port_by_name(&self, port_name: &str) -> Result<Port, CneError> {
+        let port_index = self.get_port_index_from_name(port_name)?;
+
+        self.get_port_by_index(port_index)
+    }
+
+    pub(crate) fn get_port_index_from_name(&self, port_name: &str) -> Result<u16, CneError> {
         let port_index = self.lports.get_index_of(port_name).ok_or_else(|| {
             CneError::ConfigError(format!("Port name {} is not present in config", port_name))
         })?;
 
-        self.get_port_by_index(port_index as u16)
+        Ok(port_index as u16)
     }
 
     pub(crate) fn get_port_details(&self, port_index: u16) -> Result<PortDetails, CneError> {

--- a/lang/rs/apis/cne/src/error.rs
+++ b/lang/rs/apis/cne/src/error.rs
@@ -17,6 +17,8 @@ pub enum CneError {
     PacketError(String),
     /// Port error.
     PortError(String),
+    /// Buffered Tx Port error.
+    PortTxBuffError(String),
     /// Error getting port statistics.
     PortStatsError(String),
     /// Error registering/unregistering thread with CNE.
@@ -34,6 +36,7 @@ impl Display for CneError {
             CneError::ConfigError(s) => format!("CneError::ConfigError({})", s),
             CneError::PacketError(s) => format!("CneError::PacketError({})", s),
             CneError::PortError(s) => format!("CneError::PortError({})", s),
+            CneError::PortTxBuffError(s) => format!("CneError::PortTxBuffError({})", s),
             CneError::PortStatsError(s) => format!("CneError::PortStatsError({})", s),
             CneError::RegisterError(s) => format!("CneError::RegisterError({})", s),
             CneError::RxBurstError(s) => format!("CneError::RxBurstError({})", s),

--- a/lang/rs/apis/cne/src/lib.rs
+++ b/lang/rs/apis/cne/src/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod instance;
 pub mod packet;
 pub mod port;
+pub mod port_tx_buff;
 mod util;
 
 #[cfg(test)]

--- a/lang/rs/apis/cne/src/port.rs
+++ b/lang/rs/apis/cne/src/port.rs
@@ -33,7 +33,7 @@ struct PortInner {
 unsafe impl Send for PortInner {}
 
 /// Port statistics.
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct PortStats {
     /// Total number of successfully received packets.
     pub in_packets: u64,
@@ -260,6 +260,20 @@ impl Port {
 
         let cne = CneInstance::get_instance();
         cne.get_port_details(port.port_index)
+    }
+
+    /// Get port index of the [port](Port).
+    ///
+    /// Returns port index in lports section of JSONC file or error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [CneError::PortError] if an error is encountered.
+    ///
+    pub fn get_port_index(&self) -> Result<u16, CneError> {
+        let port = self.lock()?;
+
+        Ok(port.port_index)
     }
 
     fn lock(&self) -> Result<MutexGuard<PortInner>, CneError> {

--- a/lang/rs/apis/cne/src/port_tx_buff.rs
+++ b/lang/rs/apis/cne/src/port_tx_buff.rs
@@ -1,0 +1,148 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020-2022 Intel Corporation.
+ */
+
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use super::error::*;
+use super::packet::*;
+use super::port::*;
+
+/// CNE Buffered Tx Port.
+#[derive(Clone)]
+pub struct BufferedTxPort {
+    port: Port,
+    buffer_size: usize,
+    pkts: Arc<Mutex<Vec<Packet>>>,
+}
+
+impl BufferedTxPort {
+    /// Creates an instance of [BufferedTxPort] from an existing (port)[Port].
+    ///
+    /// This function takes an existing port and returns an instance of BufferedTxPort.
+    /// this port. Buffered TX port allows to buffer one packet at a time and transmits
+    /// the packets once buffer is full.
+    ///
+    /// Returns an instance of BufferedTxPort.
+    ///
+    /// # Arguments
+    /// * `port` - An existing port.
+    /// * `buffer_size` - Number of packets that can be buffered in port.
+    ///
+    pub fn new(port: Port, buffer_size: usize) -> BufferedTxPort {
+        BufferedTxPort {
+            port,
+            buffer_size,
+            pkts: Arc::new(Mutex::new(Vec::with_capacity(buffer_size))),
+        }
+    }
+
+    /// Buffers a single [packet](Packet) for future transmission.
+    ///
+    /// This function takes a single packet and buffers it for future transmission on
+    /// this port. Once the buffer is full, an attempt will be made to transmit all the
+    /// buffered packets. This function transparently frees the packet after it is sent.
+    ///
+    /// Returns number of packets actually sent if buffer is full or 0 if packet is buffered.
+    ///
+    /// # Arguments
+    /// * `pkt` - packet to be buffered.
+    ///
+    /// # Errors
+    ///
+    /// Returns [CneError::PortTxBuffError] if an error is encountered.
+    ///
+    pub fn tx_buff_add(&self, pkt: Packet) -> Result<u16, CneError> {
+        let mut pkts = self.lock()?;
+        pkts.push(pkt);
+
+        if pkts.len() < self.buffer_size {
+            Ok(0)
+        } else {
+            Self::flush(&self.port, &mut pkts)
+        }
+    }
+
+    /// Get number of packets buffered.
+    ///
+    /// Returns number of packets buffered in this port or error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [CneError::PortTxBuffError] if an error is encountered.
+    ///
+    pub fn tx_buff_count(&self) -> Result<u16, CneError> {
+        let pkts = self.lock()?;
+        Ok(pkts.len() as u16)
+    }
+
+    /// Flush all the packets buffered on this port for transmission.
+    ///
+    /// This function sends all the packets buffered on this port for
+    /// transmission. It transparently frees the packet in the buffer.
+    ///
+    /// Returns number of packets actually sent or error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [CneError::PortTxBuffError] if an error is encountered.
+    ///
+    pub fn tx_buff_flush(&self) -> Result<u16, CneError> {
+        let mut pkts = self.lock()?;
+        Self::flush(&self.port, &mut pkts)
+    }
+
+    /// Free all packets buffered in the port.
+    ///
+    /// # Errors
+    ///
+    /// Returns [CneError::PortTxBuffError] if an error is encountered.
+    ///
+    pub fn tx_buff_free(&self) -> Result<(), CneError> {
+        let mut pkts = self.lock()?;
+        if !pkts.is_empty() {
+            Packet::free_packet_buffer(&mut pkts)
+                .map_err(|e| CneError::PortTxBuffError(e.to_string()))?;
+            pkts.clear();
+        }
+        Ok(())
+    }
+
+    /// Get port index of the [port](BufferedTxPort).
+    ///
+    /// Returns port index in lports section of JSONC file or error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [CneError::PortTxBuffError] if an error is encountered.
+    ///
+    pub fn tx_buff_port_index(&self) -> Result<u16, CneError> {
+        self.port
+            .get_port_index()
+            .map_err(|e| CneError::PortTxBuffError(e.to_string()))
+    }
+}
+
+// BufferedTxPort private functions.
+impl BufferedTxPort {
+    fn flush(port: &Port, pkts: &mut Vec<Packet>) -> Result<u16, CneError> {
+        if !pkts.is_empty() {
+            let pkts_sent = port
+                .tx_burst(pkts)
+                .map_err(|e| CneError::PortTxBuffError(e.to_string()))?;
+            // Free packets which are not sent.
+            Packet::free_packet_buffer(&mut pkts[pkts_sent as usize..])
+                .map_err(|e| CneError::PortTxBuffError(e.to_string()))?;
+            pkts.clear();
+            Ok(pkts_sent)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn lock(&self) -> Result<MutexGuard<Vec<Packet>>, CneError> {
+        self.pkts
+            .lock()
+            .map_err(|e| CneError::PortTxBuffError(e.to_string()))
+    }
+}


### PR DESCRIPTION
- Buffered TX port allows to buffer one packet at a time and transmits the
  packets once buffer is full. It can be used to forward packet arriving
  at one port to a different port by buffering the packet in destination port.

- Store ports in a map when CNE Instance is created. When application requests
  a port, return a clone (atomic reference count) of port. This also allows port
  to be safely accessed across multiple Rust threads.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>