### PR TITLE
Listen state and udp crash fixes

### DIFF
--- a/examples/cnet-graph/cnet-graph.c
+++ b/examples/cnet-graph/cnet-graph.c
@@ -222,7 +222,7 @@ tcp_recv(int cd)
         nb_mbufs = chnl_recv(cd, mbufs, RECV_NB_MBUFS);
         if (nb_mbufs <= 0) {
             if (nb_mbufs < 0)
-                CNE_ERR("Receive packets failed\n");
+                CNE_ERR("Receive packets failed %d: %s\n", errno, strerror(errno));
             break;
         }
 

--- a/lib/cnet/chnl/cnet_chnl.c
+++ b/lib/cnet/chnl/cnet_chnl.c
@@ -28,6 +28,8 @@
 #include "pktmbuf.h"             // for pktmbuf_data_len, pktmbuf_t, ...
 
 static void chnl_free(struct chnl *ch);
+static struct chnl *alloc_chnl(void);
+static void free_chnl(struct chnl *ch);
 
 static inline int
 alloc_cd(struct chnl *ch)
@@ -71,6 +73,45 @@ mp_init(mempool_t *mp, void *opaque_arg __cne_unused, void *_b, unsigned i __cne
     ch->ch_cd = -1;
 }
 
+static inline struct chnl *
+alloc_chnl(void)
+{
+    stk_t *stk      = this_stk;
+    struct chnl *ch = NULL;
+
+    if (stk && stk->chnl_objs && mempool_get(stk->chnl_objs, (void *)&ch) < 0)
+        CNE_NULL_RET("Allocation for channel structure failed\n");
+
+    if (alloc_cd(ch) < 0) {
+        free_chnl(ch);
+        CNE_NULL_RET("Allocation of channel descriptor failed\n");
+    }
+    chnl_state_set(ch, _NOSTATE);
+
+    return ch;
+}
+
+static inline void
+free_chnl(struct chnl *ch)
+{
+    stk_t *stk = this_stk;
+
+    if (!ch || !stk || !stk->chnl_objs)
+        CNE_RET("Free for channel structure failed\n");
+
+    free_cd(ch);
+
+    vec_free(ch->ch_rcv.cb_vec);
+    vec_free(ch->ch_snd.cb_vec);
+
+    if (cne_mutex_destroy(&ch->ch_mutex))
+        CNE_RET("unable to destroy ch_mutex\n");
+
+    mp_init(stk->chnl_objs, NULL, (void *)ch, 0);
+
+    mempool_put(stk->chnl_objs, (void *)ch);
+}
+
 /*
  * This routine allocates a chnl structure from the free list,
  * and initializes it for use.
@@ -78,13 +119,13 @@ mp_init(mempool_t *mp, void *opaque_arg __cne_unused, void *_b, unsigned i __cne
 static struct chnl *
 chnl_alloc(void)
 {
-    stk_t *stk             = this_stk;
-    struct mempool_cfg cfg = {0};
-    struct chnl *ch        = NULL;
-    struct cnet *cnet      = cnet_get();
-
     if (stk_lock()) {
+        stk_t *stk = this_stk;
+
         if (!stk->chnl_objs) {
+            struct mempool_cfg cfg = {0};
+            struct cnet *cnet      = cnet_get();
+
             cfg.objcnt     = cnet->num_chnls;
             cfg.objsz      = sizeof(struct chnl);
             cfg.cache_sz   = 64;
@@ -101,17 +142,7 @@ chnl_alloc(void)
     } else
         CNE_NULL_RET("Unable to acquire mutex\n");
 
-    if (mempool_get(stk->chnl_objs, (void *)&ch) < 0)
-        CNE_NULL_RET("Allocate for chnl_obj failed\n");
-
-    if (alloc_cd(ch) < 0) {
-        mempool_put(stk->chnl_objs, ch);
-        CNE_NULL_RET("allocate of channel descriptor failed\n");
-    }
-
-    chnl_state_set(ch, _NOSTATE);
-
-    return ch;
+    return alloc_chnl();
 }
 
 /*
@@ -121,30 +152,12 @@ chnl_alloc(void)
 static void
 chnl_free(struct chnl *ch)
 {
-    stk_t *stk = this_stk;
+    if (ch) {
+        if (chnl_state_tst(ch, _CHNL_FREE))
+            CNE_RET("chnl is already free!");
 
-    if (!ch || !stk)
-        return;
-
-    if (chnl_state_tst(ch, _CHNL_FREE))
-        CNE_RET("chnl is already free!");
-
-    free_cd(ch);
-
-    vec_free(ch->ch_rcv.cb_vec);
-    vec_free(ch->ch_snd.cb_vec);
-
-    ch->ch_rcv.cb_vec = NULL;
-    ch->ch_snd.cb_vec = NULL;
-
-    /* Set chnl structure to the free state */
-    chnl_state_set(ch, _CHNL_FREE);
-    ch->ch_pcb = NULL;
-
-    if (cne_mutex_destroy(&ch->ch_mutex))
-        CNE_ERR("unable to destroy ch_mutex\n");
-
-    mempool_put(stk->chnl_objs, (void *)ch);
+        free_chnl(ch);
+    }
 }
 
 /*
@@ -204,7 +217,7 @@ chnl_cleanup(struct chnl *ch)
 }
 
 static int
-__alloc_pcb(struct chnl *ch, int typ)
+initialize_chnl(struct chnl *ch, int typ)
 {
     stk_t *stk = this_stk;
     struct chnl_buf *rb, *sb;
@@ -285,7 +298,7 @@ __chnl_create(int32_t dom, int32_t type, int32_t pro, struct pcb_entry *ppcb)
         goto err;
     }
 
-    if (__alloc_pcb(ch, type)) {
+    if (initialize_chnl(ch, type)) {
         __errno_set(ENOBUFS);
         goto err;
     }

--- a/lib/cnet/udp/cnet_udp_chnl.c
+++ b/lib/cnet/udp/cnet_udp_chnl.c
@@ -87,12 +87,10 @@ udp_chnl_recv(struct chnl *ch, pktmbuf_t **mbufs, int nb_mbufs)
     tlen = vec_len(ch->ch_rcv.cb_vec);
     if (tlen > 0) {
         n = (tlen > nb_mbufs) ? nb_mbufs : tlen;
+
         memcpy(mbufs, ch->ch_rcv.cb_vec, sizeof(pktmbuf_t *) * n);
 
-        tlen -= n;
-        memmove(ch->ch_rcv.cb_vec, ch->ch_rcv.cb_vec + (sizeof(pktmbuf_t *) * n),
-                tlen * sizeof(pktmbuf_t *));
-        vec_set_len(ch->ch_rcv.cb_vec, tlen);
+        vec_remove(ch->ch_rcv.cb_vec, n);
     }
     for (int i = 0; i < n; i++)
         sz += pktmbuf_data_len(mbufs[i]);

--- a/lib/include/cne_vec.h
+++ b/lib/include/cne_vec.h
@@ -349,23 +349,26 @@ _vec_find_index(void **vec, void *v)
     } while (0)
 
 /**
- * Remove a number of items from the vector.
+ * Remove a number of items from the front of a vector list.
  *
- * @param _v
+ * @param v
  *   The pointer to the vector to remove the entries from
- * @param _nb
+ * @param nb
  *   The number of items to remove from the vector
  */
