### PR TITLE
fix static default builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ else
 endif
 
 all: FORCE
-	${Build} build
+ifeq (${static_build},1)
+	${Build} ${verbose} static build
+else
+	${Build} ${verbose} build
+endif
 
 help: FORCE
 	${Build} help
@@ -31,7 +35,11 @@ help: FORCE
 	@echo "    eg: 'make static_build=1 rebuild install' for static executables"
 
 build: FORCE
+ifeq (${static_build},1)
+	${Build} ${verbose} static build
+else
 	${Build} ${verbose} build
+endif
 
 rebuild: FORCE
 ifeq (${static_build},1)


### PR DESCRIPTION
In the Makefile the default builds did not use the static_build flag
and would always build shared executable.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>