### PR TITLE
testcne: Fix the compilation error stringop-overread

### DIFF
--- a/test/testcne/pktdev_test.c
+++ b/test/testcne/pktdev_test.c
@@ -370,7 +370,7 @@ pktdev_main(int argc, char **argv)
 
         if (!(strcmp(tests[i], "net_ring")))
             strlcpy(ifname, "ring0", sizeof(ifname));
-        else if (!strncmp(tests[i], PMD_NET_NULL_NAME, strnlen(PMD_NET_NULL_NAME, IF_NAMESIZE)))
+        else if (!strcmp(tests[i], PMD_NET_NULL_NAME))
             strlcpy(ifname, "null0", sizeof(ifname));
         else
             strlcpy(ifname, afxdp_ifname, sizeof(ifname));


### PR DESCRIPTION
Fix the following error was found in Fedora release 36 (Thirty Six) by gcc 12.2.1 when executed "make debug".

../test/testcne/pktdev_test.c: In function ‘pktdev_main’: ../test/testcne/pktdev_test.c:373:19: error: ‘strnlen’ specified bound 16 exceeds source size 9 [-Werror=stringop-overread]
  373 |         else if (!strncmp(tests[i], PMD_NET_NULL_NAME,
      strnlen(PMD_NET_NULL_NAME, IF_NAMESIZE)))
      |
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
[278/339] Compiling C object test/testcne/test-cne.p/ring_api.c.o
ninja: build stopped: subcommand failed.
make: *** [Makefile:65: debug] Error 1