### PR TITLE
Enable lto for Rust build which improves performance.

### DIFF
--- a/lang/rs/Cargo.toml
+++ b/lang/rs/Cargo.toml
@@ -11,3 +11,6 @@ members = [
     "examples/fwd"
 ]
 
+[profile.release]
+lto = true
+


### PR DESCRIPTION
Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>