### PR TITLE
fix go executables using static pmds

### DIFF
--- a/lang/go/bindings/cne/cgo_config.go
+++ b/lang/go/bindings/cne/cgo_config.go
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2022 Intel Corporation.
+ */
+
+package cne
+
+/*
+#cgo CFLAGS: -I../../../../usr/local/include/cndp
+#cgo LDFLAGS: -L../../../../usr/local/lib/x86_64-linux-gnu -Wl,--whole-archive -lcndp_pmds -Wl,--no-whole-archive -lcndp -lbsd
+*/
+import "C"

--- a/lang/go/bindings/cne/jcfg.go
+++ b/lang/go/bindings/cne/jcfg.go
@@ -6,9 +6,6 @@
 package cne
 
 /*
-#cgo CFLAGS: -I../../../../usr/local/include/cndp
-#cgo LDFLAGS: -L../../../../usr/local/lib/x86_64-linux-gnu -lcndp -lbsd
-
 #include <cne_mmap.h>
 #include <pktmbuf.h>
 #include <pktdev.h>

--- a/lang/go/bindings/cne/lport.go
+++ b/lang/go/bindings/cne/lport.go
@@ -5,9 +5,6 @@
 package cne
 
 /*
-#cgo CFLAGS: -I../../../../usr/local/include/cndp
-#cgo LDFLAGS: -L../../../../usr/local/lib/x86_64-linux-gnu -lcndp -lbsd
-
 #include <cne.h>
 #include <pktmbuf.h>
 #include <pktdev.h>

--- a/lang/go/bindings/cne/lring.go
+++ b/lang/go/bindings/cne/lring.go
@@ -5,9 +5,6 @@
 package cne
 
 /*
-#cgo CFLAGS: -I../../../../usr/local/include/cndp
-#cgo LDFLAGS: -L../../../../usr/local/lib/x86_64-linux-gnu -lcndp
-
 #include <stdint.h>
 #include <cne_ring.h>
 

--- a/lang/go/bindings/cne/msgchan.go
+++ b/lang/go/bindings/cne/msgchan.go
@@ -5,9 +5,6 @@
 package cne
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/../../../../usr/local/include/cndp
-#cgo LDFLAGS: -L${SRCDIR}/../../../../usr/local/lib/x86_64-linux-gnu -lcndp
-
 #include <cne_common.h>
 #include <msgchan.h>
 */

--- a/lang/go/bindings/cne/packet.go
+++ b/lang/go/bindings/cne/packet.go
@@ -5,9 +5,6 @@
 package cne
 
 /*
-#cgo CFLAGS: -I../../../../usr/local/include/cndp
-#cgo LDFLAGS: -L../../../../usr/local/lib/x86_64-linux-gnu -lcndp
-
 #include <cne_common.h>
 #include <pktmbuf.h>
 #include <pktdev.h>

--- a/lang/go/bindings/cne/run_test
+++ b/lang/go/bindings/cne/run_test
@@ -3,8 +3,10 @@
 cdir=$(pwd)
 PROJECT_PATH="${cdir}/../../../.."
 
-precmd="sudo -E LD_LIBRARY_PATH=$PROJECT_PATH/usr/local/lib/x86_64-linux-gnu LD_PRELOAD=$PROJECT_PATH/usr/local/lib/x86_64-linux-gnu/libpmd_af_xdp.so"
+precmd="sudo -E LD_LIBRARY_PATH=$PROJECT_PATH/usr/local/lib/x86_64-linux-gnu"
 cmdstring="$precmd ./cne.test -test.v -config ../examples/fwd/fwd.jsonc"
+
+go env -w CGO_LDFLAGS_ALLOW='-Wl,--(?:no-)?whole-archive'
 
 function go_tidy() {
     go mod tidy

--- a/lang/go/bindings/cne/system.go
+++ b/lang/go/bindings/cne/system.go
@@ -6,9 +6,6 @@
 package cne
 
 /*
-#cgo CFLAGS: -I../../../../usr/local/include/cndp
-#cgo LDFLAGS: -L../../../../usr/local/lib/x86_64-linux-gnu -lcndp -lbsd
-
 #include <cne.h>
 #include <cne_mmap.h>
 #include <pktmbuf.h>

--- a/lang/go/bindings/cne/umem.go
+++ b/lang/go/bindings/cne/umem.go
@@ -5,9 +5,6 @@
 package cne
 
 /*
-#cgo CFLAGS: -I../../../../usr/local/include/cndp
-#cgo LDFLAGS: -L../../../../usr/local/lib/x86_64-linux-gnu -lcndp -lbsd
-
 #include <cne.h>
 #include <cne_mmap.h>
 #include <pktmbuf.h>

--- a/lang/go/bindings/examples/fwd/run_fwd
+++ b/lang/go/bindings/examples/fwd/run_fwd
@@ -3,8 +3,8 @@
 cdir=$(pwd)
 PROJECT_PATH="${cdir}/../../../../.."
 
-cmdstring="sudo -E LD_LIBRARY_PATH=$PROJECT_PATH/usr/local/lib/x86_64-linux-gnu \
-    LD_PRELOAD=$PROJECT_PATH/usr/local/lib/x86_64-linux-gnu/libpmd_af_xdp.so ./fwd $*"
+cmdstring="sudo -E LD_LIBRARY_PATH=$PROJECT_PATH/usr/local/lib/x86_64-linux-gnu ./fwd $*"
+go env -w CGO_LDFLAGS_ALLOW='-Wl,--(?:no-)?whole-archive'
 
 go mod tidy
 rc=$?

--- a/lang/go/bindings/examples/tests/test_cne
+++ b/lang/go/bindings/examples/tests/test_cne
@@ -1,2 +1,3 @@
+go env -w CGO_LDFLAGS_ALLOW='-Wl,--(?:no-)?whole-archive'
 (go mod tidy && LD_LIBRARY_PATH=/work/projects/intel/networking.dataplane/cndp/usr/local/lib/x86_64-linux-gnu go test -v)
 stty sane

--- a/lib/core/pmds/tun/meson.build
+++ b/lib/core/pmds/tun/meson.build
@@ -9,4 +9,5 @@ deps += [include]
 libtun = library('tun', sources, install: true, dependencies: deps)
 tun = declare_dependency(link_with: libtun, include_directories: include_directories('.'))
 
+enabled_libs += 'tun'
 cndp_libs += libtun


### PR DESCRIPTION
The go code examples and tests were failing because of the PMDs are now static libraries. The problem turns out that building cgo code with --whole-archive is not allowed unless you enable the CGO_LDFLAGS_ALLOW environment variable before building.

Also a number of the binding go files included CGO options multiple times, which is not required. We only need to have the CGO options once per package. Moved the CGO directives into a single file cgo_config.go then removed these lines from the rest of the files.

Make sure the TUN library is included in the libcndp.so/.a files and remove it from the libcndp_pmds.a file. The lib/core/pmds/tun library is not a PMD.

Tested the test routines and the examples/fwd code as shared objects. Turns out having static go binaries is complex with CGO and the go test command will not accept static linking.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>