### PR TITLE
fix clang build errors

### DIFF
--- a/examples/afxdp_user/main.c
+++ b/examples/afxdp_user/main.c
@@ -12,7 +12,11 @@ typedef __signed__ int s32;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wcast-qual"
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
+#else
 #pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#endif
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #pragma GCC diagnostic ignored "-Wsign-compare"
 

--- a/lib/cnet/chnl/cnet_chnl_opt.c
+++ b/lib/cnet/chnl/cnet_chnl_opt.c
@@ -128,20 +128,6 @@ chnl_sbreserve(struct chnl_buf *sb, uint32_t cc)
 }
 
 /**
- * This routine sets the minimum amount of data that must be queued to a chnl
- * buffer before a listening process will be woken up, subject to the following
- * constraints: 'cb_lowat' cannot be less than 1 or more than 'cb_hiwat'.
- */
-static inline void
-chnl_sblimit(struct chnl_buf *sb, uint32_t cc)
-{
-    sb->cb_lowat = (int32_t)CNE_MAX(cc, (uint32_t)1);
-
-    if (sb->cb_lowat > sb->cb_hiwat)
-        sb->cb_lowat = sb->cb_hiwat;
-}
-
-/**
  * This routine get an integer chnl option value, regardless of the
  * size of the integer.
  *

--- a/lib/cnet/tcp/cnet_tcp.c
+++ b/lib/cnet/tcp/cnet_tcp.c
@@ -968,7 +968,7 @@ tcp_do_response(struct netif *netif __cne_unused, struct pcb_entry *pcb, pktmbuf
         pktmbuf_reset(mbuf);
 
     /* Create the options and obtain the options length */
-    optlen = tcp_send_options(pcb->tcb, opts, flags);
+    optlen = tcp_send_options(pcb->tcb, (uint8_t *)opts, flags);
 
     /* move the starting offset to account for headers */
     pktmbuf_data_off(mbuf) += sizeof(struct cne_tcp_hdr) + optlen + sizeof(struct cne_ipv4_hdr) +

--- a/lib/include/cne_vec.h
+++ b/lib/include/cne_vec.h
@@ -356,15 +356,15 @@ _vec_find_index(void **vec, void *v)
  * @param _nb
  *   The number of items to remove from the vector
  */
-#define vec_remove(_v, _nb)                             \
-    do {                                                \
-        vec_hdr_t *h = vec_header(_v);                  \
-        int _n       = h->len - _nb;                    \
-        if (_n >= 0) {                                  \
-            char *src = &h->data[0] + (_nb * h->esize); \
-            memmove(&h->data[0], src, _n * h->esize);   \
-            h->len = _n;                                \
-        }                                               \
+#define vec_remove(_v, _nb)                                     \
+    do {                                                        \
+        vec_hdr_t *h = vec_header(_v);                          \
+        int _n       = h->len - _nb;                            \
+        if (_n >= 0) {                                          \
+            char *src = (char *)&h->data[0] + (_nb * h->esize); \
+            memmove(&h->data[0], src, _n * h->esize);           \
+            h->len = _n;                                        \
+        }                                                       \
     } while (0)
 
 /**

--- a/meson.build
+++ b/meson.build
@@ -216,7 +216,10 @@ endif
 
 # for clang 32-bit compiles we need libatomic for 64-bit atomic ops
 if cc.get_id() == 'clang'
-    atomic_dep = dependency('atomic', required: true, static: use_static_libs)
+    atomic_dep = dependency('atomic', required: false, method: 'pkg-config', static: use_static_libs)
+    if not atomic_dep.found()
+        atomic_dep = cc.find_library('atomic', required: true)
+    endif
     add_project_link_arguments('-latomic', language: 'c')
     extra_ldflags += '-latomic'
 endif


### PR DESCRIPTION
Using 'CC=clang CXX=clang++ make rebuild-install' to build CNDP
using the clang compiler. The clang compiler detected a number of
issues in the code, which gcc did not detect.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>