### PR TITLE
Fix static build: Generate static library for pmds.

### DIFF
--- a/lib/core/pmds/net/af_packet/meson.build
+++ b/lib/core/pmds/net/af_packet/meson.build
@@ -6,7 +6,8 @@ headers = files('pmd_af_packet.h')
 
 deps += [cne, mempool, mmap, pktdev, pktmbuf]
 
-libpmd_af_packet = both_libraries('pmd_af_packet', sources, install: true, dependencies: deps)
+libpmd_af_packet = static_library('pmd_af_packet', sources, install: true, dependencies: deps)
+
 pmd_af_packet = declare_dependency(link_with: libpmd_af_packet, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_af_packet

--- a/lib/core/pmds/net/af_xdp/meson.build
+++ b/lib/core/pmds/net/af_xdp/meson.build
@@ -6,7 +6,8 @@ headers = files('pmd_af_xdp.h')
 
 deps += [mmap, cne, kvargs, pktdev, mempool, pktmbuf, ring, uds, xskdev, bpf_dep]
 
-libpmd_af_xdp = both_libraries('pmd_af_xdp', sources, install: true, dependencies: deps)
+libpmd_af_xdp = static_library('pmd_af_xdp', sources, install: true, dependencies: deps)
+
 pmd_af_xdp = declare_dependency(link_with: libpmd_af_xdp, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_af_xdp

--- a/lib/core/pmds/net/memif/meson.build
+++ b/lib/core/pmds/net/memif/meson.build
@@ -7,7 +7,8 @@ headers = files('pmd_memif_socket.h', 'memif_socket.h', 'memif.h')
 
 deps += [mmap, cne, kvargs, events, pktdev, mempool, pktmbuf, ring, hash]
 
-libpmd_memif = both_libraries('pmd_memif', sources, install:true, dependencies: deps)
+libpmd_memif = static_library('pmd_memif', sources, install:true, dependencies: deps)
+
 pmd_memif = declare_dependency(link_with: libpmd_memif, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_memif

--- a/lib/core/pmds/net/meson.build
+++ b/lib/core/pmds/net/meson.build
@@ -13,7 +13,9 @@ dirs = [
 foreach d:dirs
     deps = [build_cfg, include, osal, log]
 
-    enabled_libs += 'pmd_' + d
+        libname = 'pmd_' + d
+        enabled_pmd_libs += libname
+
 	subdir(d)
 
 	install_headers(headers, subdir: meson.project_name().to_lower())

--- a/lib/core/pmds/net/null/meson.build
+++ b/lib/core/pmds/net/null/meson.build
@@ -6,7 +6,8 @@ headers = files('pmd_null.h')
 
 deps += [cne, mempool, mmap, pktdev, pktmbuf]
 
-libpmd_null = both_libraries('pmd_null', sources, install: true, dependencies: deps)
+libpmd_null = static_library('pmd_null', sources, install: true, dependencies: deps)
+
 pmd_null = declare_dependency(link_with: libpmd_null, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_null

--- a/lib/core/pmds/net/ring/meson.build
+++ b/lib/core/pmds/net/ring/meson.build
@@ -6,7 +6,8 @@ headers = files('pmd_ring.h')
 
 deps += [pktdev, ring, pktmbuf, mmap, mempool, cne, kvargs]
 
-libpmd_ring = both_libraries('pmd_ring', sources, install: true, dependencies: deps)
+libpmd_ring = static_library('pmd_ring', sources, install: true, dependencies: deps)
+
 pmd_ring = declare_dependency(link_with: libpmd_ring, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_ring

--- a/lib/core/pmds/net/tap/meson.build
+++ b/lib/core/pmds/net/tap/meson.build
@@ -6,7 +6,8 @@ headers = files('pmd_tap.h')
 
 deps += [cne, mempool, mmap, pktdev, pktmbuf, tun]
 
-libpmd_tap = both_libraries('pmd_tap', sources, install: true, dependencies: deps)
+libpmd_tap = static_library('pmd_tap', sources, install: true, dependencies: deps)
+
 pmd_tap = declare_dependency(link_with: libpmd_tap, include_directories: include_directories('.'))
 
 cndp_pmds += libpmd_tap

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,7 @@ cndp_libs = []
 extra_ldflags = []
 enabled_libs = []
 cndp_pmds = []
+enabled_pmd_libs = []
 
 cne_conf = configuration_data()
 
@@ -429,19 +430,37 @@ cndp_a_name = 'libcndp.a'
 cndp_so_name = 'libcndp.so'
 
 mklib = find_program('tools/mklib.sh')
-run_command(mklib, cndp_a_name, libcndp_a, check: true)
-run_command(mklib, cndp_so_name, libcndp_so, check: true)
 
-cndp_a = custom_target('libcndp_a_target',
-    output: cndp_a_name,
-    input: join_paths('/tmp', cndp_a_name),
-    command:[find_program('cp'), '@INPUT@', cndp_a_name],
-    install_dir: join_paths('lib', 'x86_64-linux-gnu'),
-    install: true)
-cndp_so = custom_target('libcndp_so_target',
-    output: cndp_so_name,
-    input: join_paths('/tmp', cndp_so_name),
-    command:[find_program('cp'), '@INPUT@', cndp_so_name],
+if use_static_libs
+    run_command(mklib, cndp_a_name, libcndp_a, check: true)
+    cndp_a = custom_target('libcndp_a_target',
+        output: cndp_a_name,
+        input: join_paths('/tmp', cndp_a_name),
+        command:[find_program('cp'), '@INPUT@', cndp_a_name],
+        install_dir: join_paths('lib', 'x86_64-linux-gnu'),
+        install: true)
+else
+    run_command(mklib, cndp_so_name, libcndp_so, check: true)
+    cndp_so = custom_target('libcndp_so_target',
+        output: cndp_so_name,
+        input: join_paths('/tmp', cndp_so_name),
+        command:[find_program('cp'), '@INPUT@', cndp_so_name],
+        install_dir: join_paths('lib', 'x86_64-linux-gnu'),
+        install: true)
+endif
+
+# Generate libcndp_pmds.a
+libcndp_pmds_a = []
+foreach lib:enabled_pmd_libs
+    libcndp_pmds_a += 'lib' + lib + '.a '
+endforeach
+
+cndp_pmds_a_name = 'libcndp_pmds.a'
+run_command(mklib, cndp_pmds_a_name, libcndp_pmds_a, check: true)
+cndp_pmds_a = custom_target('libcndp_pmds_a_target',
+    output: cndp_pmds_a_name,
+    input: join_paths('/tmp', cndp_pmds_a_name),
+    command:[find_program('cp'), '@INPUT@', cndp_pmds_a_name],
     install_dir: join_paths('lib', 'x86_64-linux-gnu'),
     install: true)
 


### PR DESCRIPTION
pmds uses constructor which runs before main function to register pmds. linker doesn't include any symbols from PMDs in the application binary if application doesn't explicitly use any symbols from PMD library. CNDP applications need not directly call any functions in pmd library and pmd library symbols is not included in application by linker. So pmds should be linked as static whole-archive. 

Remove pmds libraries from libcndp.so and libcndp.a.
Generate libcndp_pmds.a which groups all PMD libraries.

Build works in both cases: "make rebuild" and "make static_build=1 rebuild".

Note: shared libraries are still generated for other CNDP CNE libraries in default non static build. For PMDs, generate only static libraries.

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>