### PR TITLE
update all of the copyright notices

### DIFF
--- a/doc/guides/prog_guide/graph_lib.rst
+++ b/doc/guides/prog_guide/graph_lib.rst
@@ -1,6 +1,6 @@
 ..  SPDX-License-Identifier: BSD-3-Clause
     Copyright (c) 2020 Marvell International Ltd.
-    Copyright (c) <2019-2021>, Intel Corporation. All rights reserved.
+    Copyright (c) 2019-2022 Intel Corporation.
 
 .. _Graph_Library:
 

--- a/examples/cnet-graph/meson.build
+++ b/examples/cnet-graph/meson.build
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2022 Intel Corporation
 
 sources = files('cnet-graph.c', 'parse-args.c', 'stats.c')
 

--- a/examples/cnet-quic/meson.build
+++ b/examples/cnet-quic/meson.build
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2022 Intel Corporation
 
 sources = files('cnet-quic.c', 'parse-args.c', 'stats.c', 'quic-cli.c')
 

--- a/examples/dlb_test/stats.c
+++ b/examples/dlb_test/stats.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2019-2020 Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdio.h>             // for snprintf, fflush, NULL, stdout

--- a/examples/l3fwd-graph/meson.build
+++ b/examples/l3fwd-graph/meson.build
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2022 Intel Corporation
 
 sources = files('fwd.c', 'parse-args.c', 'stats.c')
 