-#define vec_remove(_v, _nb)                                     \
-    do {                                                        \
-        vec_hdr_t *h = vec_header(_v);                          \
-        int _n       = h->len - _nb;                            \
-        if (_n >= 0) {                                          \
-            char *src = (char *)&h->data[0] + (_nb * h->esize); \
-            memmove(&h->data[0], src, _n * h->esize);           \
-            h->len = _n;                                        \
-        }                                                       \
-    } while (0)
+static inline void
+vec_remove(void *v, uint32_t nb)
+{
+    vec_hdr_t *h = vec_header(v);
+
+    if (h && h->len && nb <= h->len) {
+        int n = h->len - nb;
+
+        if (n > 0)
+            memmove(v, CNE_PTR_ADD(v, (nb * h->esize)), n * h->esize);
+        h->len = n;
+    }
+}
 
 /**
  * Dump out a vec_hdr_t structure


### PR DESCRIPTION
cleanup the chnl alloc/free code

    The alloc/free of a chnl structure was not being zero'd when
    pushed back to the mempool, needed to make sure it was cleaned up.

fix UDP receive seg-fault

    The UDP chnl receive routine was not copying the correct number
    of bytes from the vector list to the mbuf list being returned
    to the caller.

    Converted the vec_remove() routine to a inline function for debugging.

fix listen state not being set

    In the chnl_open() routine the connection was not calling the
    listen routine for connections with IP string as 0.0.0.0. This
    caused the TCP protocol to not enter the listen state.

    Signed-off-by: Keith Wiles <keith.wiles@intel.com>