### PR TITLE
fix the cne_register_test()

### DIFF
--- a/test/testcne/cne_register_test.c
+++ b/test/testcne/cne_register_test.c
@@ -4,11 +4,12 @@
 
 // IWYU pragma: no_include <bits/getopt_core.h>
 
-#include <stdio.h>             // for NULL, EOF
-#include <stdint.h>            // for uint16_t, uint32_t
-#include <cne.h>               // for cne_register, cne_unregister
-#include <tst_info.h>          // for tst_error, tst_end, tst_start, TST_FAILED
-#include <getopt.h>            // for getopt_long, option
+#include <stdio.h>           // for NULL, EOF
+#include <stdint.h>          // for uint16_t, uint32_t
+#include <cne.h>             // for cne_register, cne_unregister
+#include <tst_info.h>        // for tst_error, tst_end, tst_start, TST_FAILED
+#include <getopt.h>          // for getopt_long, option
+#include <pthread.h>
 #include <cne_common.h>        // for CNE_SET_USED
 
 #include "cne_register_test.h"
@@ -19,8 +20,8 @@ __on_exit(int sig __cne_unused, void *arg __cne_unused, int exit_type __cne_unus
     return;
 }
 
-static int
-cne_register_test(void)
+static void *
+cne_register_test(void *arg)
 {
     int tuid, cuid, tcnt, ret = 0;
     int v = 1234, vv = 0;
@@ -30,63 +31,65 @@ cne_register_test(void)
 
     tuid = cne_register("TestCNERegister");
     if (tuid)
-        tst_ok("PASS --- TEST: New thread registered, uid %d\n", tuid);
+        tst_ok("PASS --- TEST: New thread registered, uid %d", tuid);
 
     cuid = cne_entry_uid();
     if (tuid != cuid) {
-        tst_error("Invalid uid\n");
+        tst_error("Invalid uid");
         goto err;
     } else
-        tst_ok("PASS --- TEST: Current uid retrieved, %d\n", tuid);
+        tst_ok("PASS --- TEST: Current uid retrieved, %d", tuid);
 
     ret = cne_set_private(tuid, setv);
     if (ret < 0) {
-        tst_error("Unable to set a private value for uid = %d\n", tuid);
+        tst_error("Unable to set a private value for uid = %d", tuid);
         goto err;
     } else
-        tst_ok("PASS --- TEST: Set private value, %d\n", *(int *)setv);
+        tst_ok("PASS --- TEST: Set private value, %d", *(int *)setv);
 
     ret = cne_get_private(tuid, getv);
     if (ret < 0) {
-        tst_error("Unable to get the private value for uid = %d\n", tuid);
+        tst_error("Unable to get the private value for uid = %d", tuid);
         goto err;
     } else
-        tst_ok("PASS --- TEST: Retrieved private value, %d\n", *(int *)*getv);
+        tst_ok("PASS --- TEST: Retrieved private value, %d", *(int *)*getv);
 
     if (*(int *)setv != *(int *)*getv) {
-        tst_error("Incorrect private value for uid = %d\n", tuid);
+        tst_error("Incorrect private value for uid = %d", tuid);
         goto err;
     } else
-        tst_ok("PASS --- TEST: The set private value was retrieved\n");
+        tst_ok("PASS --- TEST: The set private value was retrieved");
 
     tcnt = cne_active_threads();
     if (tcnt < 0) {
-        tst_error("Error retrieving total active threads\n");
+        tst_error("Error retrieving total active threads");
         goto err;
     } else
-        tst_ok("PASS --- TEST: Total number of active threads, %d\n", tcnt);
+        tst_ok("PASS --- TEST: Total number of active threads, %d", tcnt);
 
-    if (tuid) {
-        if (cne_unregister(tuid) < 0) {
-            tst_error("cne_unregister(%d) failed\n", tuid);
-            return -1;
-        } else
-            tst_ok("PASS --- TEST: uid %d unregistered\n", tuid);
-    }
+    if (cne_unregister(tuid) < 0) {
+        tst_error("cne_unregister(%d) failed", tuid);
+        *(int *)arg = -1;
+        return NULL;
+    } else
+        tst_ok("PASS --- TEST: uid %d unregistered", tuid);
 
     ret = cne_on_exit(__on_exit, NULL, NULL, 0);
     if (ret < 0) {
         tst_error("Error on exit\n");
         goto err;
     } else
-        tst_ok("PASS --- TEST: Exit CNE Registration test\n");
+        tst_ok("PASS --- TEST: Exit CNE Registration test");
 
-    return 0;
+    *(int *)arg = 0;
+    return NULL;
 
 err:
     if (tuid)
         cne_unregister(tuid);
-    return -1;
+
+    *(int *)arg = -1;
+    return NULL;
 }
 
 int
@@ -95,7 +98,8 @@ cne_register_main(int argc, char **argv)
     tst_info_t *tst;
     int verbose = 0, opt;
     char **argvopt;
-    int option_index;
+    int option_index, ret, eno;
+    pthread_t tid;
     static const struct option lgopts[] = {{NULL, 0, 0, 0}};
 
     argvopt = argv;
@@ -112,7 +116,16 @@ cne_register_main(int argc, char **argv)
 
     tst = tst_start("CNE Registration");
 
-    if (cne_register_test() < 0)
+    ret = 0;
+    if ((eno = pthread_create(&tid, NULL, cne_register_test, &ret)) != 0) {
+        tst_error("pthread create failed: %s", strerror(eno));
+        goto err;
+    }
+    if ((eno = pthread_join(tid, NULL)) != 0) {
+        tst_error("pthread join failed: %s", strerror(eno));
+        goto err;
+    }
+    if (ret < 0)
         goto err;
 
     tst_end(tst, TST_PASSED);


### PR DESCRIPTION
The cne_register_test() function must be run inside a new pthread or
it will corrupt the per_thread__cne variable of the current thread.

The problem really appears when the cne_register() occurs
as it replaces the threads per_thread__cne variable with the new
registered value corrupting the main thread value.

The cne_id() would detect per_thread__cne as null and return -1,
but it makes more sense to print a message and exit error as the
system is corrupted.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>