### PR TITLE
xskdev: revert b98a35d.

### DIFF
--- a/lib/core/xskdev/xskdev.c
+++ b/lib/core/xskdev/xskdev.c
@@ -304,11 +304,7 @@ __get_mbuf_rx_aligned(void *_xi, void *umem_addr, const struct xdp_desc *d, void
     *bufs = xsk_umem__get_data(umem_addr, (uint64_t)addr + xi->buf_mgmt.pool_header_sz);
 
     xskdev_buf_set_data_len(xi, *bufs, d->len);
-#if USE_LIBBPF_8
-    xskdev_buf_set_data(xi, *bufs, offset);
-#else
     xskdev_buf_set_data(xi, *bufs, offset - xi->buf_mgmt.buf_headroom);
-#endif
 
     return d->len;
 }


### PR DESCRIPTION
This reverts xskdev changes in commit b98a35d. Tested with libxdp:
1.2.4, 1.2.5, 1.2.6. This is not an issue for cnet or txgen.

I've done quite a bit of testing and I can't find the combination of libraries that was causing the issue.