### PR TITLE
Write generated bindings from build.rs in OUT directory.

### DIFF
--- a/lang/rs/bindings/cne-sys/build.rs
+++ b/lang/rs/bindings/cne-sys/build.rs
@@ -110,9 +110,8 @@ fn main() {
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
 
-    // Write the bindings to the $CARGO_MANIFEST_DIR/src/bindings.rs file.
-    let mut out_path_manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    out_path_manifest.push("src");
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path_manifest = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path_manifest.join("bindings.rs"))
         .expect("Couldn't write bindings!");

--- a/lang/rs/bindings/cne-sys/src/bindings.rs
+++ b/lang/rs/bindings/cne-sys/src/bindings.rs
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2020-2022 Intel Corporation.
+ */
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+#![allow(improper_ctypes)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/lang/rs/bindings/cne-sys/src/lib.rs
+++ b/lang/rs/bindings/cne-sys/src/lib.rs
@@ -14,11 +14,6 @@
 //!
 //! Also see the high-level CNE API crate for CNDP [GitHub](https://github.com/CloudNativeDataPlane/cndp/tree/main/lang/rs/apis/cne)
 
-#[allow(non_upper_case_globals)]
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
-#[allow(dead_code)]
-#[allow(improper_ctypes)]
 pub mod bindings;
 
 #[cfg(test)]


### PR DESCRIPTION
Rust cargo publish doesn't allow source directory to be modified by build.rs. If we do a dry run for cargo publish we will get following error. "Build scripts should not modify anything outside of OUT_DIR." So write generated bindings file in build.rs in OUT directory.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>