### PR TITLE
testcne: fix ring api buffer overflow

### DIFF
--- a/test/testcne/ring_api.c
+++ b/test/testcne/ring_api.c
@@ -650,8 +650,7 @@ test_ring_thread(void *args)
     do {
         ws->function(ws);
 
-        // cne_printf("Done test function ws:%p id:%"PRIuPTR"\n", ws, ws->id);
-        rdy = epoll_wait(epfd, &ev, 2, 0);
+        rdy = epoll_wait(epfd, &ev, 1, 0);
         for (int i = 0; i < rdy; i++) {
             if (ev.events & EPOLLIN) {
                 process_supervisor_message(ev.data.ptr);


### PR DESCRIPTION
Fix the following error found by gcc 12.2.0:

ring_api.c:654:15: error: ‘epoll_wait’ writing 24 bytes into a region\
 of size 12 overflows the destination [-Werror=stringop-overflow=]
                  rdy = epoll_wait(epfd, &ev, 2, 0);

The epoll_event list contains a single element, so it is wrong to expect up to two.

Signed-off-by: Jeff Shaw <jeffrey.b.shaw@intel.com>