### PR TITLE
fix pktdev_close to release internal lport data

### DIFF
--- a/lib/core/pktdev/pktdev.h
+++ b/lib/core/pktdev/pktdev.h
@@ -192,7 +192,7 @@ pktdev_rx_burst(uint16_t lport_id, pktmbuf_t **rx_pkts, const uint16_t nb_pkts)
 
     /* Check packet stream status */
     if (!pktdev_admin_state(lport_id)) {
-        PKTDEV_LOG(DEBUG, "Packet stream is disabled for '%d'\n", lport_id);
+        CNE_DEBUG("Packet stream is disabled for '%d'\n", lport_id);
         return PKTDEV_ADMIN_STATE_DOWN;
     }
 
@@ -273,7 +273,7 @@ pktdev_tx_burst(uint16_t lport_id, pktmbuf_t **tx_pkts, uint16_t nb_pkts)
 
     /* Check packet stream status */
     if (!pktdev_admin_state(lport_id)) {
-        PKTDEV_LOG(DEBUG, "Packet stream is disabled for '%d'\n", lport_id);
+        CNE_DEBUG("Packet stream is disabled for '%d'\n", lport_id);
         return PKTDEV_ADMIN_STATE_DOWN;
     }
 

--- a/lib/core/pktdev/pktdev_api.h
+++ b/lib/core/pktdev/pktdev_api.h
@@ -400,8 +400,15 @@ CNDP_API int pktdev_port_setup(lport_cfg_t *c);
  *
  * @param lport_id
  *   The lport ID to use for the removal of the lport from the system
+ * @return
+ *   -1 on error or 0 success
  */
 CNDP_API int pktdev_port_remove(int lport_id);
+
+/**
+ * Remove all lports and releases each lport resources, ignoring errors.
+ */
+CNDP_API void pktdev_port_remove_all(void);
 
 /**
  * Dump out a lport_cfg_t structure.

--- a/lib/core/pktdev/pktdev_core.h
+++ b/lib/core/pktdev/pktdev_core.h
@@ -15,10 +15,7 @@
  * public API because they are used by inline functions in the published API.
  *
  * Applications should not use these directly.
- *
  */
-
-#define PKTDEV_LOG(level, ...) cne_log(CNE_LOG_##level, __func__, __LINE__, "" __VA_ARGS__)
 
 /*
  * Definitions of all functions exported by an Ethernet driver through the
@@ -187,11 +184,12 @@ struct pktdev_ops {
  * process, while the actual configuration data for the device is shared.
  */
 struct cne_pktdev {
-    eth_rx_burst_t rx_pkt_burst;      /**< Pointer to PMD receive function. */
-    eth_tx_burst_t tx_pkt_burst;      /**< Pointer to PMD transmit function. */
-    eth_tx_prep_t tx_pkt_prepare;     /**< Pointer to PMD transmit prepare function. */
-    struct pktdev_data *data;         /**< Pointer to device data. */
-    void *process_private;            /**< Pointer to per-process device data. */
+    eth_rx_burst_t rx_pkt_burst;      /**< Pointer to PMD receive function */
+    eth_tx_burst_t tx_pkt_burst;      /**< Pointer to PMD transmit function */
+    eth_tx_prep_t tx_pkt_prepare;     /**< Pointer to PMD transmit prepare function */
+    struct pktdev_data *data;         /**< Pointer to device data */
+    struct pktdev_driver *drv;        /**< Pointer to driver data */
+    void *process_private;            /**< Pointer to per-process device data */
     const struct pktdev_ops *dev_ops; /**< Functions exported by PMD */
     enum pktdev_state state;          /**< Flag indicating the lport state */
 } __cne_cache_aligned;

--- a/lib/core/pktdev/pktdev_driver.h
+++ b/lib/core/pktdev/pktdev_driver.h
@@ -32,15 +32,15 @@ typedef int(pktdev_probe_t)(lport_cfg_t *cfg);
 /**
  * Remove function to remove a lport
  */
