### PR TITLE
Add Rust compiler version.

### DIFF
--- a/lang/rs/README.md
+++ b/lang/rs/README.md
@@ -24,7 +24,8 @@ Following are the steps required to build Rust bindings, high level APIs and exa
         Ubuntu: `export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/x86_64-linux-gnu`
         Fedora: `export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib64`
 
-3. Install [Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html). Rust version >= 1.56.0 is required.
+3. Install [Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html). Rust version >= 1.63.0 is required.
+   If you have a previous version of Rust installed via rustup, run `rustup update stable` to get latest version.
 
 4. Install dependencies needed by rust bindgen tool. Please refer rust bindgen [requirements](https://rust-lang.github.io/rust-bindgen/requirements.html) for details.
 

--- a/lang/rs/apis/cne/README.md
+++ b/lang/rs/apis/cne/README.md
@@ -29,7 +29,7 @@ Following are the steps required to build this library and run test cases.
 
 4. `cd lang/rs/apis/cne`
 
-5. Build CNE Rust high level crate. Rust version >= 1.56.0 is required.
+5. Build CNE Rust high level crate. Rust version >= 1.63.0 is required.
    1. If CNDP is installed in a system wide path run `cargo build`.
    2. If CNDP is installed in a custom location run `CNDP_INSTALL_PATH=<path> cargo build`.
       Here path refers to the absolute path of top-level directory where CNDP is installed.

--- a/lang/rs/bindings/cne-sys/Cargo.toml
+++ b/lang/rs/bindings/cne-sys/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.2.0"
 edition = "2021"
 license = "BSD-3-Clause"
 keywords = ["networking", "cloud native", "AF_XDP"]
+rust-version = "1.63"
 
 [lib]
 name = "cne_sys"

--- a/lang/rs/bindings/cne-sys/README.md
+++ b/lang/rs/bindings/cne-sys/README.md
@@ -28,7 +28,7 @@ Following are the steps required to build this library and run test cases.
 
 4. `cd lang/rs/bindings/cne-sys`
 
-5. Build CNE Rust bindings library. Rust version >= 1.56.0 is required.
+5. Build CNE Rust bindings library. Rust version >= 1.63.0 is required.
    1. If CNDP is installed in a system wide path run `cargo build`
    2. If CNDP is installed in a custom location run `CNDP_INSTALL_PATH=<path> cargo build`.
       Here path refers to the absolute path of top-level directory where CNDP is installed.


### PR DESCRIPTION
- Add rust-version field in Cargo.toml that tells cargo what version of the Rust language and compiler your package can be compiled with.
- Update ReadMe

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>