### PR TITLE
add a linter workflow

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,36 @@
+# This workflow executes several linters on changed files based on languages used in your code base whenever
+# you push a code or open a pull request.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/github/super-linter
+name: Lint Code Base
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  run-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: "main"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_CLANG_FORMAT: true
+          VALIDATE_BASH: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_GO: true
+          VALIDATE_RUST_CLIPPY: true
+          VALIDATE_PYTHON_PYLINT: true
+          VALIDATE_MARKDOWN: true


### PR DESCRIPTION
Added a GitHub action that uses the actions/super-linter GitHub
action available on the GitHub actions Marketplace
https://github.com/github/super-linter

The action will run on modified files in a pull request. Enabled
linting for Bash, C, Go, Python Rust and Markdown.

Signed-off-by: Elza Mathew <elza.mathew@intel.com>