### PR TITLE
Update Ubuntu Dockerfile to clean up apt-get statements

### DIFF
--- a/containerization/docker/ubuntu/Dockerfile
+++ b/containerization/docker/ubuntu/Dockerfile
@@ -17,7 +17,12 @@ RUN apt-get update && apt-get install -y \
     libnl-cli-3-dev \
     libnuma-dev \
     libpcap-dev \
-    wget
+    wget \
+    llvm-dev \
+    libclang-dev \
+    clang \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Build and install libbpf version >=0.3.0 and <=0.6.1
 SHELL ["/bin/bash", "-c"]
@@ -44,10 +49,6 @@ RUN make && make install
 WORKDIR /cndp/lang/go/stats/prometheus
 RUN go build prometheus.go
 
-# Install Rust bindgen dependencies.
-RUN apt-get install -y \
-    llvm-dev libclang-dev clang curl
-
 # Install Rust and Cargo.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
@@ -73,7 +74,8 @@ RUN apt-get update && apt-get install -y \
     libnl-3-200 \
     libnl-cli-3-200 \
     libnuma1 \
-    libpcap0.8
+    libpcap0.8 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy artifacts from the build container
 COPY --from=build /cndp/usr/local/bin/cndpfwd /usr/bin/


### PR DESCRIPTION
Fixes #240

This commit updates the Ubuntu Dockerfile's apt-get statements to remove potential apt refresh issus and reduces
the cndp container size by ~27% (from 147MB to 107MB)

Signed-off-by: Matthew Leon <matthew.leon@intel.com>
Signed-off-by: Byron Marohn <byron.marohn@intel.com>
Signed-off-by: Stephen Weeks <stephen.weeks@intel.com>
Signed-off-by: Edmund Leemhuis <edmund.leemhuis@intel.com>