### PR TITLE
Add cne_check_registration() function.

### DIFF
--- a/lib/core/cne/cne.c
+++ b/lib/core/cne/cne.c
@@ -30,6 +30,12 @@ cne_id(void)
     return per_thread__cne->uid;
 }
 
+int
+cne_check_registration(void)
+{
+    return per_thread__cne ? 1 : 0;
+}
+
 static inline struct cne_entry *
 __get_entry(int tidx)
 {

--- a/lib/core/cne/cne.h
+++ b/lib/core/cne/cne.h
@@ -156,9 +156,17 @@ CNDP_API int cne_get_private(int tidx, void **v);
  * Get the unique ID value using the internal ID get routine
  *
  * @return
- *   The unique ID value or -1 on error
+ *   The unique ID value. Function asserts on error.
  */
 CNDP_API int cne_id(void);
+
+/**
+ * Check if calling thread is registered with CNE.
+ *
+ * @return
+ *   1 if thread is registered or 0 if not registered.
+ */
+CNDP_API int cne_check_registration(void);
 
 /**
  * Return the max number of threads allowed

--- a/test/testcne/cne_register_test.c
+++ b/test/testcne/cne_register_test.c
@@ -23,15 +23,29 @@ __on_exit(int sig __cne_unused, void *arg __cne_unused, int exit_type __cne_unus
 static void *
 cne_register_test(void *arg)
 {
-    int tuid, cuid, tcnt, ret = 0;
+    int tuid = 0, cuid, tcnt, ret = 0;
     int v = 1234, vv = 0;
     void *setv  = &v;
     void *tempv = &vv;
     void **getv = &tempv;
 
+    ret = cne_check_registration();
+    if (ret > 0) {
+        tst_error("Check registration returned success before registering thread with CNE");
+        goto err;
+    } else
+        tst_ok("PASS --- TEST: Thread is not yet registered with CNE");
+
     tuid = cne_register("TestCNERegister");
     if (tuid)
         tst_ok("PASS --- TEST: New thread registered, uid %d", tuid);
+
+    ret = cne_check_registration();
+    if (!ret) {
+        tst_error("Check registration failed after registering thread with CNE");
+        goto err;
+    } else
+        tst_ok("PASS --- TEST: Thread is registered with CNE");
 
     cuid = cne_entry_uid();
     if (tuid != cuid) {


### PR DESCRIPTION
- This function checks if calling thread is registered with CNE.
- Update test cne.
- Update Rust CNE library register_thread() function.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>