### PR TITLE
Remove LD_PRELOAD of pmd library for Rust applications

### DIFF
--- a/lang/rs/apis/cne/run_cne_test.sh
+++ b/lang/rs/apis/cne/run_cne_test.sh
@@ -4,13 +4,11 @@
 
 # Build CNDP and install (sudo CNE_DEST_DIR=/ make install) before running this script.
 
-# Need to LD_PRELOAD libpmd_af_xdp.so since Rust binary doesn't include it and is required for CNDP applications.
-# Including libpmd_af_xdp.so as whole-archive during linking of rust binary doesn't seem to work.
 CRATE=cndp-cne
 
 # Build (This will do incremental build)
 cargo build
 
-sudo -E  LD_LIBRARY_PATH="$LD_LIBRARY_PATH" LD_PRELOAD="$LD_LIBRARY_PATH"/libpmd_af_xdp.so RUST_LOG=debug "$(which cargo)" test -p "$CRATE" --tests  -- --show-output --test-threads=1
+sudo -E  LD_LIBRARY_PATH="$LD_LIBRARY_PATH" RUST_LOG=debug "$(which cargo)" test -p "$CRATE" --tests  -- --show-output --test-threads=1
 
 stty sane

--- a/lang/rs/apis/cne/run_loopback.sh
+++ b/lang/rs/apis/cne/run_loopback.sh
@@ -21,8 +21,6 @@ PORT=${2:-0}
 # group name should be present in lcore-groups in jsonc file.
 CORE=${3:-"group0"}
 
-# Need to LD_PRELOAD libpmd_af_xdp.so since Rust binary doesn't include it and is required for applications.
-# Including libpmd_af_xdp.so as whole-archive during linking of rust binary doesn't seem to work.
-sudo -E LD_LIBRARY_PATH="$LD_LIBRARY_PATH" LD_PRELOAD="$LD_LIBRARY_PATH"/libpmd_af_xdp.so RUST_LOG=info "$(which cargo)" run -p "$CRATE" --release -- -c "$CONFIG" -p "$PORT" -a "$CORE"
+sudo -E LD_LIBRARY_PATH="$LD_LIBRARY_PATH" RUST_LOG=info "$(which cargo)" run -p "$CRATE" --release -- -c "$CONFIG" -p "$PORT" -a "$CORE"
 
 stty sane

--- a/lang/rs/apis/cne/src/config.rs
+++ b/lang/rs/apis/cne/src/config.rs
@@ -195,14 +195,13 @@ impl Config {
             CneError::ConfigError(format!("Port {} is not configured", port_index))
         })?;
 
-        let port = match lport.pkt_api {
+        match lport.pkt_api {
             Some(pkt_api) => Ok(Port::new(port_index, pkt_api)),
             None => {
                 let err_msg = format!("Port {} is not configured", port_index);
                 Err(CneError::PortError(err_msg))
             }
-        };
-        port
+        }
     }
 
     #[allow(dead_code)]

--- a/lang/rs/bindings/cne-sys/build.rs
+++ b/lang/rs/bindings/cne-sys/build.rs
@@ -53,6 +53,11 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", libcndp_so_path);
     println!("cargo:rustc-link-lib=cndp");
 
+    // CNDP pmd_af_xdp static library should be linked as whole archive.
+    // This will avoid preload PMD (eg: LD_PRELOAD=libpmd_af_xdp.so) while running
+    // CNDP CNE Rust binaries.
+    println!("cargo:rustc-link-lib=static:-bundle,+whole-archive=pmd_af_xdp");
+
     // Tell cargo to invalidate the built crate whenever the .h or .c or meson.build files in bindings directory changes.
     let bindings_parse_files = fs::read_dir("./src/c_src")
         .expect("Error reading directory")

--- a/lang/rs/bindings/cne-sys/src/bindings.rs
+++ b/lang/rs/bindings/cne-sys/src/bindings.rs
@@ -2,6 +2,8 @@
  * Copyright (c) 2020-2022 Intel Corporation.
  */
 
+#![allow(unknown_lints)]
+#![allow(clippy::all)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/lang/rs/examples/echo_server/run_echo_server.sh
+++ b/lang/rs/examples/echo_server/run_echo_server.sh
@@ -39,9 +39,7 @@ elif [ "$MODE" == "cne" ]; then
     # group name should be present in lcore-groups in jsonc file.
     CORE=${3:-"group0"}
 
-    # Need to LD_PRELOAD libpmd_af_xdp.so since Rust binary doesn't include it and is required for applications.
-    # Including libpmd_af_xdp.so as whole-archive during linking of rust binary doesn't seem to work.
-    sudo -E LD_LIBRARY_PATH="$LD_LIBRARY_PATH" LD_PRELOAD="$LD_LIBRARY_PATH"/libpmd_af_xdp.so RUST_LOG=info "$(which cargo)" run -p "$CRATE" --release -- "$MODE" -c "$CONFIG" -p "$PORT" -b "$BURST" -a "$CORE"
+    sudo -E LD_LIBRARY_PATH="$LD_LIBRARY_PATH" RUST_LOG=info "$(which cargo)" run -p "$CRATE" --release -- "$MODE" -c "$CONFIG" -p "$PORT" -b "$BURST" -a "$CORE"
 else
     cargo run -p "$CRATE" --release -- help
 fi

--- a/lang/rs/examples/fwd/run_fwd.sh
+++ b/lang/rs/examples/fwd/run_fwd.sh
@@ -17,8 +17,6 @@ CONFIG=${1:-"./fwd.jsonc"}
 # Mode - drop,rx-only,tx-only,lb,fwd. Default is drop.
 MODE=${2:-"drop"}
 
-# Need to LD_PRELOAD libpmd_af_xdp.so since Rust binary doesn't include it and is required for applications.
-# Including libpmd_af_xdp.so as whole-archive during linking of rust binary doesn't seem to work.
-sudo -E LD_LIBRARY_PATH="$LD_LIBRARY_PATH" LD_PRELOAD="$LD_LIBRARY_PATH"/libpmd_af_xdp.so RUST_LOG=info "$(which cargo)" run -p "$CRATE" --release -- -c "$CONFIG" "$MODE"
+sudo -E LD_LIBRARY_PATH="$LD_LIBRARY_PATH" RUST_LOG=info "$(which cargo)" run -p "$CRATE" --release -- -c "$CONFIG" "$MODE"
 
 stty sane


### PR DESCRIPTION
- Use "whole-archive" to link pmd_af_xdp library and avoid LD_PRELOAD.
- Ignore cargo clippy lint for generated bindings file.
- Fix lint in Rust CNE.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>