### PR TITLE
bpf: add libbpf 8.0 support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,8 +67,78 @@ sudo ldconfig
 
 The following statement may be necessary if libbpf is installed from source instead of the package manager.
 
-```bash
+```cmd
 export PKG_CONFIG_PATH=/usr/lib64/pkgconfig
+```
+
+### Install libxdp from source
+
+Install dependencies:
+
+```cmd
+sudo apt-get update; sudo apt-get install -y git gcc-multilib clang llvm lld m4
+```
+
+Clone libxdp:
+
+```cmd
+git clone https://github.com/xdp-project/xdp-tools.git
+cd xdp-tools/
+```
+
+Run ./configure
+
+```bash
+./configure
+Found clang binary 'clang' with version 14 (from 'Ubuntu clang version 14.0.0-1ubuntu1')
+libbpf support: Submodule 'libbpf' (https://github.com/xdp-project/libbpf/) registered for path 'lib/libbpf'
+Cloning into '/xdp-tools/lib/libbpf'...
+Submodule path 'lib/libbpf': checked out '87dff0a2c775c5943ca9233e69c81a25f2ed1a77'
+submodule v0.8.0
+  perf_buffer__consume support: yes (submodule)
+  btf__load_from_kernel_by_id support: yes (submodule)
+  btf__type_cnt support: yes (submodule)
+  bpf_object__next_map support: yes (submodule)
+  bpf_object__next_program support: yes (submodule)
+  bpf_program__insn_cnt support: yes (submodule)
+  bpf_map_create support: yes (submodule)
+  perf_buffer__new_raw support: yes (submodule)
+  bpf_xdp_attach support: yes (submodule)
+zlib support: yes
+ELF support: yes
+pcap support: yes
+secure_getenv support: yes
+```
+
+Build and install the libbpf git submodule:
+
+```cmd
+cd lib/libbpf/
+git submodule init && git submodule update
+cd src
+make CFLAGS+=-fpic; PREFIX=/usr make install
+cd -
+```
+
+Update pkg-config path as shown in the previous section.
+
+In the top level xdp-tools directory:
+
+```cmd
+make -j; PREFIX=/usr make -j install
+```
+
+check pkg-config can find libxdp:
+
+```cmd
+pkg-config --modversion libxdp
+1.2.2
+```
+
+on some systems it maybe necessary to run:
+
+```bash
+export PKG_CONFIG_PATH=/usr/lib/pkgconfig
 ```
 
 ## Fedora Installation Instructions

--- a/examples/vpp-plugin/cndp/cndp.h
+++ b/examples/vpp-plugin/cndp/cndp.h
@@ -18,7 +18,7 @@
 #ifndef __included_cndp_h__
 #define __included_cndp_h__
 
-#ifdef USE_LIBXDP
+#if USE_LIBXDP
 #include <xdp/xsk.h>
 #else
  #include <bpf/xsk.h>

--- a/lib/core/pmds/net/af_xdp/pmd_af_xdp.c
+++ b/lib/core/pmds/net/af_xdp/pmd_af_xdp.c
@@ -11,7 +11,7 @@
 #include <bsd/string.h>        // for strlcpy
 #include <stdint.h>            // for uint16_t, uint64_t
 #include <linux/bpf.h>         // for XDP_PACKET_HEADROOM
-#ifdef USE_LIBXDP
+#if USE_LIBXDP
 #include <xdp/xsk.h>
 #else
 #include <bpf/xsk.h>        // for XSK_RING_CONS__DEFAULT_NUM_DESCS, xsk_...

--- a/lib/core/xskdev/xskdev.c
+++ b/lib/core/xskdev/xskdev.c
@@ -956,8 +956,13 @@ xskdev_socket_create(struct lport_cfg *c)
             CNE_ERR_GOTO(err, "Update of BPF map failed. %s\n", strerror(errno));
     } else {
         /* Getting the program ID must be after the xdp_socket__create() call */
+#if USE_LIBBPF_8
+        if (bpf_xdp_query_id(xi->if_index, xi->xdp_flags, &xi->prog_id))
+            CNE_ERR_GOTO(err, "bpf_get_link_xdp_id failed. %s\n", strerror(errno));
+#else
         if (bpf_get_link_xdp_id(xi->if_index, &xi->prog_id, xi->xdp_flags))
             CNE_ERR_GOTO(err, "bpf_get_link_xdp_id failed. %s\n", strerror(errno));
+#endif
     }
 
     CNE_DEBUG("Program ID %u, if_index %d, if_name '%s'\n", xi->prog_id, xi->if_index, xi->ifname);
@@ -988,12 +993,20 @@ xskdev_socket_destroy(xskdev_info_t *xi)
         CNE_DEBUG("ifindex %d, %s, prog_id %u\n", xi->if_index, xi->ifname, xi->prog_id);
         if (xi->if_index) {
             if (xi->unprivileged == 0) {
+#if USE_LIBBPF_8
+                if (bpf_xdp_query_id(xi->if_index, xi->xdp_flags, &curr_prog_id))
+#else
                 if (bpf_get_link_xdp_id(xi->if_index, &curr_prog_id, xi->xdp_flags))
+#endif
                     CNE_ERR("bpf_get_link_xdp_id failed\n");
                 else {
                     /* Try to remove the bpf program */
                     if (xi->prog_id == curr_prog_id)
+#if USE_LIBBPF_8
+                        bpf_xdp_detach(xi->if_index, xi->xdp_flags, NULL);
+#else
                         bpf_set_link_xdp_fd(xi->if_index, -1, xi->xdp_flags);
+#endif
                     else if (curr_prog_id)
                         CNE_INFO("program on interface changed %d, not removing\n", curr_prog_id);
                 }

--- a/lib/core/xskdev/xskdev.h
+++ b/lib/core/xskdev/xskdev.h
@@ -17,7 +17,7 @@
 #include <pthread.h>        // for pthread_mutex_t, pthread_mutex_init, pthre...
 #include <stdint.h>         // for uint16_t, uint32_t
 #include <stdio.h>          // for FILE, NULL, size_t
-#ifdef USE_LIBXDP
+#if USE_LIBXDP
 #include <xdp/xsk.h>
 #else
 #include <bpf/xsk.h>

--- a/lib/include/cne_common.h
+++ b/lib/include/cne_common.h
@@ -53,16 +53,6 @@ extern "C" {
 #endif
 
 /**
- * Enable the use of libxdp
- */
-#if HAS_LIBXDP == 1
-#define USE_LIBXDP 1
-#endif
-
-#if HAS_LIBBPF_8
-#define USE_LIBBPF_8 1
-#endif
-/**
  * Helper routine to set a default value if x == y then x = z.
  *
  * @param x

--- a/lib/include/cne_common.h
+++ b/lib/include/cne_common.h
@@ -59,6 +59,9 @@ extern "C" {
 #define USE_LIBXDP 1
 #endif
 
+#if HAS_LIBBPF_8
+#define USE_LIBBPF_8 1
+#endif
 /**
  * Helper routine to set a default value if x == y then x = z.
  *

--- a/meson.build
+++ b/meson.build
@@ -164,7 +164,8 @@ if nl_cli_dep.found()
 endif
 
 cne_conf.set10('HAS_XSK_UMEM_SHARED', false)
-cne_conf.set10('HAS_LIBXDP', false)
+cne_conf.set10('USE_LIBXDP', false)
+cne_conf.set10('USE_LIBBPF_8', false)
 xdp_dep = dependency('libxdp', version : '>=1.2.0', required: false, method: 'pkg-config', static: use_static_libs)
 bpf_dep = dependency('libbpf', required: false, method: 'pkg-config', static: use_static_libs)
 if not bpf_dep.found()
@@ -176,9 +177,9 @@ if cc.has_header('linux/if_xdp.h')
         if bpf_dep.found() and cc.has_header('bpf/bpf.h')
             bpf_8_dep = dependency('libbpf', version : '>=0.8.0', required: false, method: 'pkg-config')
             if bpf_8_dep.found()
-                cne_conf.set10('HAS_LIBBPF_8', true)
+                cne_conf.set10('USE_LIBBPF_8', true)
             endif
-            cne_conf.set10('HAS_LIBXDP', true)
+            cne_conf.set10('USE_LIBXDP', true)
             cne_conf.set10('HAS_XSK_UMEM_SHARED', true)
             extra_ldflags += '-lbpf'
             extra_ldflags += '-lxdp'

--- a/meson.build
+++ b/meson.build
@@ -174,6 +174,10 @@ endif
 if cc.has_header('linux/if_xdp.h')
     if xdp_dep.found() and cc.has_header('xdp/xsk.h')
         if bpf_dep.found() and cc.has_header('bpf/bpf.h')
+            bpf_8_dep = dependency('libbpf', version : '>=0.8.0', required: false, method: 'pkg-config')
+            if bpf_8_dep.found()
+                cne_conf.set10('HAS_LIBBPF_8', true)
+            endif
             cne_conf.set10('HAS_LIBXDP', true)
             cne_conf.set10('HAS_XSK_UMEM_SHARED', true)
             extra_ldflags += '-lbpf'

--- a/usrtools/xskmap_load_send/xskmap_load_send.h
+++ b/usrtools/xskmap_load_send/xskmap_load_send.h
@@ -7,7 +7,7 @@
 #include <getopt.h>
 #include <bsd/string.h>
 #include <bpf/bpf.h>
-#ifdef USE_LIBXDP
+#if USE_LIBXDP
 #include <xdp/xsk.h>
 #else
 #include <bpf/xsk.h>


### PR DESCRIPTION
- [x] Baseline support for libxdp 1.2.5 and libbpf 0.8.0
- [x] Update readme to show how to build and install libxdp 1.2.5 and libbpf 0.8.0
- [x] Update implementation to use USE_LIBXDP and USE_LIBBPF_8 directly