### PR TITLE
fix up performance drop for FQ

### DIFF
--- a/examples/cndpfwd/main.c
+++ b/examples/cndpfwd/main.c
@@ -225,7 +225,7 @@ _txonly_test(jcfg_lport_t *lport, struct fwd_info *fwd)
         pd->tx_overrun += n;
     }
 
-    return 0;
+    return n_pkts;
 }
 
 static int
@@ -288,7 +288,7 @@ _txonly_rx_test(jcfg_lport_t *lport, struct fwd_info *fwd)
         pd->tx_overrun += n;
     }
 
-    return 0;
+    return n_pkts;
 }
 
 static void

--- a/examples/cndpfwd/stats.c
+++ b/examples/cndpfwd/stats.c
@@ -123,9 +123,11 @@ print_port_stats(int lport_id, struct fwd_port *p, struct fwd_info *fwd)
         prt_cnt(skip, col, stats.rx_rcvd_count, CYAN_TYPE);
         prt_cnt(skip, col, stats.rx_burst_called, CYAN_TYPE);
 
+        prt_cnt(skip, col, stats.fq_add_called, CYAN_TYPE);
         prt_cnt(skip, col, stats.fq_add_count, CYAN_TYPE);
-        prt_cnt(skip, col, stats.fq_alloc_failed, RED_TYPE);
-        prt_cnt(skip, col, stats.fq_buf_freed, CYAN_TYPE);
+        prt_cnt(skip, col, stats.fq_full, CYAN_TYPE);
+        prt_cnt(skip, col, stats.fq_alloc_zero, CYAN_TYPE);
+        prt_cnt(skip, col, stats.fq_reserve_failed, CYAN_TYPE);
 
         prt_cnt(skip, col, stats.tx_kicks, CYAN_TYPE);
         prt_cnt(skip, col, stats.tx_kick_failed, RED_TYPE);
@@ -216,9 +218,11 @@ struct stats_line {
     {COL_LINE | DBG_LINE, "[green]%-*s [yellow]|[]\n", "   Rcvd Count"},
     {COL_LINE | DBG_LINE, "[green]%-*s [yellow]|[]\n", "   Burst Called"},
 
-    {HDR_LINE | DBG_LINE, "[yellow:-:italic]%-*s [cyan:-:-]%-*s [yellow]|[]\n", "Added", "FQ"},
-    {COL_LINE | DBG_LINE, "[green]%-*s [yellow]|[]\n", "   Alloc Failed"},
-    {COL_LINE | DBG_LINE, "[green]%-*s [yellow]|[]\n", "   Buf Freed"},
+    {HDR_LINE | DBG_LINE, "[yellow:-:italic]%-*s [cyan:-:-]%-*s [yellow]|[]\n", "Called", "FQ"},
+    {COL_LINE | DBG_LINE, "[green]%-*s [yellow]|[]\n", "   Added"},
+    {COL_LINE | DBG_LINE, "[green]%-*s [yellow]|[]\n", "   Full"},
+    {COL_LINE | DBG_LINE, "[green]%-*s [yellow]|[]\n", "   Alloc Zero"},
+    {COL_LINE | DBG_LINE, "[green]%-*s [yellow]|[]\n", "   Rsvd Failed"},
 
     {HDR_LINE | DBG_LINE, "[yellow:-:italic]%-*s [cyan:-:-]%-*s [yellow]|[]\n", "Kicks", "TX"},
     {COL_LINE | DBG_LINE, "[green]%-*s [yellow]|[]\n", "   Kicks Failed"},

--- a/lib/include/cne_lport.h
+++ b/lib/include/cne_lport.h
@@ -121,18 +121,20 @@ typedef struct lport_stats {
     uint64_t tx_ring_empty;      /**< Number of times the TX ring is empty */
 #endif
     /* FQ debug stats */
-    uint64_t fq_add_count;    /**< Number of FQ buffers added */
-    uint64_t fq_alloc_failed; /**< Number of buffer allocations failed */
-    uint64_t fq_buf_freed;    /**< Number of buffers freed from FQ add */
-                              /* TX debug stats */
-    uint64_t tx_kicks;        /**< Number of times we need to do a tx kick */
-    uint64_t tx_kick_failed;  /**< Number of times the tx kick failed */
-    uint64_t tx_kick_again;   /**< Number of times tx kick needed to be restarted */
-    uint64_t tx_ring_full;    /**< TX Ring is full */
-    uint64_t tx_copied;       /**< TX packet was copied */
-                              /* CQ debug stats */
-    uint64_t cq_empty;        /**< CQ is empty counter */
-    uint64_t cq_buf_freed;    /**< Number of buffers freed */
+    uint64_t fq_add_called;     /**< Number of FQ add called */
+    uint64_t fq_add_count;      /**< Number of FQ buffers added */
+    uint64_t fq_full;           /**< Not enough entries */
+    uint64_t fq_alloc_zero;     /**< Number of times xskdev_buf_alloc returned zero */
+    uint64_t fq_reserve_failed; /**< Number of time reserve FQ call failed */
+    /* TX debug stats */
+    uint64_t tx_kicks;       /**< Number of times we need to do a tx kick */
+    uint64_t tx_kick_failed; /**< Number of times the tx kick failed */
+    uint64_t tx_kick_again;  /**< Number of times tx kick needed to be restarted */
+    uint64_t tx_ring_full;   /**< TX Ring is full */
+    uint64_t tx_copied;      /**< TX packet was copied */
+                             /* CQ debug stats */
+    uint64_t cq_empty;       /**< CQ is empty counter */
+    uint64_t cq_buf_freed;   /**< Number of buffers freed */
 } lport_stats_t;
 
 #ifdef __cplusplus

--- a/lib/usr/app/metrics/metrics.c
+++ b/lib/usr/app/metrics/metrics.c
@@ -124,8 +124,11 @@ metrics_port_stats(metrics_client_t *c, char *name, lport_stats_t *s)
     metrics_append(c, ",\"%s_n_rx_count\":%ld", name, s->rx_rcvd_count);
     metrics_append(c, ",\"%s_n_rx_burst_called\":%ld", name, s->rx_burst_called);
 
+    metrics_append(c, ",\"%s_n_fq_add_called\":%ld", name, s->fq_add_called);
     metrics_append(c, ",\"%s_n_fq_add_count\":%ld", name, s->fq_add_count);
-    metrics_append(c, ",\"%s_n_fq_alloc_failed\":%ld", name, s->fq_alloc_failed);
+    metrics_append(c, ",\"%s_n_fq_full\":%ld", name, s->fq_full);
+    metrics_append(c, ",\"%s_n_fq_alloc_zero\":%ld", name, s->fq_alloc_zero);
+    metrics_append(c, ",\"%s_n_fq_reserve_failed\":%ld", name, s->fq_reserve_failed);
 
     metrics_append(c, ",\"%s_n_tx_kicks\":%ld", name, s->tx_kicks);
     metrics_append(c, ",\"%s_n_tx_failed_kicks\":%ld", name, s->tx_kick_failed);


### PR DESCRIPTION
The FQ routine fq_add() was allocating mbufs and freeing them when the FQ was full, this caused a performance drop. The code will now determine if the FQ needs mbufs and how many before allocating the mbufs from the pktmbuf pool.

During testing of tx only cndpfwd and the idlemgr was enabled causing the thread to sleep due to no RX traffic. Modified the txonly routine to return 1 to make it look like the port was active to idlemgr.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>