### PR TITLE
fix up registering go threads

### DIFF
--- a/lang/go/bindings/cne/lport_test.go
+++ b/lang/go/bindings/cne/lport_test.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestStarting(t *testing.T) {
@@ -19,7 +18,7 @@ func TestStarting(t *testing.T) {
 	} else {
 		defer configFile.Close()
 
-		// Open with a JSON-C string
+		// Open with a JSON-C file
 		cneSys, err = OpenWithFile(*configStr)
 		if err != nil {
 			log.Fatalf("error parsing JSON string: %v", err)
@@ -29,58 +28,58 @@ func TestStarting(t *testing.T) {
 
 func TestGetChannel(t *testing.T) {
 
-	for _, lport := range cneSys.LPortList() {
+	t.Run("TestGetChannel", func(t *testing.T) {
+		for _, lport := range cneSys.LPortList() {
 
-		t.Run("TestLoopback", func(t *testing.T) {
 			if cnt, err := lport.GetLPortChannels(); err != nil {
 				t.Fatalf("error getting channels %v\n", err)
 			} else if cnt == 0 {
 				t.Fatalf("error getting channels is zero: %v\n", err)
 			}
-		})
-	}
+		}
+	})
 }
 
 func TestRxBurst(t *testing.T) {
 
-	for _, lport := range cneSys.LPortList() {
+	t.Run("TestRxBurst", func(t *testing.T) {
+		tid := RegisterThread("RxBurst")
+		if tid < 0 {
+			t.Fatalf("error registering thread")
+		}
+		defer UnregisterThread(tid)
 
-		rxPackets := make([]*Packet, 256)
+		for _, lport := range cneSys.LPortList() {
 
-		t.Run("TestRxBurst", func(t *testing.T) {
-			tid := cneSys.RegisterThread("rx" + time.Now().String())
-			if tid <= 0 {
-				return
-			}
-			defer cneSys.UnregisterThread(tid)
+			rxPackets := make([]*Packet, 256)
 
 			size := RxBurst(lport.LPortID(), rxPackets)
 			if size > 0 {
 				PktBufferFree(rxPackets[:size])
 			}
-		})
-	}
+		}
+	})
 }
 
 func TestPktBufferAlloc(t *testing.T) {
 
-	for _, lport := range cneSys.LPortList() {
+	t.Run("TestPktBufferAlloc", func(t *testing.T) {
+		tid := RegisterThread("PktBufferAlloc")
+		if tid < 0 {
+			t.Fatalf("error registering thread")
+		}
+		defer UnregisterThread(tid)
 
-		txPackets := make([]*Packet, 256)
+		for _, lport := range cneSys.LPortList() {
 
-		t.Run("TestPktBufferAlloc", func(t *testing.T) {
-			tid := cneSys.RegisterThread("prepare_tx" + time.Now().String())
-			if tid <= 0 {
-				return
-			}
-			defer cneSys.UnregisterThread(tid)
+			txPackets := make([]*Packet, 256)
 
 			size := PktBufferAlloc(lport.LPortID(), txPackets)
 			if size > 0 {
 				PktBufferFree(txPackets[:size])
 			}
-		})
-	}
+		}
+	})
 }
 
 func TestTxBurst(t *testing.T) {
@@ -90,15 +89,15 @@ func TestTxBurst(t *testing.T) {
 		return
 	}
 
-	for _, lport := range cneSys.LPortList() {
-		txPackets := make([]*Packet, 256)
+	t.Run("TestTxBurst", func(t *testing.T) {
+		tid := RegisterThread("TxBurst")
+		if tid < 0 {
+			t.Fatalf("error registering thread")
+		}
+		defer UnregisterThread(tid)
 
-		t.Run("TestTxBurst", func(t *testing.T) {
-			tid := cneSys.RegisterThread("tx" + time.Now().String())
-			if tid <= 0 {
-				return
-			}
-			defer cneSys.UnregisterThread(tid)
+		for _, lport := range cneSys.LPortList() {
+			txPackets := make([]*Packet, 256)
 
 			size := PktBufferAlloc(lport.LPortID(), txPackets)
 			if size <= 0 {
@@ -107,21 +106,21 @@ func TestTxBurst(t *testing.T) {
 			WritePktDataList(txPackets[:size], 0, data)
 
 			TxBurst(lport.LPortID(), txPackets[:size], true)
-		})
-	}
+		}
+	})
 }
 
 func TestLoopback(t *testing.T) {
 
-	for _, lport := range cneSys.LPortList() {
-		rxPackets := make([]*Packet, 256)
+	t.Run("TestLoopback", func(t *testing.T) {
+		tid := RegisterThread("Loopback")
+		if tid < 0 {
+			t.Fatalf("error registering thread")
+		}
+		defer UnregisterThread(tid)
 
-		t.Run("TestLoopback", func(t *testing.T) {
-			tid := cneSys.RegisterThread("lb" + time.Now().String())
-			if tid <= 0 {
-				return
-			}
-			defer cneSys.UnregisterThread(tid)
+		for _, lport := range cneSys.LPortList() {
+			rxPackets := make([]*Packet, 256)
 
 			size := RxBurst(lport.LPortID(), rxPackets)
 			if size > 0 {
@@ -129,113 +128,11 @@ func TestLoopback(t *testing.T) {
 
 				TxBurst(lport.LPortID(), rxPackets[:size], true)
 			}
-		})
-	}
+		}
+	})
 }
 
 func TestEnding(t *testing.T) {
 
 	defer cneSys.Close()
-}
-
-func BenchmarkRxBurstSerial(b *testing.B) {
-	var lport *LPort
-
-	if lport = cneSys.LPortList()[0]; lport == nil {
-		b.Fatalf("error getting lport information\n")
-		return
-	}
-
-	rxPackets := make([]*Packet, 256)
-
-	tid := cneSys.RegisterThread("rx_serial" + time.Now().String())
-	if tid <= 0 {
-		return
-	}
-	defer cneSys.UnregisterThread(tid)
-
-	for i := 0; i < b.N; i++ {
-		size := RxBurst(lport.LPortID(), rxPackets)
-		if size > 0 {
-			PktBufferFree(rxPackets[:size])
-		}
-	}
-}
-
-func BenchmarkPktBufferAllocSerial(b *testing.B) {
-	var lport *LPort
-
-	if lport = cneSys.LPortList()[0]; lport == nil {
-		b.Fatalf("error getting lport information\n")
-		return
-	}
-
-	txPackets := make([]*Packet, 256)
-
-	tid := cneSys.RegisterThread("pktbuffer_alloc_serial" + time.Now().String())
-	if tid <= 0 {
-		return
-	}
-	defer cneSys.UnregisterThread(tid)
-
-	for i := 0; i < b.N; i++ {
-		size := PktBufferAlloc(lport.LPortID(), txPackets)
-		if size > 0 {
-			PktBufferFree(txPackets[:size])
-		}
-	}
-}
-
-func BenchmarkLoopbackSerial(b *testing.B) {
-	var lport *LPort
-
-	if lport = cneSys.LPortList()[0]; lport == nil {
-		b.Fatalf("error getting lport information\n")
-		return
-	}
-
-	rxPackets := make([]*Packet, 256)
-
-	tid := cneSys.RegisterThread("loopback_serial" + time.Now().String())
-	if tid <= 0 {
-		return
-	}
-	defer cneSys.UnregisterThread(tid)
-
-	for i := 0; i < b.N; i++ {
-		size := RxBurst(lport.LPortID(), rxPackets)
-		if size > 0 {
-			SwapMacAddrs(rxPackets[:size])
-
-			TxBurst(lport.LPortID(), rxPackets[:size], true)
-		}
-	}
-}
-
-func BenchmarkTxBurstSerial(b *testing.B) {
-	var lport *LPort
-
-	if lport = cneSys.LPortList()[0]; lport == nil {
-		b.Fatalf("error getting lport information\n")
-		return
-	}
-
-	txPackets := make([]*Packet, 256)
-	data, err := hex.DecodeString("fd3c78299efefd3c00450008b82c9efe110400004f122e00a8c00100a8c01e221a002e16d2040101706f6e6d6c6b9a9e787776757473727131307a79")
-	if err != nil {
-		return
-	}
-
-	tid := cneSys.RegisterThread("tx_serial" + time.Now().String())
-	if tid <= 0 {
-		return
-	}
-	defer cneSys.UnregisterThread(tid)
-
-	for i := 0; i < b.N; i++ {
-		size := PktBufferAlloc(lport.LPortID(), txPackets)
-
-		WritePktDataList(txPackets[:size], 0, data)
-		TxBurst(lport.LPortID(), txPackets[:size], true)
-	}
 }

--- a/lang/go/bindings/cne/system_test.go
+++ b/lang/go/bindings/cne/system_test.go
@@ -7,7 +7,6 @@ package cne
 import (
 	"io"
 	"os"
-	"strconv"
 	"time"
 
 	"testing"
@@ -83,48 +82,6 @@ func TestGetPort(t *testing.T) {
 		if lport == nil {
 			t.Errorf("error getting port information\n")
 			return
-		}
-	})
-	t.Run("TestGetPortInValid", func(t *testing.T) {
-
-	})
-}
-
-func BenchmarkGetPortSerial(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		lport := cneSys.LPortList()[0]
-		if lport == nil {
-			b.Errorf("error getting port information\n")
-			return
-		}
-	}
-}
-
-func BenchmarkGetPortParallel(b *testing.B) {
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			lport := cneSys.LPortList()[0]
-			if lport == nil {
-				b.Errorf("error getting port information\n")
-				return
-			}
-		}
-	})
-}
-
-func BenchmarkRegisterThreadParallel(b *testing.B) {
-	i := 0
-	b.RunParallel(func(pb *testing.PB) {
-		str := strconv.Itoa(i)
-		i++
-		tid := cneSys.RegisterThread("register_thread" + str)
-		if tid <= 0 {
-			return
-		}
-		defer cneSys.UnregisterThread(tid)
-
-		for pb.Next() {
-
 		}
 	})
 }


### PR DESCRIPTION
Each Go thread wanting to call CNDP APIs needs to do a RegisterThread()
call to allocate a unique identifier used by mempool cache support.
The call also does a LockOSThread to pin the Go thread to the same
system thread as thread local storage is used in CNDP.

The RegisterThread() and UnregisterThread() routines did not need
the System receiver pointer to be passed into the routines. This
change removes the need to call these routines with a System pointer.

Use cne.RegisterThread("foo") and cne.UnregisterThread(int).

The RegisterThread and UnregisterThread routine used a mutex to
lock access to the cne_register(), but cne_register() now has
locks to protect the register and unregister calls.

The lport_test.go and system_test.go have been changed to move the
t.Run() calls to include the lport for loop instead of calling register
for each lport is not required and the RegisterThread()/UnregisterThread()
calls are only done once per t.Run() call. The lport_test.go benchmark
tests were removed.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>