### PR TITLE
simulate xdp port stats reset

### DIFF
--- a/examples/cndpfwd/stats.c
+++ b/examples/cndpfwd/stats.c
@@ -86,6 +86,10 @@ print_port_stats(int lport_id, struct fwd_port *p, struct fwd_info *fwd)
     prt_cnt(skip, col, stats.ierrors, RED_TYPE);
     prt_cnt(skip, col, stats.imissed, RED_TYPE);
     prt_cnt(skip, col, stats.rx_invalid, RED_TYPE);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+    prt_cnt(skip, col, stats.rx_ring_full, CYAN_TYPE);
+    prt_cnt(skip, col, stats.rx_fill_ring_empty, CYAN_TYPE);
+#endif
 
     prt_cnt(skip, col, tx_pps, YELLOW_TYPE);
     prt_cnt(skip, col, stats.opackets, MAGENTA_TYPE);
@@ -93,6 +97,9 @@ print_port_stats(int lport_id, struct fwd_port *p, struct fwd_info *fwd)
     prt_cnt(skip, col, stats.oerrors, RED_TYPE);
     prt_cnt(skip, col, stats.odropped, CYAN_TYPE);
     prt_cnt(skip, col, stats.tx_invalid, RED_TYPE);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+    prt_cnt(skip, col, stats.tx_ring_empty, CYAN_TYPE);
+#endif
 
     if (fwd->flags & FWD_ACL_STATS) {
         prt_cnt(skip, col, acl_prefilter_pps, YELLOW_TYPE);
@@ -177,12 +184,19 @@ struct stats_line {
     {COL_LINE, "[green]%-*s [yellow]|[]\n", "   Errors"},
     {COL_LINE, "[green]%-*s [yellow]|[]\n", "   Missed"},
     {COL_LINE, "[green]%-*s [yellow]|[]\n", "   Invalid"},
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+    {COL_LINE, "[green]%-*s [yellow]|[]\n", "   ring full"},
+    {COL_LINE, "[green]%-*s [yellow]|[]\n", "   ring empty"},
+#endif
     {HDR_LINE, "[yellow:-:italic]%-*s [green:-:-]%-*s [yellow]|[]\n", "Pkts/s", "TX"},
     {COL_LINE, "[green]%-*s [yellow]|[]\n", "   Total Pkts"},
     {COL_LINE, "[green]%-*s [yellow]|[]\n", "   Total MBs"},
     {COL_LINE, "[green]%-*s [yellow]|[]\n", "   Errors"},
     {COL_LINE, "[green]%-*s [yellow]|[]\n", "   Dropped"},
     {COL_LINE, "[green]%-*s [yellow]|[]\n", "   Invalid"},
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+    {COL_LINE, "[green]%-*s [yellow]|[]\n", "   ring empty"},
+#endif
 
     {HDR_LINE | ACL_LINE, "[yellow:-:italic]%-*s [green:-:-]%-*s [yellow]|[]\n", "Pkts/s",
      "ACL Drop"},

--- a/lib/core/xskdev/xskdev.h
+++ b/lib/core/xskdev/xskdev.h
@@ -131,7 +131,7 @@ typedef struct xskdev_info {
         __get_mbuf_addr_tx;               /**< Internal function to set the mbuf address on tx */
     xskdev_get_mbuf_rx_t __get_mbuf_rx;   /**< Internal function to get the mbuf address on rx */
     xskdev_pull_cq_addr_t __pull_cq_addr; /**< Internal function to pull the complete queue */
-
+    struct xdp_statistics orig_stats; /**< Internal XDP statistics structure of original stats */
 } xskdev_info_t;
 
 /**

--- a/lib/include/cne_lport.h
+++ b/lib/include/cne_lport.h
@@ -115,19 +115,24 @@ typedef struct lport_stats {
     uint64_t rx_poll_wakeup;     /**< Number of times poll() called */
     uint64_t rx_rcvd_count;      /**< Number of packets received */
     uint64_t rx_burst_called;    /**< Number of times rx_burst was called */
-                                 /* FQ debug stats */
-    uint64_t fq_add_count;       /**< Number of FQ buffers added */
-    uint64_t fq_alloc_failed;    /**< Number of buffer allocations failed */
-    uint64_t fq_buf_freed;       /**< Number of buffers freed from FQ add */
-                                 /* TX debug stats */
-    uint64_t tx_kicks;           /**< Number of times we need to do a tx kick */
-    uint64_t tx_kick_failed;     /**< Number of times the tx kick failed */
-    uint64_t tx_kick_again;      /**< Number of times tx kick needed to be restarted */
-    uint64_t tx_ring_full;       /**< TX Ring is full */
-    uint64_t tx_copied;          /**< TX packet was copied */
-                                 /* CQ debug stats */
-    uint64_t cq_empty;           /**< CQ is empty counter */
-    uint64_t cq_buf_freed;       /**< Number of buffers freed */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+    uint64_t rx_ring_full;       /**< Number of times RX ring is full */
+    uint64_t rx_fill_ring_empty; /**< Number of times the RX fill ring was empty */
+    uint64_t tx_ring_empty;      /**< Number of times the TX ring is empty */
+#endif
+    /* FQ debug stats */
+    uint64_t fq_add_count;    /**< Number of FQ buffers added */
+    uint64_t fq_alloc_failed; /**< Number of buffer allocations failed */
+    uint64_t fq_buf_freed;    /**< Number of buffers freed from FQ add */
+                              /* TX debug stats */
+    uint64_t tx_kicks;        /**< Number of times we need to do a tx kick */
+    uint64_t tx_kick_failed;  /**< Number of times the tx kick failed */
+    uint64_t tx_kick_again;   /**< Number of times tx kick needed to be restarted */
+    uint64_t tx_ring_full;    /**< TX Ring is full */
+    uint64_t tx_copied;       /**< TX packet was copied */
+                              /* CQ debug stats */
+    uint64_t cq_empty;        /**< CQ is empty counter */
+    uint64_t cq_buf_freed;    /**< Number of buffers freed */
 } lport_stats_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
When the xskdev_stats_reset() is called the lport_stats_t is set to zero,
but the XDP stats are not reset as they are handled by the kernel. This
means the counter we display like imissed or inpacket do not appear to
be reset to zero. We can not reset the XDP stats so keep a copy on init
of the port and after a reset of the stats on a lport.

Add some logic to simulate the XDP stats are reset by keeping a original
set of stats from the XDP counters and substract the difference to
get the correct value after a reset call.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>