### PR TITLE
Fix a compiling error on RHEL/Rocky 9

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,9 +199,18 @@ endif
 
 cne_conf.set('HAS_UINTR_SUPPORT', false)
 if cc.has_argument('-muintr') and cc.get_id() == 'gcc' and cc.has_header('x86gprintrin.h')
+  ret=run_command('cat', '/etc/redhat-release', check:false)
+  os_ver = ''
+  if ( ret.returncode() == 0)
+    os_ver = ret.stdout().strip()
+  endif
+  if ( ret.returncode() == -11 or not os_ver.contains('9.0'))
     message('GCC Version: ' + cc.version())
     cne_conf.set('HAS_UINTR_SUPPORT', true)
     add_project_arguments('-muintr', language: 'c')
+  else
+    message('>>>Remove uintr')
+  endif
 endif
 
 # Check for libdlb


### PR DESCRIPTION
We got a compile error when we moved to RHEL/Rocky 9 recently, the proposed code is to disable "uintr" flag.

[20/377] Compiling C object lib/usr/slib/ibroker/libcne_ibroker.so.p/uintr_handler.c.o
FAILED: lib/usr/slib/ibroker/libcne_ibroker.so.p/uintr_handler.c.o 
cc -Ilib/usr/slib/ibroker/libcne_ibroker.so.p -Ilib/usr/slib/ibroker -I../lib/usr/slib/ibroker -I. -I.. -Ilib/include -I../lib/include -Ilib/core/osal -I../lib/core/osal -Ilib/core/log -I../lib/core/log -Ilib/core/ring -I../lib/core/ring -Ilib/usr/clib/timer -I../lib/usr/clib/timer -Ilib/core/cne -I../lib/core/cne -I/usr/include/libnl3 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -Werror -O3 -g -muintr -Wno-pedantic -Wcast-qual -Wdeprecated -Wformat-nonliteral -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wold-style-definition -Wpointer-arith -Wsign-compare -Wstrict-prototypes -Wundef -Wwrite-strings -Wno-address-of-packed-member -Wno-packed-not-aligned -Wno-missing-field-initializers -D_GNU_SOURCE -include cne_build_config.h -march=native -DCC_AVX2_SUPPORT -fPIC -MD -MQ lib/usr/slib/ibroker/libcne_ibroker.so.p/uintr_handler.c.o -MF lib/usr/slib/ibroker/libcne_ibroker.so.p/uintr_handler.c.o.d -o lib/usr/slib/ibroker/libcne_ibroker.so.p/uintr_handler.c.o -c ../lib/usr/slib/ibroker/uintr_handler.c
/tmp/ccvboPZ5.s: Assembler messages:
/tmp/ccvboPZ5.s:136: Error: no such instruction: `uiret'
[21/377] Compiling C object lib/usr/clib/nodes/libcne_nodes.so.p/pkt_drop.c.o
……
[73/377] Compiling C object lib/usr/slib/ibroker/libcne_ibroker.so.p/ibroker.c.o
FAILED: lib/usr/slib/ibroker/libcne_ibroker.so.p/ibroker.c.o 
cc -Ilib/usr/slib/ibroker/libcne_ibroker.so.p -Ilib/usr/slib/ibroker -I../lib/usr/slib/ibroker -I. -I.. -Ilib/include -I../lib/include -Ilib/core/osal -I../lib/core/osal -Ilib/core/log -I../lib/core/log -Ilib/core/ring -I../lib/core/ring -Ilib/usr/clib/timer -I../lib/usr/clib/timer -Ilib/core/cne -I../lib/core/cne -I/usr/include/libnl3 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -Werror -O3 -g -muintr -Wno-pedantic -Wcast-qual -Wdeprecated -Wformat-nonliteral -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wold-style-definition -Wpointer-arith -Wsign-compare -Wstrict-prototypes -Wundef -Wwrite-strings -Wno-address-of-packed-member -Wno-packed-not-aligned -Wno-missing-field-initializers -D_GNU_SOURCE -include cne_build_config.h -march=native -DCC_AVX2_SUPPORT -fPIC -MD -MQ lib/usr/slib/ibroker/libcne_ibroker.so.p/ibroker.c.o -MF lib/usr/slib/ibroker/libcne_ibroker.so.p/ibroker.c.o.d -o lib/usr/slib/ibroker/libcne_ibroker.so.p/ibroker.c.o -c ../lib/usr/slib/ibroker/ibroker.c
/tmp/cccltTdo.s: Assembler messages:
/tmp/cccltTdo.s:254: Error: no such instruction: `stui'

Mark Liu