### PR TITLE
remove unused function declaration

### DIFF
--- a/lib/cnet/punt/kernel_recv_priv.h
+++ b/lib/cnet/punt/kernel_recv_priv.h
@@ -62,16 +62,6 @@ struct kernel_recv_node_main {
 /**
  * @internal
  *
- * Get the Ethernet Rx node data.
- *
- * @return
- *   Pointer to Ethernet Rx node data.
- */
-struct kernel_recv_node_main *kernel_recv_get_node_data_get(void);
-
-/**
- * @internal
- *
  * Get the Kernel Recv node.
  *
  * @return


### PR DESCRIPTION
Remove kernel_recv_get_node_data_get() routine as it is not used.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>