### PR TITLE
add tx-only-rx mode

### DIFF
--- a/doc/guides/sample_app_ug/cndpfwd.rst
+++ b/doc/guides/sample_app_ug/cndpfwd.rst
@@ -13,6 +13,7 @@ The cndpfwd sample application is a simple example of packet processing using CN
  * fwd
  * acl-strict
  * acl-permissive
+ * tx-only-rx (TX-Only plus draining RX ring)
 
 In forward mode ('fwd'), the destination logical port on which to forward the packet is specified by
 the last octet of the destination MAC address. It should be a valid lport number 0-N. If the
@@ -48,7 +49,8 @@ a linux environment:
 .. code-block:: console
 
     Usage: ./builddir/examples/cndpfwd/cndpfwd [-h] [-c json_file] [-b burst] <mode>
-      <mode>         Mode types [drop | rx-only], tx-only, [lb | loopback], fwd, acl-strict or acl-permissive
+      <mode>         Mode types [drop | rx-only], tx-only, [lb | loopback], fwd, tx-only-rx,
+                     acl-strict or acl-permissive
       -a <api>       The API type to use xskdev or pktdev APIs, default is xskdev.\n"
                      The -a option overrides JSON file.\n"
       -b <burst>     Burst size. If not present default burst size 256 max 256.
@@ -196,7 +198,8 @@ The configuration json file is located in the ``cndpfwd`` example sub-directory
         //   no-metrics - (O) Disable metrics gathering and thread
         //   no-restapi - (O) Disable RestAPI support
         //   cli        - (O) Enable/Disable CLI supported
-        //   mode       - (O) Mode type [drop | rx-only], tx-only, [lb | loopback], fwd, acl-strict, acl-permissive
+        //   mode       - (O) Mode type [drop | rx-only], tx-only, [lb | loopback], fwd, tx-only-rx
+        //                    acl-strict, acl-permissive
         //   uds_path   - (0) Path to unix domain socket to get xsk map fd
         "options": {
             "pkt_api": "xskdev",

--- a/examples/cndpfwd/fwd.jsonc
+++ b/examples/cndpfwd/fwd.jsonc
@@ -121,7 +121,8 @@
     //   no-metrics - (O) Disable metrics gathering and thread
     //   no-restapi - (O) Disable RestAPI support
     //   cli        - (O) Enable/Disable CLI supported
-    //   mode       - (O) Mode type [drop | rx-only], tx-only, [lb | loopback], fwd, acl-strict, acl-permissive
+    //   mode       - (O) Mode type [drop | rx-only], tx-only, [lb | loopback], fwd, tx-only-rx,
+    //                    acl-strict, acl-permissive
     //   uds_path   - (O) Path to unix domain socket to get xsk map fd
     "options": {
         "pkt_api": "xskdev",

--- a/examples/cndpfwd/main.h
+++ b/examples/cndpfwd/main.h
@@ -64,6 +64,7 @@ enum {
 #define MODE_FWD            "fwd"            /**< L2 Forwarding mode */
 #define MODE_ACL_STRICT     "acl-strict"     /**< ACL forwarding with permit list mode */
 #define MODE_ACL_PERMISSIVE "acl-permissive" /**< ACL forwarding with deny list mode */
+#define MODE_TX_ONLY_RX     "tx-only-rx"     /**< Transmit only plus RX enabled */
 
 typedef enum {
     UNKNOWN_TEST,
@@ -72,7 +73,8 @@ typedef enum {
     TXONLY_TEST,
     FWD_TEST,
     ACL_STRICT_TEST,
-    ACL_PERMISSIVE_TEST
+    ACL_PERMISSIVE_TEST,
+    TXONLY_RX_TEST
 } test_t;
 
 #define XSKDEV_API_NAME "xskdev"
@@ -175,6 +177,8 @@ get_app_mode(const char *type)
             return ACL_STRICT_TEST;
         else if (!strncasecmp(type, MODE_ACL_PERMISSIVE, nlen))
             return ACL_PERMISSIVE_TEST;
+        else if (!strncasecmp(type, MODE_TX_ONLY_RX, nlen))
+            return TXONLY_RX_TEST;
         else {
             cne_printf("[yellow]*** [magenta]Unknown mode[]: '[red]%s[]'\n", type);
             cne_printf("    [magenta]Known modes default[] '[cyan]%s[magenta]'[]:\n", MODE_DROP);


### PR DESCRIPTION
The originl tx-only mode would also check the RX ring and free
any packets found. The tx-only mode will now only send packets and
not check the RX ring for packets.

A new mode tx-only-rx mode has been added to do tx-only and check
the RX ring for packets and free any packets found.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>