### PR TITLE
Fix uintr compile on RHEL 9

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -200,9 +200,12 @@ if cc.has_header('linux/if_xdp.h')
     endif
 endif
 
+# Check whether the compiler and linker support User Interrupts. Some compilers have the -muintr
+# flag, but the assembler can fail if it does not support the instructions. Check this by testing
+# whether a simple program compiles and links.
 cne_conf.set('HAS_UINTR_SUPPORT', false)
-if cc.has_argument('-muintr') and cc.get_id() == 'gcc' and cc.has_header('x86gprintrin.h')
-    message('GCC Version: ' + cc.version())
+tp = '#include <x86gprintrin.h>\nint main() { _stui(); return 0; }'
+if cc.get_id() == 'gcc' and cc.links(tp, args: '-muintr', name: '-muintr')
     cne_conf.set('HAS_UINTR_SUPPORT', true)
     add_project_arguments('-muintr', language: 'c')
 endif


### PR DESCRIPTION
It is not enough to check for -muintr compiler flag on RHEL 9. The linker produces the following error messages:

/tmp/ccaRDbYW.s: Assembler messages:
/tmp/ccaRDbYW.s:260: Error: no such instruction: `stui' /tmp/ccaRDbYW.s:626: Error: no such instruction: `clui' /tmp/ccaRDbYW.s:754: Error: no such instruction: `senduipi %rax'

To avoid this, check to see if a simple program links. If it does, the toolchain should be able to build programs using uintr.

Signed-off-by: Jeff Shaw <jeffrey.b.shaw@intel.com>