--- a/lang/go/tools/cmon/helpers.go
+++ b/lang/go/tools/cmon/helpers.go
@@ -16,13 +16,13 @@ func CloudMonInfo(color bool) string {
 	if !color {
 		return fmt.Sprintf("%s, Version: %s Pid: %d %s",
 			"CNDP Monitor Tool", Version(), os.Getpid(),
-			"Copyright © 2019-2021 Intel Corporation")
+			"Copyright (c) 2019-2022 Intel Corporation")
 	}
 
 	return fmt.Sprintf("[%s, Version: %s Pid: %s %s]",
 		cz.Yellow("CNDP Monitor Tool"), cz.Green(Version()),
 		cz.Red(os.Getpid()),
-		cz.SkyBlue("Copyright © 2019-2021 Intel Corporation"))
+		cz.SkyBlue("Copyright (c) 2019-2022 Intel Corporation"))
 }
 
 func sprintf(msg string, w ...interface{}) string {

--- a/lib/cnet/incs/cnet_const.h
+++ b/lib/cnet/incs/cnet_const.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2016-2020 Intel Corporation
+ * Copyright (c) 2016-2022 Intel Corporation
  */
 
 #ifndef __CNET_CONST_H

--- a/lib/core/cne/cne.h
+++ b/lib/core/cne/cne.h
@@ -45,8 +45,8 @@ enum {
 typedef void (*on_exit_fn_t)(int sig, void *arg, int exit_type);
 #endif
 
-#define COPYRIGHT_MSG       "Copyright (c) <2020-2022>, Intel Corporation. All rights reserved."
-#define COPYRIGHT_MSG_SHORT "Copyright (c) <2020-2022>, Intel Corporation"
+#define COPYRIGHT_MSG       "Copyright (c) 2020-2022 Intel Corporation. All rights reserved."
+#define COPYRIGHT_MSG_SHORT "Copyright (c) 2020-2022 Intel Corporation"
 #define POWERED_BY_CNDP     "Powered by CNDP"
 
 /**

--- a/lib/core/osal/cne_stdio.c
+++ b/lib/core/osal/cne_stdio.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdio.h>         // for vsnprintf, FILE

--- a/lib/core/osal/cne_stdio.h
+++ b/lib/core/osal/cne_stdio.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef __CNE_STDIO_H_

--- a/lib/core/osal/cne_tty.c
+++ b/lib/core/osal/cne_tty.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <bits/termios-c_lflag.h>

--- a/lib/core/osal/cne_tty.h
+++ b/lib/core/osal/cne_tty.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef __CNE_TTY_H_

--- a/lib/core/osal/vt100_out.c
+++ b/lib/core/osal/vt100_out.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdio.h>              // for NULL

--- a/lib/core/osal/vt100_out.h
+++ b/lib/core/osal/vt100_out.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef __VT100_OUT_H_

--- a/lib/usr/app/cli/cli.c
+++ b/lib/usr/app/cli/cli.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <bits/getopt_core.h>

--- a/lib/usr/app/cli/cli.h
+++ b/lib/usr/app/cli/cli.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_H_

--- a/lib/usr/app/cli/cli.rst
+++ b/lib/usr/app/cli/cli.rst
@@ -1,5 +1,5 @@
 ..  SPDX-License-Identifier: BSD-3-Clause
-    Copyright (c) <2019-2021> Intel Corporation. All rights reserved.
+    Copyright (c) 2019-2022 Intel Corporation.
 
 CLI Sample Application
 ===============================

--- a/lib/usr/app/cli/cli_auto_complete.c
+++ b/lib/usr/app/cli/cli_auto_complete.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <cne_strings.h>        // for cne_strcnt, cne_strtok

--- a/lib/usr/app/cli/cli_auto_complete.h
+++ b/lib/usr/app/cli/cli_auto_complete.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_AUTO_COMPLETE_H_

--- a/lib/usr/app/cli/cli_cmap.c
+++ b/lib/usr/app/cli/cli_cmap.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 /*

--- a/lib/usr/app/cli/cli_cmap.h
+++ b/lib/usr/app/cli/cli_cmap.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef __CLI_CMAP_H

--- a/lib/usr/app/cli/cli_cmds.c
+++ b/lib/usr/app/cli/cli_cmds.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include "generic/cne_cycles.h"

--- a/lib/usr/app/cli/cli_cmds.h
+++ b/lib/usr/app/cli/cli_cmds.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_CMDS_H_

--- a/lib/usr/app/cli/cli_common.h
+++ b/lib/usr/app/cli/cli_common.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_COMMON_H_

--- a/lib/usr/app/cli/cli_env.c
+++ b/lib/usr/app/cli/cli_env.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 #include <cli_env.h>
 #include <alloca.h>        // for alloca

--- a/lib/usr/app/cli/cli_env.h
+++ b/lib/usr/app/cli/cli_env.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_ENV_H_

--- a/lib/usr/app/cli/cli_file.c
+++ b/lib/usr/app/cli/cli_file.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <cli_file.h>

--- a/lib/usr/app/cli/cli_file.h
+++ b/lib/usr/app/cli/cli_file.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_FILE_H_

--- a/lib/usr/app/cli/cli_gapbuf.c
+++ b/lib/usr/app/cli/cli_gapbuf.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 /* inspired by an email/code written by: Joseph H. Allen, 9/10/89 */
 

--- a/lib/usr/app/cli/cli_gapbuf.h
+++ b/lib/usr/app/cli/cli_gapbuf.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 /* inspired by an email/code written by: Joseph H. Allen, 9/10/89 */
 

--- a/lib/usr/app/cli/cli_help.c
+++ b/lib/usr/app/cli/cli_help.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2019-2022 Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdio.h>         // for NULL, snprintf

--- a/lib/usr/app/cli/cli_help.h
+++ b/lib/usr/app/cli/cli_help.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_HELP_H_

--- a/lib/usr/app/cli/cli_history.c
+++ b/lib/usr/app/cli/cli_history.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdint.h>           // for uint32_t, uintptr_t

--- a/lib/usr/app/cli/cli_history.h
+++ b/lib/usr/app/cli/cli_history.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_HISTORY_H_

--- a/lib/usr/app/cli/cli_input.c
+++ b/lib/usr/app/cli/cli_input.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <string.h>            // for strcat, strchr, strlen

--- a/lib/usr/app/cli/cli_input.h
+++ b/lib/usr/app/cli/cli_input.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_INPUT_H_

--- a/lib/usr/app/cli/cli_lib.rst
+++ b/lib/usr/app/cli/cli_lib.rst
@@ -1,5 +1,5 @@
 ..  SPDX-License-Identifier: BSD-3-Clause
-    Copyright (c) <2019-2021> Intel Corporation. All rights reserved.
+    Copyright (c) 2019-2022 Intel Corporation.
 
 CLI library guide
 =================

--- a/lib/usr/app/cli/cli_map.c
+++ b/lib/usr/app/cli/cli_map.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <cne_strings.h>        // for cne_strtok, cne_stropt

--- a/lib/usr/app/cli/cli_map.h
+++ b/lib/usr/app/cli/cli_map.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 /**

--- a/lib/usr/app/cli/cli_search.c
+++ b/lib/usr/app/cli/cli_search.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <cne_strings.h>        // for cne_strtok

--- a/lib/usr/app/cli/cli_search.h
+++ b/lib/usr/app/cli/cli_search.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _CLI_SEARCH_H_

--- a/lib/usr/app/cli/cli_vt100.c
+++ b/lib/usr/app/cli/cli_vt100.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdint.h>        // for uint32_t, uint8_t

--- a/lib/usr/app/cli/cli_vt100.h
+++ b/lib/usr/app/cli/cli_vt100.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2021> Intel Corporation.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef __CLI_VT100_H_

--- a/lib/usr/app/jcfg/jcfg.c
+++ b/lib/usr/app/jcfg/jcfg.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <poll.h>                       // for pollfd, poll, POLLIN

--- a/lib/usr/app/jcfg/jcfg.h
+++ b/lib/usr/app/jcfg/jcfg.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _JCFG_H_

--- a/lib/usr/app/jcfg/jcfg_application.c
+++ b/lib/usr/app/jcfg/jcfg_application.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <json-c/json_types.h>

--- a/lib/usr/app/jcfg/jcfg_decode.c
+++ b/lib/usr/app/jcfg/jcfg_decode.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <string.h>                    // for strcmp, NULL, strdup, size_t

--- a/lib/usr/app/jcfg/jcfg_decode.h
+++ b/lib/usr/app/jcfg/jcfg_decode.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _JCFG_DECODE_H_

--- a/lib/usr/app/jcfg/jcfg_default.c
+++ b/lib/usr/app/jcfg/jcfg_default.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <json-c/json_types.h>

--- a/lib/usr/app/jcfg/jcfg_dump.c
+++ b/lib/usr/app/jcfg/jcfg_dump.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <json-c/json_types.h>

--- a/lib/usr/app/jcfg/jcfg_lgroup.c
+++ b/lib/usr/app/jcfg/jcfg_lgroup.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <json-c/json_types.h>

--- a/lib/usr/app/jcfg/jcfg_lport.c
+++ b/lib/usr/app/jcfg/jcfg_lport.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <json-c/json_types.h>

--- a/lib/usr/app/jcfg/jcfg_lport_group.c
+++ b/lib/usr/app/jcfg/jcfg_lport_group.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <json-c/json_types.h>

--- a/lib/usr/app/jcfg/jcfg_option.c
+++ b/lib/usr/app/jcfg/jcfg_option.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <json-c/json_types.h>

--- a/lib/usr/app/jcfg/jcfg_private.h
+++ b/lib/usr/app/jcfg/jcfg_private.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _JCFG_PRIVATE_H_

--- a/lib/usr/app/jcfg/jcfg_thread.c
+++ b/lib/usr/app/jcfg/jcfg_thread.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <json-c/json_types.h>

--- a/lib/usr/app/jcfg/jcfg_umem.c
+++ b/lib/usr/app/jcfg/jcfg_umem.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <json-c/json_types.h>

--- a/lib/usr/clib/msgchan/meson.build
+++ b/lib/usr/clib/msgchan/meson.build
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) <2022>, Intel Corporation
+# Copyright (c) 2022 Intel Corporation
 
 sources = files('msgchan.c')
 headers = files('msgchan.h')

--- a/lib/usr/clib/msgchan/msgchan.c
+++ b/lib/usr/clib/msgchan/msgchan.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2022>, Intel Corporation.
+ * Copyright (c) 2022 Intel Corporation.
  */
 
 #include <inttypes.h>          // for PRIu32

--- a/lib/usr/clib/msgchan/msgchan.h
+++ b/lib/usr/clib/msgchan/msgchan.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2022>, Intel Corporation.
+ * Copyright (c) 2022 Intel Corporation.
  */
 
 #ifndef _MSGCHAN_H_

--- a/lib/usr/clib/msgchan/msgchan_priv.h
+++ b/lib/usr/clib/msgchan/msgchan_priv.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2022>, Intel Corporation
+ * Copyright (c) 2022 Intel Corporation
  */
 
 #ifndef _MSGCHAN_PRIV_H_

--- a/test/testcne/cthread_test.c
+++ b/test/testcne/cthread_test.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2019-2020 Intel Corporation
+ * Copyright (c) 2019-2022 Intel Corporation
  */
 
 // IWYU pragma: no_include <bits/getopt_core.h>

--- a/test/testcne/cthread_test.h
+++ b/test/testcne/cthread_test.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2019-2020 Intel Corporation
+ * Copyright (c) 2019-2022 Intel Corporation
  */
 
 #ifndef _CTHREAD_TEST_H_

--- a/test/testcne/kvargs_test.c
+++ b/test/testcne/kvargs_test.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdio.h>             // for NULL, snprintf, EOF

--- a/test/testcne/msgchan_test.c
+++ b/test/testcne/msgchan_test.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2022>, Intel Corporation.
+ * Copyright (c) 2022 Intel Corporation.
  */
 
 #include <stdio.h>         // for NULL, snprintf, EOF

--- a/test/testcne/pktdev_test.c
+++ b/test/testcne/pktdev_test.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 // IWYU pragma: no_include <bits/getopt_core.h>

--- a/test/testcne/vec_test.c
+++ b/test/testcne/vec_test.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2019-2020 Intel Corporation
+ * Copyright (c) 2019-2022 Intel Corporation
  */
 
 // IWYU pragma: no_include <bits/getopt_core.h>

--- a/test/testcne/vec_test.h
+++ b/test/testcne/vec_test.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2019-2020 Intel Corporation
+ * Copyright (c) 2019-2022 Intel Corporation
  */
 
 #ifndef _VEC_TEST_H_

--- a/usrtools/txgen/INSTALL.md
+++ b/usrtools/txgen/INSTALL.md
@@ -6,7 +6,7 @@ TXGen - Traffic Generator powered by CNDP
 ** (TXGen) Sounds like 'Packet-Gen'**
 
 ---
-**Copyright &copy; \<2019-2022\>, Intel Corporation. All rights reserved.**
+**Copyright &copy; \2019-2022\ Intel Corporation. All rights reserved.**
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/usrtools/txgen/app/_ether.h
+++ b/usrtools/txgen/app/_ether.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) 2010-2022 Intel Corporation. All rights reserved.
+ * Copyright (c) 2010-2022 Intel Corporation.
  */
 
 #ifndef _ETHER_H_

--- a/usrtools/txgen/app/capture.c
+++ b/usrtools/txgen/app/capture.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2010-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2010-2022 Intel Corporation.
  */
 
 #include "capture.h"

--- a/usrtools/txgen/app/capture.h
+++ b/usrtools/txgen/app/capture.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2010-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2010-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_CAPTURE_H_

--- a/usrtools/txgen/app/cksum.c
+++ b/usrtools/txgen/app/cksum.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2014-2021> Intel Corporation. All rights reserved.
+ * Copyright (c) 2014-2022 Intel Corporation.
  */
 
 #include <stdint.h>            // for uint32_t, uint16_t, int32_t, uint8_t

--- a/usrtools/txgen/app/cksum.h
+++ b/usrtools/txgen/app/cksum.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2014-2021> Intel Corporation. All rights reserved.
+ * Copyright (c) 2014-2022 Intel Corporation.
  */
 
 #ifndef __CKSUM_H

--- a/usrtools/txgen/app/cli-functions.c
+++ b/usrtools/txgen/app/cli-functions.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2022 Intel Corporation.
  */
 
 #include "cli-functions.h"

--- a/usrtools/txgen/app/cli-functions.h
+++ b/usrtools/txgen/app/cli-functions.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2022 Intel Corporation.
  */
 
 #ifndef _CLI_COMMANDS_H_

--- a/usrtools/txgen/app/cmds.c
+++ b/usrtools/txgen/app/cmds.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdatomic.h>           // for atomic_load, atomic_exchange

--- a/usrtools/txgen/app/cmds.h
+++ b/usrtools/txgen/app/cmds.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_CMDS_H_

--- a/usrtools/txgen/app/display.c
+++ b/usrtools/txgen/app/display.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <sys/stat.h>        // for fchmod

--- a/usrtools/txgen/app/display.h
+++ b/usrtools/txgen/app/display.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_DISPLAY_H_

--- a/usrtools/txgen/app/ether.c
+++ b/usrtools/txgen/app/ether.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include "ether.h"

--- a/usrtools/txgen/app/ether.h
+++ b/usrtools/txgen/app/ether.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_ETHER_H_

--- a/usrtools/txgen/app/ipv4.c
+++ b/usrtools/txgen/app/ipv4.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <netinet/in.h>        // for htonl, htons, in_addr

--- a/usrtools/txgen/app/ipv4.h
+++ b/usrtools/txgen/app/ipv4.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_IPV4_H_

--- a/usrtools/txgen/app/main.c
+++ b/usrtools/txgen/app/main.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <execinfo.h>        // for backtrace, backtrace_symbols

--- a/usrtools/txgen/app/parse-args.h
+++ b/usrtools/txgen/app/parse-args.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _PARSE_ARGS_H_

--- a/usrtools/txgen/app/port-cfg.h
+++ b/usrtools/txgen/app/port-cfg.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _PORT_CFG_H_

--- a/usrtools/txgen/app/seq.h
+++ b/usrtools/txgen/app/seq.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_SEQ_H_

--- a/usrtools/txgen/app/stats.c
+++ b/usrtools/txgen/app/stats.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdio.h>               // for snprintf, NULL

--- a/usrtools/txgen/app/stats.h
+++ b/usrtools/txgen/app/stats.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_STATS_H_

--- a/usrtools/txgen/app/tcp.c
+++ b/usrtools/txgen/app/tcp.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <netinet/in.h>        // for htonl, htons, in_addr

--- a/usrtools/txgen/app/tcp.h
+++ b/usrtools/txgen/app/tcp.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_TCP_H_

--- a/usrtools/txgen/app/txgen.c
+++ b/usrtools/txgen/app/txgen.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <stdint.h>            // for uint64_t, uint8_t, uint16_t, uint...

--- a/usrtools/txgen/app/txgen.h
+++ b/usrtools/txgen/app/txgen.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_H_

--- a/usrtools/txgen/app/udp.c
+++ b/usrtools/txgen/app/udp.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #include <netinet/in.h>        // for htons, htonl, in_addr

--- a/usrtools/txgen/app/udp.h
+++ b/usrtools/txgen/app/udp.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_UDP_H_

--- a/usrtools/txgen/app/version.h
+++ b/usrtools/txgen/app/version.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright (c) <2019-2020>, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022 Intel Corporation.
  */
 
 #ifndef _TXGEN_VERSION_H_

--- a/usrtools/txgen/docs/source/commands.rst
+++ b/usrtools/txgen/docs/source/commands.rst
@@ -4,7 +4,7 @@
 .. _commands:
 
 ``*** TXGen ***``
-Copyright &copy \<2019-2021\>, Intel Corporation.
+Copyright &copy 2019-2022 Intel Corporation.
 
 The txgen output display needs 132 columns and about 42 lines to display
 currentlyt. I am using an xterm of 132x42, but you can have a larger display

--- a/usrtools/txgen/xdp.cfg
+++ b/usrtools/txgen/xdp.cfg
@@ -1,5 +1,5 @@
 # TX-Gen 20.11.0
-# Copyright (c) <2020-2021>, Intel Corporation. All rights reserved., Powered by CNDP
+# Copyright (c) 2020-2022 Intel Corporation. All rights reserved., Powered by CNDP
 
 #######################################################################
 # TXGen Configuration script information:


### PR DESCRIPTION
Code contained a number of different ways to format the copyright line.

Remove <> and the comma
- Copyright (c) <dates>, Intel Corporation. --> Copyright (c) dates Intel Corporation.
- Remove all <> around dates
- Updated all Intel copyright dates to this year

Signed-off-by: Keith Wiles <keith.wiles@intel.com>