### PR TITLE
call cne_init routine to initialize subsystem

### DIFF
--- a/lang/go/bindings/cne/system.go
+++ b/lang/go/bindings/cne/system.go
@@ -56,6 +56,20 @@ func (sys *System) initializeSystem() error {
 	return nil
 }
 
+// InitCNE initializes the CNE system and returns error on failure.
+//
+// The cne_init() is also called from OpenWithConfig(), which means
+// this routine does not need to be called if OpenWith*() routines
+// are used. It is OK to call this routine multiple times as it is
+// protected to only initialize once.
+func InitCNE() error {
+
+	if C.cne_init() < 0 {
+		return fmt.Errorf("error initializing CNE subsystem")
+	}
+	return nil
+}
+
 // OpenWithConfig by passing in a initialized cne.Config structure
 func OpenWithConfig(cfg *Config) (*System, error) {
 	if err := cfg.validateConfig(); err != nil {
@@ -66,6 +80,10 @@ func OpenWithConfig(cfg *Config) (*System, error) {
 	sys.tidMap = make(map[string]*int)
 	sys.groupSet = make(map[string]*unix.CPUSet)
 	sys.oldSet = make(map[string]*unix.CPUSet)
+
+	if err := InitCNE(); err != nil {
+		return nil, err
+	}
 
 	// create cpu sets for lcore groups
 	for group, cores := range cfg.LCoreGroupData {

--- a/lang/go/bindings/examples/tests/cne_test.go
+++ b/lang/go/bindings/examples/tests/cne_test.go
@@ -21,6 +21,11 @@ var (
 	LoopCount     int64  = 500000
 )
 
+func TestMsgChanStart(t *testing.T) {
+
+	cne.InitCNE()
+}
+
 func TestMsgChan(t *testing.T) {
 
 	g := Goblin(t)
@@ -78,6 +83,16 @@ func TestMsgChan(t *testing.T) {
 			g.Assert(recv == s.RecvRing).IsTrue(fmt.Sprintf("MsgChannel Recv Pointer %v != %v", recv, s.RecvRing))
 			g.Assert(send == s.SendRing).IsTrue(fmt.Sprintf("MsgChannel Recv Pointer %v != %v", recv, s.SendRing))
 		})
+		g.It("MsgChannel Info", func() {
+			mc, err := cne.NewMsgChannel(msgChanName, msgChanSize)
+			g.Assert(err == nil).IsTrue(fmt.Sprintf("NewMsgChannel error: %v", err))
+
+			s := mc.Info()
+
+			g.Assert(s != nil).IsTrue(fmt.Sprintf("MsgChan Info failed: %+v", s))
+
+			mc.Close()
+		})
 		g.It("MsgChannel RecvFree", func() {
 			mc, err := cne.NewMsgChannel(msgChanName, msgChanSize)
 			g.Assert(err == nil).IsTrue(fmt.Sprintf("NewMsgChannel error: %v", err))
@@ -104,6 +119,10 @@ func TestMsgChan(t *testing.T) {
 			g.Assert(uint(s) == msgChanSize-5).IsTrue(fmt.Sprintf("MsgChan Size %v != %v", s, msgChanSize-5))
 		})
 	})
+}
+
+func TestMsgChanEnd(t *testing.T) {
+
 }
 
 // Equal tells whether a and b contain the same elements.


### PR DESCRIPTION
The cne subsystem needs to be initialized and the Go code was not calling cne_init() routine. Adding a new function and calling the routine in the OpenWithConfig() routine. The tailq init routine was not being called, which will cause a failure.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>