### PR TITLE
graph: fix memory leak when realloc node objs

### DIFF
--- a/lib/usr/clib/graph/cne_graph_worker.h
+++ b/lib/usr/clib/graph/cne_graph_worker.h
@@ -215,7 +215,7 @@ __cne_node_enqueue_prologue(struct cne_graph *graph, struct cne_node *node, cons
         __cne_node_enqueue_tail_update(graph, node);
 
     if (unlikely(node->size < (idx + space)))
-        __cne_node_stream_alloc(graph, node);
+        __cne_node_stream_alloc_size(graph, node, node->size + space);
 }
 
 /**
@@ -465,7 +465,7 @@ cne_node_next_stream_get(struct cne_graph *graph, struct cne_node *node, cne_edg
     uint16_t free_space = node->size - idx;
 
     if (unlikely(free_space < nb_objs))
-        __cne_node_stream_alloc_size(graph, node, nb_objs);
+        __cne_node_stream_alloc_size(graph, node, node->size + nb_objs);
 
     return &node->objs[idx];
 }


### PR DESCRIPTION
For __cne_node_enqueue_prologue(), If the number of objs is more than
the node->size * 2, the extra objs will write out of bounds memory.
It should use __cne_node_stream_alloc_size() to request enough memory.

And for cne_node_next_stream_put(), it will realloc a small size, when
the node free space is small and new objs is less than the current
node->size. Some objs pointer are lost, and it will cause memory leak.
It should request enough size of memory, containing the original objs
and new objs at least.

Signed-off-by: Zhirun Yan <zhirun.yan@intel.com>
Signed-off-by: Liang, Cunming <cunming.liang@intel.com>