-typedef int(pktdev_remove_t)(int lport);
+typedef int(pktdev_remove_t)(struct cne_pktdev *dev);
 
 /**
  * A virtual device driver abstraction.
  */
 struct pktdev_driver {
-    TAILQ_ENTRY(pktdev_driver) next; /**< Next in list. */
+    TAILQ_ENTRY(pktdev_driver) next; /**< Next in list */
     const char *name;                /**< driver name */
-    pktdev_probe_t *probe;           /**< device probe function. */
+    pktdev_probe_t *probe;           /**< device probe function */
     pktdev_remove_t *remove;         /**< Remove routine */
 };
 
@@ -48,7 +48,7 @@ struct pktdev_driver {
  * Register a virtual device driver.
  *
  * @param driver
- *   A pointer to a cne_vdev_driver structure describing the driver
+ *   A pointer to a pktdev_driver structure describing the driver
  *   to be registered.
  */
 void pktdev_register(struct pktdev_driver *driver);
@@ -97,14 +97,6 @@ CNDP_API struct cne_pktdev *pktdev_allocate(const char *name, const char *ifname
  *  void
  */
 CNDP_API void _pktdev_reset(struct cne_pktdev *dev);
-
-/**
- * Tell pktdev from the driver the initialization is complete
- *
- * @param dev
- *   The internal pktdev structure pointer
- */
-CNDP_API void pktdev_create_done(struct cne_pktdev *dev);
 
 /**
  * Release the port or pktdev structure

--- a/lib/core/pmds/net/null/pmd_null.c
+++ b/lib/core/pmds/net/null/pmd_null.c
@@ -116,6 +116,14 @@ static const struct pktdev_ops pmd_null_ops = {
     .stats_reset   = pmd_null_stats_reset,
 };
 
+static int pmd_null_probe(lport_cfg_t *cfg);
+
+static struct pktdev_driver null_drv = {
+    .probe = pmd_null_probe,
+};
+
+PMD_REGISTER_DEV(net_null, null_drv)
+
 static int
 pmd_null_probe(lport_cfg_t *cfg)
 {
@@ -128,6 +136,7 @@ pmd_null_probe(lport_cfg_t *cfg)
     dev = pktdev_allocate(cfg->name, NULL);
     if (!dev)
         return -1;
+    dev->drv = &null_drv;
 
     priv = calloc(1, sizeof(*priv));
     if (!priv)
@@ -147,26 +156,5 @@ pmd_null_probe(lport_cfg_t *cfg)
     dev->rx_pkt_burst      = pmd_null_rx_burst;
     dev->tx_pkt_burst      = pmd_null_tx_burst;
 
-    pktdev_create_done(dev);
     return dev->data->lport_id;
 }
-
-static int
-pmd_null_remove(int lport_id)
-{
-    struct cne_pktdev *dev;
-
-    dev = pktdev_get(lport_id);
-    if (!dev)
-        return -1;
-
-    pktdev_release_port(dev);
-    return 0;
-}
-
-static struct pktdev_driver null_drv = {
-    .probe  = pmd_null_probe,
-    .remove = pmd_null_remove,
-};
-
-PMD_REGISTER_DEV(net_null, null_drv)


### PR DESCRIPTION
When pktdev_close() was called the code would close the lport
but it needed to release the lport by calling pktdev_release_port().

Cleanup the a PMD probe and remove routines. In the probe routine we
now store the struct pktdev_driver pointer in the struct cne_pktdev structure
to allow for a cleaner remove or close of an lport. Remove pktdev_create_done()
routine and move the logic into the pktdev_port_setup() routine.

This would allow the Go code to be able to cleanup correctly and the PMDs
were checking if dev == NULL before calling pktdev_release_port() which is
not required.

Remove the PKTDEV_LOG() macro and use CNE_XXX macros instead.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>