### PR TITLE
enable rust linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -31,6 +31,6 @@ jobs:
           VALIDATE_BASH: true
           VALIDATE_GITHUB_ACTIONS: true
           VALIDATE_GO: true
-          VALIDATE_RUST_CLIPPY: true
+          VALIDATE_RUST_2021: true
           VALIDATE_PYTHON_PYLINT: true
           VALIDATE_MARKDOWN: true


### PR DESCRIPTION
Setting VARIABLE_RUST_CLIPPY: true doesn't seem to trigger the Rust linter
to run on Rust files edited in a PR https://github.com/CloudNativeDataPlane/cndp/runs/7591581991?check_suite_focus=true.
Setting VARIABLE_RUST_2021: true, instead to convince the Rust
linter to run.
Based on the doc https://github.com/github/super-linter#environment-variables

Fixes: e7839cdd7 - ("add a linter workflow")

Signed-off-by: Elza Mathew <elza.mathew@intel.com>