### PR TITLE
Build Rust example application in Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore target directory in lang/rs
+lang/rs/target

--- a/containerization/docker/fedora/Dockerfile
+++ b/containerization/docker/fedora/Dockerfile
@@ -38,4 +38,18 @@ RUN make && make install
 WORKDIR /cndp/lang/go/stats/prometheus
 RUN go build prometheus.go
 
+# Install Rust bindgen dependencies.
+RUN dnf -y install clang-devel curl
+
+# Install Rust and Cargo.
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Set Cargo path.
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Build and install Rust packet fwd example application.
+# 'fwd' binary will be installed in /cndp/usr/local/bin
+WORKDIR /cndp/lang/rs
+RUN CNDP_INSTALL_PATH="/cndp" cargo install --root /cndp/usr/local/ --path examples/fwd
+
 WORKDIR /cndp

--- a/containerization/docker/ubuntu/Dockerfile
+++ b/containerization/docker/ubuntu/Dockerfile
@@ -44,6 +44,20 @@ RUN make && make install
 WORKDIR /cndp/lang/go/stats/prometheus
 RUN go build prometheus.go
 
+# Install Rust bindgen dependencies.
+RUN apt-get install -y \
+    llvm-dev libclang-dev clang curl
+
+# Install Rust and Cargo.
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Set Cargo path.
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Build and install Rust packet fwd example application.
+WORKDIR /cndp/lang/rs
+RUN CNDP_INSTALL_PATH="/cndp" cargo install --root /cndp/usr/local/ --path examples/fwd
+
 # Setup container to run CNDP applications
 FROM ubuntu:22.04
 
@@ -61,6 +75,7 @@ RUN apt-get update && apt-get install -y \
 
 # Copy artifacts from the build container
 COPY --from=build /cndp/usr/local/bin/cndpfwd /usr/bin/
+COPY --from=build /cndp/usr/local/bin/fwd /usr/bin
 COPY --from=build /cndp/usr/local/lib/x86_64-linux-gnu/*.so /usr/lib/
 COPY --from=build /cndp/lang/go/stats/prometheus/prometheus /usr/bin/
 COPY --from=build /usr/lib64/libbpf.so.0 /usr/lib/


### PR DESCRIPTION
- Build Rust packet fwd application in Dockerfile
- Ignore Rust target build directory from docker context.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>