### PR TITLE
only enable gofmt for golangci-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -27,6 +27,10 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: "main"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Set the LINTER_RULES_PATH to be the top-level directory of the repo so
+          # that .golangci.yml is available to the golangci-lint linter
+          # https://github.com/github/super-linter/blob/main/docs/using-rules-files.md
+          LINTER_RULES_PATH: /
           VALIDATE_CLANG_FORMAT: true
           VALIDATE_BASH: true
           VALIDATE_GITHUB_ACTIONS: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+run:
+  timeout: 5m
+linters:
+  disable-all: true
+  enable:
+    - gofmt


### PR DESCRIPTION
golangci-linter runs a set of linters by default if we use the
golangci-linter through super-linter. This was causing some false
positives to be seen. For example, in this PR -
https://github.com/CloudNativeDataPlane/cndp/runs/7883419903?check_suite_focus=true#step:4:474
Adding a config file for golangci-linter so that only the gofmt linter is enabled for now and
no false positives are seen. Other linters are disabled.

Signed-off-by: Elza Mathew <elza.mathew@intel.com>