### PR TITLE
Use spin::Mutex for port instead of sync::Mutex to improve performance.

### DIFF
--- a/lang/rs/apis/cne/Cargo.toml
+++ b/lang/rs/apis/cne/Cargo.toml
@@ -25,6 +25,7 @@ num_cpus = "^1.0"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
+spin = "^0.9"
 
 [dev-dependencies]
 etherparse = "^0.10"

--- a/lang/rs/apis/cne/run_cne_test.sh
+++ b/lang/rs/apis/cne/run_cne_test.sh
@@ -7,6 +7,10 @@
 # Need to LD_PRELOAD libpmd_af_xdp.so since Rust binary doesn't include it and is required for CNDP applications.
 # Including libpmd_af_xdp.so as whole-archive during linking of rust binary doesn't seem to work.
 CRATE=cndp-cne
+
+# Build (This will do incremental build)
+cargo build
+
 sudo -E  LD_LIBRARY_PATH=$LD_LIBRARY_PATH LD_PRELOAD=$LD_LIBRARY_PATH/libpmd_af_xdp.so RUST_LOG=debug `which cargo` test -p $CRATE --tests  -- --show-output --test-threads=1
 
 stty sane

--- a/lang/rs/apis/cne/run_loopback.sh
+++ b/lang/rs/apis/cne/run_loopback.sh
@@ -8,6 +8,9 @@
 # eg 2:./run_loopback.sh ../../fwd.json 0 25 -> Run using user specified values.
 CRATE=loopback
 
+# Build (This will do incremental build)
+cargo build --release
+
 # JSON file. Use default jsonc file in library crate.
 CONFIG=${1:-"./fwd.jsonc"}
 

--- a/lang/rs/apis/cne/src/port.rs
+++ b/lang/rs/apis/cne/src/port.rs
@@ -2,9 +2,10 @@
  * Copyright (c) 2020-2022 Intel Corporation.
  */
 
+use spin::{Mutex, MutexGuard};
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::Arc;
 
 use cne_sys::bindings::{
     _pktdev_rx_burst, _pktdev_tx_burst, _pktmbuf_alloc_bulk, _xskdev_rx_burst, _xskdev_tx_burst,
@@ -277,8 +278,6 @@ impl Port {
     }
 
     fn lock(&self) -> Result<MutexGuard<PortInner>, CneError> {
-        self.inner
-            .lock()
-            .map_err(|e| CneError::PortError(e.to_string()))
+        Ok(self.inner.lock())
     }
 }

--- a/lang/rs/apis/cne/src/port_tx_buff.rs
+++ b/lang/rs/apis/cne/src/port_tx_buff.rs
@@ -2,7 +2,8 @@
  * Copyright (c) 2020-2022 Intel Corporation.
  */
 
-use std::sync::{Arc, Mutex, MutexGuard};
+use spin::{Mutex, MutexGuard};
+use std::sync::Arc;
 
 use super::error::*;
 use super::packet::*;
@@ -141,8 +142,6 @@ impl BufferedTxPort {
     }
 
     fn lock(&self) -> Result<MutexGuard<Vec<Packet>>, CneError> {
-        self.pkts
-            .lock()
-            .map_err(|e| CneError::PortTxBuffError(e.to_string()))
+        Ok(self.pkts.lock())
     }
 }

--- a/lang/rs/examples/echo_server/run_echo_server.sh
+++ b/lang/rs/examples/echo_server/run_echo_server.sh
@@ -14,6 +14,9 @@
 
 CRATE=echo_server
 
+# Build (This will do incremental build)
+cargo build --release
+
 # Mode - pnet or cne. Default is cne.
 MODE=${1:-"cne"}
 

--- a/lang/rs/examples/fwd/run_fwd.sh
+++ b/lang/rs/examples/fwd/run_fwd.sh
@@ -8,6 +8,9 @@
 
 CRATE=fwd
 
+# Build (This will do incremental build)
+cargo build --release
+
 # Mode - drop,rx-only,tx-only,lb,fwd. Default is drop.
 MODE=${1:-"drop"}
 


### PR DESCRIPTION
- Using spin mutex for port instead of sync::Mutex is improving performance
  in case of packet forward.

- Update example scripts to do incremental build.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>