### PR TITLE
Build both static and shared libraries for PMDs.

### DIFF
--- a/lib/core/pmds/net/af_packet/meson.build
+++ b/lib/core/pmds/net/af_packet/meson.build
@@ -6,7 +6,7 @@ headers = files('pmd_af_packet.h')
 
 deps += [cne, mempool, mmap, pktdev, pktmbuf]
 
-libpmd_af_packet = library('pmd_af_packet', sources, install: true, dependencies: deps)
+libpmd_af_packet = both_libraries('pmd_af_packet', sources, install: true, dependencies: deps)
 pmd_af_packet = declare_dependency(link_with: libpmd_af_packet, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_af_packet

--- a/lib/core/pmds/net/af_xdp/meson.build
+++ b/lib/core/pmds/net/af_xdp/meson.build
@@ -6,7 +6,7 @@ headers = files('pmd_af_xdp.h')
 
 deps += [mmap, cne, kvargs, pktdev, mempool, pktmbuf, ring, uds, xskdev, bpf_dep]
 
-libpmd_af_xdp = library('pmd_af_xdp', sources, install: true, dependencies: deps)
+libpmd_af_xdp = both_libraries('pmd_af_xdp', sources, install: true, dependencies: deps)
 pmd_af_xdp = declare_dependency(link_with: libpmd_af_xdp, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_af_xdp

--- a/lib/core/pmds/net/memif/meson.build
+++ b/lib/core/pmds/net/memif/meson.build
@@ -7,7 +7,7 @@ headers = files('pmd_memif_socket.h', 'memif_socket.h', 'memif.h')
 
 deps += [mmap, cne, kvargs, events, pktdev, mempool, pktmbuf, ring, hash]
 
-libpmd_memif = library('pmd_memif', sources, install:true, dependencies: deps)
+libpmd_memif = both_libraries('pmd_memif', sources, install:true, dependencies: deps)
 pmd_memif = declare_dependency(link_with: libpmd_memif, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_memif

--- a/lib/core/pmds/net/null/meson.build
+++ b/lib/core/pmds/net/null/meson.build
@@ -6,7 +6,7 @@ headers = files('pmd_null.h')
 
 deps += [cne, mempool, mmap, pktdev, pktmbuf]
 
-libpmd_null = library('pmd_null', sources, install: true, dependencies: deps)
+libpmd_null = both_libraries('pmd_null', sources, install: true, dependencies: deps)
 pmd_null = declare_dependency(link_with: libpmd_null, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_null

--- a/lib/core/pmds/net/ring/meson.build
+++ b/lib/core/pmds/net/ring/meson.build
@@ -6,7 +6,7 @@ headers = files('pmd_ring.h')
 
 deps += [pktdev, ring, pktmbuf, mmap, mempool, cne, kvargs]
 
-libpmd_ring = library('pmd_ring', sources, install: true, dependencies: deps)
+libpmd_ring = both_libraries('pmd_ring', sources, install: true, dependencies: deps)
 pmd_ring = declare_dependency(link_with: libpmd_ring, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_ring

--- a/lib/core/pmds/net/tap/meson.build
+++ b/lib/core/pmds/net/tap/meson.build
@@ -6,7 +6,7 @@ headers = files('pmd_tap.h')
 
 deps += [cne, mempool, mmap, pktdev, pktmbuf, tun]
 
-libpmd_tap = library('pmd_tap', sources, install: true, dependencies: deps)
+libpmd_tap = both_libraries('pmd_tap', sources, install: true, dependencies: deps)
 pmd_tap = declare_dependency(link_with: libpmd_tap, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_tap


### PR DESCRIPTION
Build both static and shared libraries by default for PMDs.

CNDP applications might require to link pmd library using "--whole-archive". For example, this option can used by Rust binaries to link pmd_af_xdp static library. Currently only shared libraries are built by default, though pmds needs to be linked 
as "--whole-archive".

If "--whole-archive" is not used while linking, then Rust applications need to use LD_PRELOAD=libpmd_af_xdp.so while running the application. Using "--whole-archive" forces linker to include every object file from the pmd and application can run normally without calling LD_PRELOAD.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>