### PR TITLE
Fix go bindings lport setup

### DIFF
--- a/lang/go/bindings/cne/lport.go
+++ b/lang/go/bindings/cne/lport.go
@@ -90,6 +90,8 @@ func (sys *System) setupLPort(lportName string, lportInfo *LPortInfo) error {
 
 	for i := 0; i < len(netdevName) && i < C.LPORT_NAME_LEN; i++ {
 		pcfg.ifname[i] = C.char(netdevName[i])
+	}
+	for i := 0; i < len(lportName) && i < C.LPORT_NAME_LEN; i++ {
 		pcfg.name[i] = C.char(lportName[i])
 	}
 


### PR DESCRIPTION
The full lport name was not being copied to the lport_cfg_t.
It was being trunctated to the length of the network device name.

Signed-off-by: Nicholas Waples <nwaples@gmail.com>