### PR TITLE
remove the pktdev_port_remove code

### DIFF
--- a/lib/core/pktdev/pktdev_api.c
+++ b/lib/core/pktdev/pktdev_api.c
@@ -106,33 +106,6 @@ pktdev_offloads_get(uint16_t lport_id, struct offloads *off)
     return 0;
 }
 
-int
-pktdev_port_remove(int lport)
-{
-    struct cne_pktdev *dev;
-
-    dev = pktdev_get(lport);
-    if (!dev || !dev->drv)
-        return -1;
-
-    if (dev->drv->remove) {
-        if (dev->drv->remove(dev) < 0)
-            return -1;
-    }
-
-    pktdev_release_port(dev);
-
-    return 0;
-}
-
-void
-pktdev_port_remove_all(void)
-{
-    for (int lport = 0; lport < CNE_MAX_ETHPORTS; lport++)
-        if (pktdev_port_remove(lport) <= 0) /* ignore return value */
-            continue;
-}
-
 void
 lport_cfg_dump(FILE *f, lport_cfg_t *c)
 {
@@ -141,12 +114,10 @@ lport_cfg_dump(FILE *f, lport_cfg_t *c)
             f = stdout;
 
         cne_fprintf(f, "lport_cfg_t: %p\n", c);
-        cne_fprintf(f, "  name          : %s\n", c->name);
+        cne_fprintf(f, "  name            : %s\n", c->name);
         cne_fprintf(f, "  netdev          : %s\n", c->ifname);
         cne_fprintf(f, "  pmd_name        : %s\n", c->pmd_name);
         cne_fprintf(f, "  qid             : %u\n", c->qid);
-
-        cne_fprintf(f, "                    Rx/Tx values");
         cne_fprintf(f, "  bufcnt          : %u\n", c->bufcnt);
         cne_fprintf(f, "  bufsz           : %u\n", c->bufsz);
     }

--- a/lib/core/pktdev/pktdev_api.h
+++ b/lib/core/pktdev/pktdev_api.h
@@ -394,23 +394,6 @@ CNDP_API int pktdev_portid(struct cne_pktdev *dev);
 CNDP_API int pktdev_port_setup(lport_cfg_t *c);
 
 /**
- * Remove or destroy a lport which releases its resources.
- * Please make sure to stop a lport with pktdev_stop() before
- * removing it.
- *
- * @param lport_id
- *   The lport ID to use for the removal of the lport from the system
- * @return
- *   -1 on error or 0 success
- */
-CNDP_API int pktdev_port_remove(int lport_id);
-
-/**
- * Remove all lports and releases each lport resources, ignoring errors.
- */
-CNDP_API void pktdev_port_remove_all(void);
-
-/**
  * Dump out a lport_cfg_t structure.
  *
  * @param f

--- a/lib/core/pktdev/pktdev_driver.h
+++ b/lib/core/pktdev/pktdev_driver.h
@@ -41,7 +41,6 @@ struct pktdev_driver {
     TAILQ_ENTRY(pktdev_driver) next; /**< Next in list */
     const char *name;                /**< driver name */
     pktdev_probe_t *probe;           /**< device probe function */
-    pktdev_remove_t *remove;         /**< Remove routine */
 };
 
 /**

--- a/test/testcne/loop_test.c
+++ b/test/testcne/loop_test.c
@@ -24,7 +24,7 @@
 
 #include "loop_test.h"
 #include "cne_common.h"          // for CNE_SET_USED, __cne_unused, cne_countof
-#include "pktdev_api.h"          // for pktdev_port_remove, pktdev_port_setup
+#include "pktdev_api.h"          // for pktdev_port_setup
 #include "cne_lport.h"           // for lport_cfg_t, lport_stats_t, LPORT_DFLT...
 #include "netdev_funcs.h"        // for netdev_link, netdev_get_link, netdev_s...
 #include "xskdev.h"              // for XSKDEV_DFLT_RX_NUM_DESCS, XSKDEV_DFLT_...
@@ -319,8 +319,8 @@ loop_main(int argc, char **argv)
     }
 
 leave:
-    if (pktdev_port_remove(lport) < 0)
-        tst_error("pktdev_port_remove(%d) failed\n", lport);
+    if (pktdev_close(lport) < 0)
+        tst_error("pktdev_close(%d) failed\n", lport);
 
     benchmark_done = true;
 

--- a/test/testcne/pktdev_test.c
+++ b/test/testcne/pktdev_test.c
@@ -313,12 +313,6 @@ general_tests(const char *ifname, const char *pmd)
     } else
         tst_ok("PASS --- TEST: pktdev close success\n");
 
-    if (pktdev_port_remove(lport)) {
-        tst_error("ERROR - Could not remove the lport\n");
-        goto leave;
-    } else
-        tst_ok("PASS --- TEST: pktdev remove success\n");
-
     lport = -1;
     sleep(1);
 


### PR DESCRIPTION
The pktdev_port_remove() and related structures was used for hot swap in DPDK
it is not required here in CNDP, so we are removing code. The application
should be using pktdev_close() instead.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>