### PR TITLE
fix go binding code to validate json-c file

### DIFF
--- a/lang/go/bindings/cne/system.go
+++ b/lang/go/bindings/cne/system.go
@@ -116,11 +116,15 @@ func OpenWithFile(path string) (*System, error) {
 	if strings.HasPrefix(str, "{") {
 		err = fmt.Errorf("path does not appear to be a valid filepath")
 	} else {
-		if configFile, err := os.Open(str); err == nil {
+		var configFile *os.File
+
+		if configFile, err = os.Open(str); err == nil {
+			var bytes []byte
+
 			defer configFile.Close()
 
 			// Read the JSON-C file into a single byte array for later parsing
-			if bytes, err := io.ReadAll(configFile); err == nil {
+			if bytes, err = io.ReadAll(configFile); err == nil {
 				return open(jsonc.ToJSON(bytes))
 			}
 		}


### PR DESCRIPTION
When the OpenWithFile() is called with an invalid config file path/filename
it would cause an exception. Now the error is returned to the caller to
process correctly.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>