### PR TITLE
Test infrastructure improvements for several tests

### DIFF
--- a/test/testcne/hash_perf_test.c
+++ b/test/testcne/hash_perf_test.c
@@ -113,7 +113,7 @@ create_table(unsigned int with_data, unsigned int table_index, unsigned int ext)
     free_table(table_index);
     htables[table_index] = cne_hash_create(&ut_params);
     if (htables[table_index] == NULL) {
-        cne_printf("Error creating table\n");
+        tst_error("Error creating table");
         free((void *)(uintptr_t)ut_params.name);
         return -1;
     }
@@ -268,7 +268,7 @@ timed_adds(unsigned int with_hash, unsigned int with_data, unsigned int table_in
             ret = cne_hash_add_key_with_hash_data(htables[table_index], (const void *)keys[i],
                                                   signatures[i], data);
             if (ret < 0) {
-                cne_printf("H+D: Failed to add key number %u\n", i);
+                tst_error("H+D: Failed to add key number %u", i);
                 return -1;
             }
         } else if (with_hash && !with_data) {
@@ -277,13 +277,13 @@ timed_adds(unsigned int with_hash, unsigned int with_data, unsigned int table_in
             if (ret >= 0)
                 positions[i] = ret;
             else {
-                cne_printf("H: Failed to add key number %u\n", i);
+                tst_error("H: Failed to add key number %u", i);
                 return -1;
             }
         } else if (!with_hash && with_data) {
             ret = cne_hash_add_key_data(htables[table_index], (const void *)keys[i], data);
             if (ret < 0) {
-                cne_printf("D: Failed to add key number %u\n", i);
+                tst_error("D: Failed to add key number %u", i);
                 return -1;
             }
         } else {
@@ -291,7 +291,7 @@ timed_adds(unsigned int with_hash, unsigned int with_data, unsigned int table_in
             if (ret >= 0)
                 positions[i] = ret;
             else {
-                cne_printf("Failed to add key number %u\n", i);
+                tst_error("Failed to add key number %u", i);
                 return -1;
             }
         }
@@ -329,40 +329,39 @@ timed_lookups(unsigned int with_hash, unsigned int with_data, unsigned int table
                 ret = cne_hash_lookup_with_hash_data(htables[table_index], (const void *)keys[j],
                                                      signatures[j], &ret_data);
                 if (ret < 0) {
-                    cne_printf("Key number %u was not found\n", j);
+                    tst_error("Key number %u was not found", j);
                     return -1;
                 }
                 expected_data = (void *)((uintptr_t)signatures[j]);
                 if (ret_data != expected_data) {
-                    cne_printf("Data returned for key number %u is %p,"
-                               " but should be %p\n",
-                               j, ret_data, expected_data);
+                    tst_error("Data returned for key number %u is %p,"
+                              " but should be %p",
+                              j, ret_data, expected_data);
                     return -1;
                 }
             } else if (with_hash && !with_data) {
                 ret = cne_hash_lookup_with_hash(htables[table_index], (const void *)keys[j],
                                                 signatures[j]);
                 if (ret < 0 || ret != positions[j]) {
-                    cne_printf("Key looked up in %d, should be in %d\n", ret, positions[j]);
+                    tst_error("Key looked up in %d, should be in %d", ret, positions[j]);
                     return -1;
                 }
             } else if (!with_hash && with_data) {
                 ret = cne_hash_lookup_data(htables[table_index], (const void *)keys[j], &ret_data);
                 if (ret < 0) {
-                    cne_printf("Key number %u was not found\n", j);
+                    tst_error("Key number %u was not found", j);
                     return -1;
                 }
                 expected_data = (void *)((uintptr_t)signatures[j]);
                 if (ret_data != expected_data) {
-                    cne_printf("Data returned for key number %u is %p,"
-                               " but should be %p\n",
-                               j, ret_data, expected_data);
+                    tst_error("Data returned for key number %u is %p, but should be %p", j,
+                              ret_data, expected_data);
                     return -1;
                 }
             } else {
                 ret = cne_hash_lookup(htables[table_index], keys[j]);
                 if (ret < 0 || ret != positions[j]) {
-                    cne_printf("Key looked up in %d, should be in %d\n", ret, positions[j]);
+                    tst_error("Key looked up in %d, should be in %d", ret, positions[j]);
                     return -1;
                 }
             }
@@ -408,21 +407,18 @@ timed_lookups_multi(unsigned int with_hash, unsigned int with_data, unsigned int
                 ret = cne_hash_lookup_bulk_data(htables[table_index], (const void **)keys_burst,
                                                 BURST_SIZE, &hit_mask, ret_data);
                 if (ret != BURST_SIZE) {
-                    cne_printf("Expect to find %u keys,"
-                               " but found %d\n",
-                               BURST_SIZE, ret);
+                    tst_error("Expect to find %u keys, but found %d", BURST_SIZE, ret);
                     return -1;
                 }
                 for (k = 0; k < BURST_SIZE; k++) {
                     if ((hit_mask & (1ULL << k)) == 0) {
-                        cne_printf("Key number %u not found\n", j * BURST_SIZE + k);
+                        tst_error("Key number %u not found", j * BURST_SIZE + k);
                         return -1;
                     }
                     expected_data[k] = (void *)((uintptr_t)signatures[j * BURST_SIZE + k]);
                     if (ret_data[k] != expected_data[k]) {
-                        cne_printf("Data returned for key number %u is %p,"
-                                   " but should be %p\n",
-                                   j * BURST_SIZE + k, ret_data[k], expected_data[k]);
+                        tst_error("Data returned for key number %u is %p, but should be %p",
+                                  j * BURST_SIZE + k, ret_data[k], expected_data[k]);
                         return -1;
                     }
                 }
@@ -431,24 +427,18 @@ timed_lookups_multi(unsigned int with_hash, unsigned int with_data, unsigned int
                     htables[table_index], (const void **)keys_burst, &signatures[j * BURST_SIZE],
                     BURST_SIZE, &hit_mask, ret_data);
                 if (ret != BURST_SIZE) {
-                    cne_printf("Expect to find %u keys,"
-                               " but found %d\n",
-                               BURST_SIZE, ret);
+                    tst_error("Expect to find %u keys, but found %d", BURST_SIZE, ret);
                     return -1;
                 }
                 for (k = 0; k < BURST_SIZE; k++) {
                     if ((hit_mask & (1ULL << k)) == 0) {
-                        cne_printf("Key number %u"
-                                   " not found\n",
-                                   j * BURST_SIZE + k);
+                        tst_error("Key number %u not found", j * BURST_SIZE + k);
                         return -1;
                     }
                     expected_data[k] = (void *)((uintptr_t)signatures[j * BURST_SIZE + k]);
                     if (ret_data[k] != expected_data[k]) {
-                        cne_printf("Data returned for key"
-                                   " number %u is %p,"
-                                   " but should be %p\n",
-                                   j * BURST_SIZE + k, ret_data[k], expected_data[k]);
+                        tst_error("Data returned for key number %u is %p, but should be %p",
+                                  j * BURST_SIZE + k, ret_data[k], expected_data[k]);
                         return -1;
                     }
                 }
@@ -458,8 +448,8 @@ timed_lookups_multi(unsigned int with_hash, unsigned int with_data, unsigned int
                     BURST_SIZE, positions_burst);
                 for (k = 0; k < BURST_SIZE; k++) {
                     if (positions_burst[k] != positions[j * BURST_SIZE + k]) {
-                        cne_printf("Key looked up in %d, should be in %d\n", positions_burst[k],
-                                   positions[j * BURST_SIZE + k]);
+                        tst_error("Key looked up in %d, should be in %d", positions_burst[k],
+                                  positions[j * BURST_SIZE + k]);
                         return -1;
                     }
                 }
@@ -468,8 +458,8 @@ timed_lookups_multi(unsigned int with_hash, unsigned int with_data, unsigned int
                                      positions_burst);
                 for (k = 0; k < BURST_SIZE; k++) {
                     if (positions_burst[k] != positions[j * BURST_SIZE + k]) {
-                        cne_printf("Key looked up in %d, should be in %d\n", positions_burst[k],
-                                   positions[j * BURST_SIZE + k]);
+                        tst_error("Key looked up in %d, should be in %d", positions_burst[k],
+                                  positions[j * BURST_SIZE + k]);
                         return -1;
                     }
                 }
@@ -508,7 +498,7 @@ timed_deletes(unsigned int with_hash, unsigned int with_data, unsigned int table
         if (ret >= 0)
             positions[i] = ret;
         else {
-            cne_printf("Failed to delete key number %u\n", i);
+            tst_error("Failed to delete key number %u", i);
             return -1;
         }
     }
@@ -525,9 +515,6 @@ static int
 run_all_tbl_perf_tests(unsigned int with_pushes, unsigned int ext)
 {
     unsigned i, j, with_data, with_hash;
-
-    cne_printf("Measuring performance, please wait");
-    fflush(stdout);
 
     for (with_data = 0; with_data <= 1; with_data++) {
         for (i = 0; i < NUM_KEYSIZES; i++) {
@@ -552,10 +539,6 @@ run_all_tbl_perf_tests(unsigned int with_pushes, unsigned int ext)
                 if (timed_deletes(with_hash, with_data, i, ext) < 0)
                     return -1;
 
-                /* Print a dot to show progress on operations */
-                cne_printf(".");
-                fflush(stdout);
-
                 reset_table(i);
             }
             free_table(i);
@@ -566,24 +549,25 @@ run_all_tbl_perf_tests(unsigned int with_pushes, unsigned int ext)
     cne_printf("-----------------------------------\n");
     for (with_data = 0; with_data <= 1; with_data++) {
         if (with_data)
-            cne_printf("\n Operations with 8-byte data\n");
+            cne_printf("Operations with 8-byte data\n");
         else
-            cne_printf("\n Operations without data\n");
+            cne_printf("Operations without data\n");
         for (with_hash = 0; with_hash <= 1; with_hash++) {
             if (with_hash)
-                cne_printf("\nWith pre-computed hash values\n");
+                cne_printf("  With pre-computed hash values\n");
             else
-                cne_printf("\nWithout pre-computed hash values\n");
+                cne_printf("  Without pre-computed hash values\n");
 
-            cne_printf("\n%-18s%-18s%-18s%-18s%-18s\n", "Keysize", "Add", "Lookup", "Lookup_bulk",
+            cne_printf("    %-18s%-18s%-18s%-18s%-18s\n", "Keysize", "Add", "Lookup", "Lookup_bulk",
                        "Delete");
             for (i = 0; i < NUM_KEYSIZES; i++) {
-                cne_printf("%-18d", hashtest_key_lens[i]);
+                cne_printf("    %-18d", hashtest_key_lens[i]);
                 for (j = 0; j < NUM_OPERATIONS; j++)
                     cne_printf("%-18" PRIu64, cycles[i][j][with_hash][with_data]);
                 cne_printf("\n");
             }
         }
+        cne_printf("\n");
     }
     return 0;
 }
@@ -615,13 +599,13 @@ fbk_hash_perf_test(void)
 
     handle = cne_fbk_hash_create(&params);
     if (handle == NULL) {
-        cne_printf("Error creating table\n");
+        tst_error("Error creating table");
         return -1;
     }
 
     keys = calloc(ENTRIES, sizeof(*keys));
     if (keys == NULL) {
-        cne_printf("fbk hash: memory allocation for key store failed\n");
+        tst_error("fbk hash: memory allocation for key store failed");
         cne_fbk_hash_free(handle);
         return -1;
     }
@@ -640,7 +624,7 @@ fbk_hash_perf_test(void)
             break;
     }
     if (added == 0) {
-        cne_printf("Failed to add keys to key store\n");
+        tst_error("Failed to add keys to key store");
         free(keys);
         return -1;
     }
@@ -662,14 +646,14 @@ fbk_hash_perf_test(void)
         lookup_time += (double)(end - begin);
     }
 
-    cne_printf("\n\n *** FBK Hash function performance test results ***\n");
+    tst_info("FBK Hash function performance test results:");
     /*
      * The use of the 'value' variable ensures that the hash lookup is not
      * being optimised out by the compiler.
      */
     if (value != 0)
-        cne_printf("Number of ticks per lookup = %g\n",
-                   (double)lookup_time / ((double)TEST_ITERATIONS * (double)TEST_SIZE));
+        tst_info("Number of ticks per lookup = %g",
+                 (double)lookup_time / ((double)TEST_ITERATIONS * (double)TEST_SIZE));
 
     cne_fbk_hash_free(handle);
     free(keys);
@@ -680,21 +664,22 @@ fbk_hash_perf_test(void)
 static int
 test_hash_perf(void)
 {
-    unsigned int with_pushes;
-    cne_printf("\nWithout locks in the code\n");
-    for (with_pushes = 0; with_pushes <= 1; with_pushes++) {
-        if (with_pushes == 0)
-            cne_printf("\nALL ELEMENTS IN PRIMARY LOCATION\n");
-        else
-            cne_printf("\nELEMENTS IN PRIMARY OR SECONDARY LOCATION\n");
-        if (run_all_tbl_perf_tests(with_pushes, 0) < 0)
-            return -1;
-    }
+    int rc;
 
-    cne_printf("\n EXTENDABLE BUCKETS PERFORMANCE\n");
+    tst_info("ALL ELEMENTS IN PRIMARY LOCATION");
+    rc = run_all_tbl_perf_tests(0, 0);
+    if (rc < 0)
+        return rc;
 
-    if (run_all_tbl_perf_tests(1, 1) < 0)
-        return -1;
+    tst_info("ELEMENTS IN PRIMARY OR SECONDARY LOCATION");
+    rc = run_all_tbl_perf_tests(1, 0);
+    if (rc < 0)
+        return rc;
+
+    tst_info("EXTENDABLE BUCKETS PERFORMANCE");
+    rc = run_all_tbl_perf_tests(1, 1);
+    if (rc < 0)
+        return rc;
 
     if (fbk_hash_perf_test() < 0)
         return -1;
@@ -730,10 +715,12 @@ hash_perf_main(int argc, char **argv)
     if (test_hash_perf() < 0)
         goto leave;
 
+    tst_ok("PASS --- %s tests passed", tst->name);
     tst_end(tst, TST_PASSED);
 
     return 0;
 leave:
+    tst_error("FAILED --- %s tests failed", tst->name);
     tst_end(tst, TST_FAILED);
     return -1;
 }

--- a/test/testcne/hash_test.c
+++ b/test/testcne/hash_test.c
@@ -162,7 +162,7 @@ test_crc32_hash_alg_equiv(void)
     unsigned i, j;
     size_t data_len;
 
-    cne_printf("\n# CRC32 implementations equivalence test\n");
+    tst_info("CRC32 implementations equivalence test");
     for (i = 0; i < CRC32_ITERATIONS; i++) {
         /* Randomizing data_len of data set */
         data_len = (size_t)((rand() % sizeof(data64)) + 1);
@@ -179,14 +179,14 @@ test_crc32_hash_alg_equiv(void)
         /* Check against 4-byte-operand sse4.2 CRC32 if available */
         cne_hash_crc_set_alg(CRC32_SSE42);
         if (hash_val != cne_hash_crc(data64, data_len, init_val)) {
-            cne_printf("Failed checking CRC32_SW against CRC32_SSE42\n");
+            tst_error("Failed checking CRC32_SW against CRC32_SSE42");
             break;
         }
 
         /* Check against 8-byte-operand sse4.2 CRC32 if available */
         cne_hash_crc_set_alg(CRC32_SSE42_x64);
         if (hash_val != cne_hash_crc(data64, data_len, init_val)) {
-            cne_printf("Failed checking CRC32_SW against CRC32_SSE42_x64\n");
+            tst_error("Failed checking CRC32_SW against CRC32_SSE42_x64");
             break;
         }
     }
@@ -197,7 +197,7 @@ test_crc32_hash_alg_equiv(void)
     if (i == CRC32_ITERATIONS)
         return 0;
 
-    cne_printf("Failed test data (hex, %zu bytes total):\n", data_len);
+    tst_error("Failed test data (hex, %zu bytes total):", data_len);
     for (j = 0; j < data_len; j++)
         cne_printf("%02X%c", ((uint8_t *)data64)[j],
                    ((j + 1) % 16 == 0 || j == data_len - 1) ? '\n' : ' ');
@@ -1020,8 +1020,7 @@ fbk_hash_unit_test(void)
     double used_entries;
 
     /* Try creating hashes with invalid parameters */
-    cne_printf("# Testing hash creation with invalid parameters "
-               "- expect error msgs\n");
+    tst_info("Testing hash creation with invalid parameters - expect error msgs");
     handle = cne_fbk_hash_create(&invalid_params_1);
     RETURN_IF_ERROR_FBK(handle != NULL, "fbk hash creation should have failed");
 
@@ -1186,7 +1185,7 @@ test_hash_creation_with_bad_parameters(void)
     handle = cne_hash_create(NULL);
     if (handle != NULL) {
         cne_hash_free(handle);
-        cne_printf("Impossible creating hash successfully without any parameter\n");
+        tst_error("Impossible creating hash successfully without any parameter");
         return -1;
     }
 
@@ -1196,7 +1195,7 @@ test_hash_creation_with_bad_parameters(void)
     handle         = cne_hash_create(&params);
     if (handle != NULL) {
         cne_hash_free(handle);
-        cne_printf("Impossible creating hash successfully with entries in parameter exceeded\n");
+        tst_error("Impossible creating hash successfully with entries in parameter exceeded");
         return -1;
     }
 
@@ -1206,8 +1205,8 @@ test_hash_creation_with_bad_parameters(void)
     handle         = cne_hash_create(&params);
     if (handle != NULL) {
         cne_hash_free(handle);
-        cne_printf("Impossible creating hash successfully if entries less than bucket_entries in "
-                   "parameter\n");
+        tst_error("Impossible creating hash successfully if entries less than bucket_entries in "
+                  "parameter");
         return -1;
     }
 
@@ -1217,7 +1216,7 @@ test_hash_creation_with_bad_parameters(void)
     handle         = cne_hash_create(&params);
     if (handle != NULL) {
         cne_hash_free(handle);
-        cne_printf("Impossible creating hash successfully if key_len in parameter is zero\n");
+        tst_error("Impossible creating hash successfully if key_len in parameter is zero");
         return -1;
     }
 
@@ -1226,12 +1225,12 @@ test_hash_creation_with_bad_parameters(void)
     params.name = "same_name";
     handle      = cne_hash_create(&params);
     if (handle == NULL) {
-        cne_printf("Cannot create first hash table with 'same_name'\n");
+        tst_error("Cannot create first hash table with 'same_name'");
         return -1;
     }
     cne_hash_free(handle);
 
-    cne_printf("# Test successful. No more errors expected\n");
+    tst_ok("Test successful. No more errors expected");
 
     return 0;
 }
@@ -1252,7 +1251,7 @@ test_hash_creation_with_good_parameters(void)
     params.hash_func = NULL;
     handle           = cne_hash_create(&params);
     if (handle == NULL) {
-        cne_printf("Creating hash with null hash_func failed\n");
+        tst_error("Creating hash with null hash_func failed");
         return -1;
     }
 
@@ -1276,14 +1275,14 @@ test_average_table_utilization(uint32_t ext_table)
     int ret;
     unsigned int cnt;
 
-    cne_printf("\n# Running test to determine average utilization"
-               "\n  before adding elements begins to fail\n");
+    tst_info("Running test to determine average utilization"
+             " before adding elements begins to fail");
     if (ext_table)
-        cne_printf("ext table is enabled\n");
+        tst_info("ext table is enabled");
     else
-        cne_printf("ext table is disabled\n");
+        tst_info("ext table is disabled");
 
-    cne_printf("Measuring performance, please wait\n");
+    tst_info("Measuring performance, please wait");
     fflush(stdout);
     ut_params.entries   = 1 << 16;
     ut_params.name      = "test_average_utilization";
@@ -1340,9 +1339,9 @@ test_average_table_utilization(uint32_t ext_table)
 
     average_keys_added /= ITERATIONS;
 
-    cne_printf("\nAverage table utilization = %.2f%% (%u/%u)\n",
-               ((double)average_keys_added / ut_params.entries * 100), average_keys_added,
-               ut_params.entries);
+    tst_info("\nAverage table utilization = %.2f%% (%u/%u)",
+             ((double)average_keys_added / ut_params.entries * 100), average_keys_added,
+             ut_params.entries);
     cne_hash_free(handle);
 
     return 0;
@@ -1382,7 +1381,7 @@ test_hash_iteration(uint32_t ext_table)
         ret = cne_hash_add_key_data(handle, keys[added_keys], data[added_keys]);
         if (ret < 0) {
             if (ext_table) {
-                cne_printf("Insertion failed for ext table\n");
+                tst_error("Insertion failed for ext table");
                 goto err;
             }
             break;
@@ -1395,8 +1394,8 @@ test_hash_iteration(uint32_t ext_table)
         for (i = 0; i < NUM_ENTRIES; i++) {
             if (memcmp(next_key, keys[i], ut_params.key_len) == 0) {
                 if (next_data != data[i]) {
-                    cne_printf("Data found in the hash table is"
-                               "not the data added with the key\n");
+                    tst_error("Data found in the hash table is"
+                              "not the data added with the key");
                     goto err;
                 }
                 added_keys--;
@@ -1404,14 +1403,14 @@ test_hash_iteration(uint32_t ext_table)
             }
         }
         if (i == NUM_ENTRIES) {
-            cne_printf("Key found in the hash table was not added\n");
+            tst_error("Key found in the hash table was not added");
             goto err;
         }
     }
 
     /* Check if all keys have been iterated */
     if (added_keys != 0) {
-        cne_printf("There were still %u keys to iterate\n", added_keys);
+        tst_error("There were still %u keys to iterate", added_keys);
         goto err;
     }
 
@@ -1419,6 +1418,8 @@ test_hash_iteration(uint32_t ext_table)
     return 0;
 
 err:
+    tst_error("tst_hash_iteration() failed");
+
     cne_hash_free(handle);
     return -1;
 }
@@ -1452,18 +1453,18 @@ test_hash_add_delete_jhash2(void)
 
     handle = cne_hash_create(&hash_params_ex);
     if (handle == NULL) {
-        cne_printf("test_hash_add_delete_jhash2 fail to create hash\n");
+        tst_error("test_hash_add_delete_jhash2 fail to create hash");
         goto fail_jhash2;
     }
     pos1 = cne_hash_add_key(handle, (void *)&key[0]);
     if (pos1 < 0) {
-        cne_printf("test_hash_add_delete_jhash2 fail to add hash key\n");
+        tst_error("test_hash_add_delete_jhash2 fail to add hash key");
         goto fail_jhash2;
     }
 
     pos2 = cne_hash_del_key(handle, (void *)&key[0]);
     if (pos2 < 0 || pos1 != pos2) {
-        cne_printf("test_hash_add_delete_jhash2 delete different key from being added\n");
+        tst_error("test_hash_add_delete_jhash2 delete different key from being added");
         goto fail_jhash2;
     }
     ret = 0;

--- a/test/testcne/pkt_test.c
+++ b/test/testcne/pkt_test.c
@@ -60,42 +60,39 @@ simple_pkt_test(void)
     int ret              = -1;
     pktmbuf_t *mbufs[32] = {NULL};
 
-    cne_printf("[blue]>>>[white]SUBTEST: pktmbuf_pool_create\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_pool_create");
 
     if (create_pktmbuf())
         goto leave;
-    tst_ok("PASS --- SUBTEST: pktmbuf_pool_create\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_pool_create");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_alloc_bulk\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_alloc_bulk");
     ret = pktmbuf_alloc_bulk(pi, mbufs, 32);
     TST_ASSERT_GOTO(ret > 0, "SUBTEST: pktmbuf_alloc_bulk failed\n", leave);
-    tst_ok("PASS --- SUBTEST: pktmbuf_alloc_bulk\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_alloc_bulk");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_copy\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_copy");
     uint64_t *p                = pktmbuf_mtod(mbufs[0], uint64_t *);
     p[0]                       = 0xfd3c78299efefd3c;
     p[1]                       = 0x00450008b82c9efe;
     p[2]                       = 0x0;
     pktmbuf_data_len(mbufs[0]) = 60;
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("pktmbuf[0]", mbufs[0], pktmbuf_data_len(mbufs[0]));
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
     pktmbuf_t *copy = pktmbuf_copy(mbufs[0], pi, 0, UINT32_MAX);
     TST_ASSERT_GOTO(copy, "SUBTEST: pktmbuf_copy failed\n", leave);
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("copy", copy, pktmbuf_data_len(copy));
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
-    tst_ok("PASS --- SUBTEST: pktmbuf_copy\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_copy");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: memcmp copied buffer\n");
+    tst_info("SUBTEST: memcmp copied buffer");
     uint64_t *p1 = pktmbuf_mtod(copy, uint64_t *);
     ret          = memcmp(p, p1, 60);
     TST_ASSERT_GOTO(ret == 0, "SUBTEST: memcmp copied buffer failed\n", leave);
-    tst_ok("PASS --- SUBTEST:  memcmp copied buffer\n");
+    tst_ok("PASS --- SUBTEST:  memcmp copied buffer");
     pktmbuf_free(copy);
 
 leave:
@@ -114,157 +111,137 @@ test_one_pktmbuf(void)
     char *data, *data2, *hdr;
     unsigned i;
 
-    cne_printf("[blue]>>>[white]SUBTEST: pktmbuf API\n");
+    tst_info("SUBTEST: pktmbuf API");
 
     /* alloc a pktmbuf */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_alloc\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_alloc");
     m = pktmbuf_alloc(pi);
     TST_ASSERT_GOTO(m, "SUBTEST: pktmbuf_alloc failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_alloc\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_alloc");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_data_len\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_data_len");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == 0, "SUBTEST: pktmbuf_data_len failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_data_len\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_data_len");
 
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("m", m, 0);
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
     /* append data */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_append\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_append");
     data = pktmbuf_append(m, MBUF_TEST_DATA_LEN);
     TST_ASSERT_GOTO(data != NULL, "SUBTEST: pktmbuf_append failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_append\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_append");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_data_len\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_data_len");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN, "SUBTEST: pktmbuf_data_len failed\n",
                     fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_data_len\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_data_len");
 
     memset(data, 0x66, pktmbuf_data_len(m));
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("m", m, MBUF_TEST_DATA_LEN);
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
-    cne_printf("\n[blue]>>>[white]pktmbuf_data_len(m) %d\n", pktmbuf_data_len(m));
+    tst_info("pktmbuf_data_len(m) %d", pktmbuf_data_len(m));
 
     /* this append should fail */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_append invalid\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_append invalid");
     data2 = pktmbuf_append(m, (uint16_t)(pktmbuf_tailroom(m) + 1));
     TST_ASSERT_GOTO(data2 == NULL, "SUBTEST: pktmbuf_append invalid failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_append invalid\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_append invalid");
 
     /* append some more data */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_append valid\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_append valid");
     data2 = pktmbuf_append(m, MBUF_TEST_DATA_LEN2);
     TST_ASSERT_GOTO(data2 != NULL, "SUBTEST: pktmbuf_append valid failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_append valid\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_append valid");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Check packet length valid\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Check packet length valid");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == (MBUF_TEST_DATA_LEN + MBUF_TEST_DATA_LEN2),
                     "SUBTEST: Check packet length valid\n", fail);
-    tst_ok("PASS --- SUBTEST: Check packet length valid\n");
+    tst_ok("PASS --- SUBTEST: Check packet length valid");
 
     /* trim data at the end of pktmbuf */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_trim\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_trim");
     TST_ASSERT_GOTO(pktmbuf_trim(m, MBUF_TEST_DATA_LEN2) == 0, "SUBTEST: pktmbuf_trim\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_trim\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_trim");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: check length after pktmbuf_trim\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: check length after pktmbuf_trim");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN,
                     "SUBTEST: check length after pktmbuf_trim\n", fail);
-    tst_ok("PASS --- SUBTEST: check length after pktmbuf_trim\n");
+    tst_ok("PASS --- SUBTEST: check length after pktmbuf_trim");
 
     /* this trim should fail */
-    cne_printf("\n[blue]>>>[white]SUBTEST: invalid pktmbuf_trim\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: invalid pktmbuf_trim");
     TST_ASSERT_GOTO(pktmbuf_trim(m, (uint16_t)(pktmbuf_data_len(m) + 1)) != 0,
                     "SUBTEST: invalid pktmbuf_trim\n", fail);
-    tst_ok("PASS --- SUBTEST: invalid pktmbuf_trim\n");
+    tst_ok("PASS --- SUBTEST: invalid pktmbuf_trim");
 
     /* prepend one header */
-    cne_printf("\n[blue]>>>[white]SUBTEST: prepend one header\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: prepend one header");
     hdr = pktmbuf_prepend(m, MBUF_TEST_HDR1_LEN);
     TST_ASSERT_GOTO(hdr != NULL, "SUBTEST: prepend one header\n", fail);
-    tst_ok("PASS --- SUBTEST: prepend one header\n");
+    tst_ok("PASS --- SUBTEST: prepend one header");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify prepend one header 1\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify prepend one header 1");
     TST_ASSERT_GOTO(data - hdr == MBUF_TEST_HDR1_LEN, "SUBTEST: Verify prepend one header 1\n",
                     fail);
-    tst_ok("PASS --- SUBTEST: Verify prepend one header 1\n");
+    tst_ok("PASS --- SUBTEST: Verify prepend one header 1");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify prepend one header 2\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify prepend one header 2");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN + MBUF_TEST_HDR1_LEN,
                     "SUBTEST: Verify prepend one header 2\n", fail);
-    tst_ok("PASS --- SUBTEST: Verify prepend one header 2\n");
+    tst_ok("PASS --- SUBTEST: Verify prepend one header 2");
 
     memset(hdr, 0x55, MBUF_TEST_HDR1_LEN);
 
     /* prepend another header */
-    cne_printf("\n[blue]>>>[white]SUBTEST: prepend another valid header\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: prepend another valid header");
     hdr = pktmbuf_prepend(m, MBUF_TEST_HDR2_LEN);
     TST_ASSERT_GOTO(hdr != NULL, "SUBTEST: prepend another valid header\n", fail);
-    tst_ok("PASS --- SUBTEST: prepend another valid header\n");
+    tst_ok("PASS --- SUBTEST: prepend another valid header");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify prepend one header 1\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify prepend one header 1");
     TST_ASSERT_GOTO(data - hdr == MBUF_TEST_ALL_HDRS_LEN, "SUBTEST: Verify prepend one header 1\n",
                     fail);
-    tst_ok("PASS --- SUBTEST: Verify prepend one header 1\n");
+    tst_ok("PASS --- SUBTEST: Verify prepend one header 1");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify prepend one header 2\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify prepend one header 2");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN + MBUF_TEST_ALL_HDRS_LEN,
                     "SUBTEST: Verify prepend one header 2\n", fail);
-    tst_ok("PASS --- SUBTEST: Verify prepend one header 2\n");
+    tst_ok("PASS --- SUBTEST: Verify prepend one header 2");
 
     memset(hdr, 0x55, MBUF_TEST_HDR2_LEN);
 
     pktmbuf_sanity_check(m, 1);
     pktmbuf_sanity_check(m, 0);
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("m", m, 0);
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
     /* this prepend should fail */
-    cne_printf("\n[blue]>>>[white]SUBTEST: prepend an invalid header\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: prepend an invalid header");
     hdr = pktmbuf_prepend(m, (uint16_t)(CNE_PKTMBUF_HEADROOM + 1));
     TST_ASSERT_GOTO(hdr == NULL, "SUBTEST: prepend an invalid header\n", fail);
-    tst_ok("PASS --- SUBTEST: prepend an invalid header\n");
+    tst_ok("PASS --- SUBTEST: prepend an invalid header");
 
     /* remove data at beginning of pktmbuf (adj) */
-    cne_printf("\n[blue]>>>[white]SUBTEST: remove data at beginning of pktmbuf (adj)\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: remove data at beginning of of pktmbuf (adj)");
     TST_ASSERT_GOTO(data == pktmbuf_adj_offset(m, MBUF_TEST_ALL_HDRS_LEN),
                     "SUBTEST: remove data at beginning of pktmbuf (adj)\n", fail);
-    tst_ok("PASS --- SUBTEST: remove data at beginning of pktmbuf (adj)\n");
+    tst_ok("PASS --- SUBTEST: remove data at beginning of pktmbuf (adj)");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: Verify pktmbuf_prepend\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: Verify pktmbuf_prepend");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN, "SUBTEST: Verify pktmbuf_prepend\n",
                     fail);
-    tst_ok("PASS --- SUBTEST: Verify pktmbuf_prepend\n");
+    tst_ok("PASS --- SUBTEST: Verify pktmbuf_prepend");
 
     /* this adj should fail */
-    cne_printf("\n[blue]>>>[white]SUBTEST: invalid remove data at beginning of pktmbuf (adj)\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: invalid remove data at beginning of pktmbuf (adj)");
     TST_ASSERT_GOTO(pktmbuf_adj_offset(m, (uint16_t)(pktmbuf_data_len(m) + 1)) == NULL,
                     "SUBTEST: invalid  remove data at beginning of pktmbuf (adj)\n", fail);
-    tst_ok("PASS --- SUBTEST:  invalid remove data at beginning of pktmbuf (adj)\n");
+    tst_ok("PASS --- SUBTEST:  invalid remove data at beginning of pktmbuf (adj)");
 
     for (i = 0; i < MBUF_TEST_DATA_LEN; i++) {
         if (data[i] != 0x66) {
@@ -272,14 +249,14 @@ test_one_pktmbuf(void)
             goto fail;
         }
     }
-    tst_ok("PASS --- SUBTEST: pktmbuf API\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf API");
     /* free pktmbuf */
     pktmbuf_free(m);
     m = NULL;
     return 0;
 
 fail:
-    tst_error("FAILED --- SUBTEST: pktmbuf API\n");
+    tst_error("FAILED --- SUBTEST: pktmbuf API");
     pktmbuf_free(m);
     return -1;
 }
@@ -293,26 +270,25 @@ test_pktmbuf_pool(void)
     unsigned i;
     pktmbuf_t *m[DEFAULT_MBUF_COUNT];
 
-    cne_printf("[blue]>>>[white]SUBTEST:  test_pktmbuf_pool\n");
+    tst_info("SUBTEST:  test_pktmbuf_pool");
 
     for (i = 0; i < DEFAULT_MBUF_COUNT - 1; i++)
         m[i] = NULL;
 
     /* alloc NB_MBUF mbufs */
-    cne_printf("\n[blue]>>>[white]SUBTEST: alloc NB_MBUF mbufs\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: alloc NB_MBUF mbufs");
     for (i = 0; i < DEFAULT_MBUF_COUNT - 1; i++) {
         m[i] = pktmbuf_alloc(pi);
         TST_ASSERT_GOTO(m[i] != NULL, "SUBTEST: alloc NB_MBUF mbufs\n", leave);
     }
-    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs\n");
+    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs");
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_copy\n");
+    tst_info("SUBTEST: pktmbuf_copy");
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
     pktmbuf_t *extra = NULL;
     extra            = pktmbuf_copy(m[0], pi, 0, UINT32_MAX);
     TST_ASSERT_GOTO(extra != NULL, "SUBTEST: pktmbuf_copy\n", leave);
-    tst_ok("PASS ---  SUBTEST: pktmbuf_copy\n");
+    tst_ok("PASS ---  SUBTEST: pktmbuf_copy");
 
     /* free them */
     for (i = 0; i < DEFAULT_MBUF_COUNT - 1; i++) {
@@ -320,12 +296,12 @@ test_pktmbuf_pool(void)
     }
 
     pktmbuf_free(extra);
-    tst_ok("PASS --- SUBTEST:  test_pktmbuf_pool\n");
+    tst_ok("PASS --- SUBTEST:  test_pktmbuf_pool");
 
     return 0;
 
 leave:
-    tst_error("FAILED --- SUBTEST:  test_pktmbuf_pool\n");
+    tst_error("FAILED --- SUBTEST:  test_pktmbuf_pool");
     return -1;
 }
 
@@ -343,14 +319,13 @@ test_pktmbuf_pool_ptr(void)
         m[i] = NULL;
 
     /* alloc NB_MBUF mbufs */
-    cne_printf("\n[blue]>>>[white]SUBTEST: alloc NB_MBUF mbufs\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: alloc NB_MBUF mbufs");
     for (i = 0; i < NB_MBUF; i++) {
         m[i] = pktmbuf_alloc(pi);
         TST_ASSERT_GOTO(m[i] != NULL, "SUBTEST: alloc NB_MBUF mbufs\n", leave);
         m[i]->data_off += 64;
     }
-    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs\n");
+    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs");
     /* free them */
     for (i = 0; i < NB_MBUF; i++) {
         pktmbuf_free(m[i]);
@@ -360,15 +335,14 @@ test_pktmbuf_pool_ptr(void)
         m[i] = NULL;
 
     /* alloc NB_MBUF mbufs */
-    cne_printf("\n[blue]>>>[white]SUBTEST: alloc NB_MBUF mbufs\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: alloc NB_MBUF mbufs");
     for (i = 0; i < NB_MBUF; i++) {
         m[i] = pktmbuf_alloc(pi);
         TST_ASSERT_GOTO(m[i] != NULL, "SUBTEST: alloc NB_MBUF mbufs\n", leave);
         TST_ASSERT_GOTO(m[i]->data_off == CNE_PKTMBUF_HEADROOM, "SUBTEST: alloc NB_MBUF mbufs\n",
                         leave);
     }
-    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs\n");
+    tst_ok("PASS ---  SUBTEST: alloc NB_MBUF mbufs");
 
 leave:
     /* free them */
@@ -376,6 +350,7 @@ leave:
         pktmbuf_free(m[i]);
     }
 
+    tst_info("NB_MBUF subtest resulted in leave call");
     return ret;
 }
 
@@ -386,7 +361,7 @@ verify_mbuf_check_panics(pktmbuf_t *buf)
     int pid;
     int status;
 
-    cne_printf("[green]");
+    vt_color(VT_GREEN, VT_NO_CHANGE, VT_OFF);
     pid = fork();
 
     if (pid == 0) {
@@ -415,77 +390,67 @@ test_failing_pktmbuf_sanity_check(void)
     pktmbuf_t *buf;
     pktmbuf_t badbuf;
 
-    cne_printf("[blue]>>>[white]SUBTEST: Checking pktmbuf_sanity_check for failure conditions\n");
+    tst_info("SUBTEST: Checking pktmbuf_sanity_check for failure conditions");
 
     /* get a good pktmbuf to use to make copies */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_alloc\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_alloc");
     buf = pktmbuf_alloc(pi);
     TST_ASSERT_GOTO(buf, "SUBTEST: pktmbuf_alloc failed\n", leave);
-    tst_ok("PASS --- SUBTEST: pktmbuf_alloc\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_alloc");
 
-    cne_printf("[magenta]Checking good pktmbuf initially\n");
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("Checking good pktmbuf initially");
+    tst_info("SUBTEST: verify_mbuf_check_panics");
     TST_ASSERT_GOTO(verify_mbuf_check_panics(buf) == -1,
                     "SUBTEST: verify_mbuf_check_panics failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics");
 
-    cne_printf("[magenta]Now checking for error conditions - [green]Note PANICS are GOOD HERE\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on NULL\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("Now checking for error conditions - Note PANICS are GOOD HERE");
+    tst_info("SUBTEST: verify_mbuf_check_panics on NULL");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(NULL),
                     "SUBTEST: verify_mbuf_check_panics on NULL failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on NULL\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on NULL");
 
     badbuf          = *buf;
     badbuf.pooldata = NULL;
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.pool = NULL\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.pool = NULL");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.pool  = NULL failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.pool  = NULL\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.pool  = NULL");
 
     badbuf          = *buf;
     badbuf.buf_addr = 0;
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0 failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = 0");
 
     badbuf          = *buf;
     badbuf.buf_addr = NULL;
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.buf_addr = NULL");
 
     badbuf        = *buf;
     badbuf.refcnt = 0;
-    cne_printf("\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0 failed\n", leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = 0");
 
     badbuf        = *buf;
     badbuf.refcnt = UINT16_MAX;
-    cne_printf(
-        "\n[blue]>>>[white]SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX");
     TST_ASSERT_GOTO(!verify_mbuf_check_panics(&badbuf),
                     "SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX failed\n",
                     leave);
-    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX\n");
+    tst_ok("PASS --- SUBTEST: verify_mbuf_check_panics on badbuf.refcnt = UINT16_MAX");
 
-    tst_ok("PASS --- SUBTEST:  Checking pktmbuf_sanity_check for failure conditions\n");
+    tst_ok("PASS --- SUBTEST:  Checking pktmbuf_sanity_check for failure conditions");
     return 0;
 
 leave:
-    tst_error("FAILED --- SUBTEST: Checking pktmbuf_sanity_check for failure conditions\n");
+    tst_error("FAILED --- SUBTEST: Checking pktmbuf_sanity_check for failure conditions");
     return -1;
 }
 
@@ -498,28 +463,26 @@ test_pktmbuf_with_non_ascii_data(void)
     pktmbuf_t *m = NULL;
     char *data;
 
-    cne_printf("[blue]>>>[white]SUBTEST: test_pktmbuf_with_non_ascii_data\n");
+    tst_info("SUBTEST: test_pktmbuf_with_non_ascii_data");
 
     /* alloc a pktmbuf */
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_alloc\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_alloc");
     m = pktmbuf_alloc(pi);
     TST_ASSERT_GOTO(m, "SUBTEST: pktmbuf_alloc failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_alloc\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_alloc");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == 0, "SUBTEST: pktmbuf_alloc failed\n", fail);
 
-    cne_printf("\n[blue]>>>[white]SUBTEST: pktmbuf_append\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("SUBTEST: pktmbuf_append");
     data = pktmbuf_append(m, MBUF_TEST_DATA_LEN);
     TST_ASSERT_GOTO(data != NULL, "SUBTEST: pktmbuf_append failed\n", fail);
-    tst_ok("PASS --- SUBTEST: pktmbuf_append\n");
+    tst_ok("PASS --- SUBTEST: pktmbuf_append");
     TST_ASSERT_GOTO(pktmbuf_data_len(m) == MBUF_TEST_DATA_LEN, "SUBTEST: pktmbuf_alloc failed\n",
                     fail);
 
     memset(data, 0xff, pktmbuf_data_len(m));
     tst_ok("PASS --- SUBTEST:  test_pktmbuf_with_non_ascii_data\n");
 
-    cne_printf("[magenta]");
+    vt_color(VT_MAGENTA, VT_NO_CHANGE, VT_OFF);
     pktmbuf_dump("m", m, MBUF_TEST_DATA_LEN);
     vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
 
@@ -528,7 +491,7 @@ test_pktmbuf_with_non_ascii_data(void)
     return 0;
 
 fail:
-    tst_error("FAILED --- SUBTEST: test_pktmbuf_with_non_ascii_data\n");
+    tst_error("FAILED --- SUBTEST: test_pktmbuf_with_non_ascii_data");
     pktmbuf_free(m);
     return -1;
 }
@@ -538,47 +501,42 @@ test_mbuf(void)
 {
     /* create pktmbuf pool if it does not exist */
     if (pi == NULL) {
-        cne_printf("\n[blue]>>>[white]TEST: pktmbuf_pool_create\n");
-        vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+        tst_info("TEST: pktmbuf_pool_create");
         if (create_pktmbuf())
             goto leave;
-        tst_ok("PASS --- TEST: pktmbuf_pool_create\n");
+        tst_ok("PASS --- TEST: pktmbuf_pool_create");
     }
 
-    cne_printf("\n[blue]>>>[white]TEST: test multiple pktmbuf alloc\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test multiple pktmbuf alloc");
     TST_ASSERT_GOTO(!test_pktmbuf_pool(), "TEST: test multiple pktmbuf alloc failed\n", leave);
-    tst_ok("PASS --- TEST: test multiple pktmbuf alloc\n");
+    tst_ok("PASS --- TEST: test multiple pktmbuf alloc");
 
     /* test that the pointer to the data on a packet pktmbuf is set properly */
-    cne_printf("\n[blue]>>>[white]TEST: test_pktmbuf_pool_ptr\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test_pktmbuf_pool_ptr");
     TST_ASSERT_GOTO(!test_pktmbuf_pool_ptr(), "TEST: test_pktmbuf_pool_ptr failed\n", leave);
-    tst_ok("PASS --- TEST: test_pktmbuf_pool_ptr\n");
+    tst_ok("PASS --- TEST: test_pktmbuf_pool_ptr");
 
     /* test data manipulation in pktmbuf */
-    cne_printf("\n[blue]>>>[white]TEST: test_one_pktmbuf\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test_one_pktmbuf");
     TST_ASSERT_GOTO(!test_one_pktmbuf(), "TEST: test_one_pktmbuf failed\n", leave);
-    tst_ok("PASS --- TEST: test_one_pktmbuf\n");
+    tst_ok("PASS --- TEST: test_one_pktmbuf");
 
-    cne_printf("\n[blue]>>>[white]TEST: test_pktmbuf_with_non_ascii_data\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test_pktmbuf_with_non_ascii_data");
     TST_ASSERT_GOTO(!test_pktmbuf_with_non_ascii_data(),
                     "TEST: test_pktmbuf_with_non_ascii_data failed\n", leave);
-    tst_ok("PASS --- TEST: test_pktmbuf_with_non_ascii_data\n");
+    tst_ok("PASS --- TEST: test_pktmbuf_with_non_ascii_data");
 
-    cne_printf("\n[blue]>>>[white]TEST: test_failing_pktmbuf_sanity_check\n");
-    vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+    tst_info("TEST: test_failing_pktmbuf_sanity_check");
     TST_ASSERT_GOTO(!test_failing_pktmbuf_sanity_check(),
                     "TEST: test_failing_pktmbuf_sanity_check failed\n", leave);
-    tst_ok("PASS --- TEST: test_failing_pktmbuf_sanity_check\n");
+    tst_ok("PASS --- TEST: test_failing_pktmbuf_sanity_check");
 
     return 0;
 
 leave:
 
     destroy_pktmbuf();
+    tst_error("mbuf tests failed");
     return -1;
 }
 

--- a/test/testcne/pktdev_test.c
+++ b/test/testcne/pktdev_test.c
@@ -114,74 +114,73 @@ general_tests(const char *ifname, const char *pmd)
                       (uint64_t)DEFAULT_MBUF_COUNT * (uint64_t)DEFAULT_MBUF_SIZE,
                       mmap_name_by_type(MMAP_HUGEPAGE_4KB));
 
-        cne_printf("\n[blue]>>>[white]TEST: Invalid PMD Name\n");
+        tst_info("TEST: Invalid PMD Name");
         reset_test_params(&pc, ifname, mmap, pmd);
         set_cleanup_params(mmap, &clnup);
         strlcpy(pc.pmd_name, PMD_NET_AF_XDP_NAME "_", sizeof(pc.pmd_name));
         retval = pktdev_port_setup(&pc);
         TST_ASSERT_FAIL_AND_CLEANUP(retval, "FAILED --- TEST: Invalid PMD Name\n", clean_up,
                                     &clnup);
-        tst_ok("PASS --- TEST: Invalid PMD Name\n");
+        tst_ok("PASS --- TEST: Invalid PMD Name");
 
-        cne_printf("\n[blue]>>>[white]TEST: Invalid ifname\n");
+        tst_info("TEST: Invalid ifname");
         reset_test_params(&pc, "UNKNOWN", mmap, pmd);
         retval = pktdev_port_setup(&pc);
         TST_ASSERT_FAIL_AND_CLEANUP(retval, "FAILED --- TEST: Invalid ifname\n", clean_up, &clnup);
-        tst_ok("PASS --- TEST: Invalid ifname\n");
+        tst_ok("PASS --- TEST: Invalid ifname");
     }
 
-    cne_printf("\n[blue]>>>[white] TEST: Valid ifname Test PMD %s[]\n", pmd);
+    tst_info("TEST: Valid ifname Test PMD %s", pmd);
     reset_test_params(&pc, ifname, mmap, pmd);
     set_cleanup_params(mmap, &clnup);
     retval = pktdev_port_setup(&pc);
     TST_ASSERT_SUCCESS_AND_CLEANUP(retval, "FAILED --- TEST: Valid ifname Test\n", clean_up,
                                    &clnup);
-    tst_ok("PASS --- TEST: Valid ifname Test[]\n");
+    tst_ok("PASS --- TEST: Valid ifname Test");
     lport = retval;
-    cne_printf("\n[blue]>>>[white]TEST: Set admin state Down[]\n");
+    tst_info("TEST: Set admin state Down");
     admin_state = false;
     retval      = pktdev_admin_state_set(lport, admin_state);
     TST_ASSERT_SUCCESS_AND_CLEANUP(retval, "FAIL --- pktdev_admin_state_set(%d) failed\n", clean_up,
                                    &clnup, lport);
     admin_state = pktdev_admin_state(lport);
     TST_ASSERT_EQUAL(admin_state, false, "TEST: Set admin state Down");
-    tst_ok("PASS --- TEST: Set admin state Down[]\n");
+    tst_ok("PASS --- TEST: Set admin state Down");
 
-    cne_printf("\n[blue]>>>[white]TEST: Set admin state up[]\n");
+    tst_info("TEST: Set admin state up");
     admin_state = true;
     retval      = pktdev_admin_state_set(lport, admin_state);
     TST_ASSERT_SUCCESS_AND_CLEANUP(retval, "FAIL --- pktdev_admin_state_set(%d) failed\n", clean_up,
                                    &clnup, lport);
     admin_state = pktdev_admin_state(lport);
     TST_ASSERT_EQUAL(admin_state, true, "TEST: Set admin state Up");
-    tst_ok("PASS --- TEST: Set admin state Up[]\n");
+    tst_ok("PASS --- TEST: Set admin state Up");
 
     if (!(strcmp(pmd, PMD_NET_AF_XDP_NAME))) {
-        cne_printf("\n[blue]>>>[white]TEST: Check lport MAC addr[]\n");
-        vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+        tst_info("TEST: Check lport MAC addr");
         /* Display the lport MAC address. */
         retval = pktdev_macaddr_get(lport, &eaddr);
         TST_ASSERT_SUCCESS_AND_CLEANUP(retval, "FAIL --- TEST:  Check lport MAC addr\n", clean_up,
                                        &clnup);
-        cne_printf("[yellow]Port %u MAC: %02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8
-                   ":%02" PRIx8 ":%02" PRIx8 "\n",
-                   lport, eaddr.ether_addr_octet[0], eaddr.ether_addr_octet[1],
-                   eaddr.ether_addr_octet[2], eaddr.ether_addr_octet[3], eaddr.ether_addr_octet[4],
-                   eaddr.ether_addr_octet[5]);
-        tst_ok("PASS --- TEST:  Check lport MAC addr\n");
+        tst_info("Port %u MAC: %02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8
+                 ":%02" PRIx8,
+                 lport, eaddr.ether_addr_octet[0], eaddr.ether_addr_octet[1],
+                 eaddr.ether_addr_octet[2], eaddr.ether_addr_octet[3], eaddr.ether_addr_octet[4],
+                 eaddr.ether_addr_octet[5]);
+        tst_ok("PASS --- TEST:  Check lport MAC addr");
 
-        cne_printf("\n[blue]>>>[white]TEST: Check lport enabled offloads[]\n");
+        tst_info("TEST: Check lport enabled offloads");
         struct offloads off;
         /* Display the lport MAC address. */
         retval = pktdev_offloads_get(lport, &off);
         TST_ASSERT_SUCCESS_AND_CLEANUP(retval, "FAIL --- TEST:  Check lport offloads\n", clean_up,
                                        &clnup);
-        cne_printf("\n\n[yellow]Port %u TX OFFLOAD %" PRIu32 "\n", lport, off.tx_checksum_offload);
-        cne_printf("[yellow]Port %u RX OFFLOAD %" PRIu32 "\n\n", lport, off.rx_checksum_offload);
-        tst_ok("PASS --- TEST:  Check lport enabled offloads[]\n");
+        tst_info("\n\nPort %u TX OFFLOAD %" PRIu32, lport, off.tx_checksum_offload);
+        tst_info("Port %u RX OFFLOAD %" PRIu32, lport, off.rx_checksum_offload);
+        tst_ok("PASS --- TEST:  Check lport enabled offloads");
     }
 
-    cne_printf("\n[blue]>>>[white]TEST: pktdev_promiscuous_enable[]\n");
+    tst_info("TEST: pktdev_promiscuous_enable");
     /* Enable RX in promiscuous mode for the Ethernet device. */
     retval = netdev_promiscuous_enable(ifname);
     if (!(strcmp(pmd, PMD_NET_AF_XDP_NAME)))
@@ -190,128 +189,128 @@ general_tests(const char *ifname, const char *pmd)
     else
         TST_ASSERT_FAIL_AND_CLEANUP(retval, "FAIL --- pktdev_promiscuous_enable(%d)\n", clean_up,
                                     &clnup, lport);
-    tst_ok("PASS --- TEST:  pktdev_promiscuous_enable\n");
+    tst_ok("PASS --- TEST:  pktdev_promiscuous_enable");
 
-    cne_printf("\n[blue]>>>[white]TEST: Check lport's port_id[]\n");
+    tst_info("TEST: Check lport's port_id");
     /* Display the lport port_id */
     struct cne_pktdev *dev;
     dev    = pktdev_get(lport);
     portid = pktdev_portid(dev);
     TST_ASSERT(portid >= 0, "TEST: Get the port id");
-    tst_ok("PASS --- TEST: Get the portid of pktdev\n");
+    tst_ok("PASS --- TEST: Get the portid of pktdev");
 
-    cne_printf("\n[blue]>>>[white]TEST: Check lport's socket_id[]\n");
+    tst_info("TEST: Check lport's socket_id");
     /* Display the socket id of the lport */
     socketid = pktdev_socket_id(lport);
     TST_ASSERT(socketid >= 0, "TEST: Get the socket id");
-    tst_ok("PASS --- TEST: Get the socket id of pktdev\n");
+    tst_ok("PASS --- TEST: Get the socket id of pktdev");
 
-    cne_printf("\n[blue]>>>[white]TEST: Check pktdev port number[]\n");
+    tst_info("TEST: Check pktdev port number");
     /* Get the total number for the pktdev ports */
     dev_num = pktdev_port_count();
     TST_ASSERT(dev_num > 0, "TEST: Get the pktdev port number");
-    tst_ok("PASS --- TEST: Get the pktdev number\n");
+    tst_ok("PASS --- TEST: Get the pktdev number");
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for pktdev_info_get\n[]");
+    tst_info("TEST: API test for pktdev_info_get");
     struct pktdev_info *dev_info = (struct pktdev_info *)malloc(sizeof(struct pktdev_info));
     if (!dev_info)
         goto leave;
     TST_ASSERT_GOTO(pktdev_info_get(lport, dev_info) == 0,
                     "ERROR - Could not get the pktdev info\n", leave);
-    tst_ok("PASS --- TEST: Get the pktdev info successful\n");
+    tst_ok("PASS --- TEST: Get the pktdev info successful");
     TST_ASSERT_GOTO(pktdev_info_get(lport + 1, dev_info) == -ENOTSUP,
                     "ERROR - The error code isn't correct\n", leave);
-    tst_ok("PASS --- TEST: Port info out of valid range checking passed\n");
+    tst_ok("PASS --- TEST: Port info out of valid range checking passed");
     TST_ASSERT_GOTO(pktdev_info_get(CNE_MAX_ETHPORTS + 1, dev_info) == -ENODEV,
                     "ERROR - The error code isn't correct\n", leave);
-    tst_ok("PASS --- TEST: Port number above max checking passed\n");
+    tst_ok("PASS --- TEST: Port number above max checking passed");
     free(dev_info);
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for pktdev_socket_id\n[]");
+    tst_info("TEST: API test for pktdev_socket_id");
     if (pktdev_socket_id(lport) >= 0)
-        tst_ok("PASS --- TEST: socket is correct\n");
+        tst_ok("PASS --- TEST: socket is correct");
     else {
-        tst_error("ERROR - Returned socket id failed\n");
+        tst_error("ERROR - Returned socket id failed");
         goto leave;
     }
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for pktdev_portid\n[]");
+    tst_info("TEST: API test for pktdev_portid");
     if (pktdev_portid(pktdev_get(lport)) == lport)
-        tst_ok("PASS --- TEST: port id is correct\n");
+        tst_ok("PASS --- TEST: port id is correct");
     else {
-        tst_error("ERROR - Return port id error\n");
+        tst_error("ERROR - Return port id error");
         goto leave;
     }
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for pktdev_arg_get\n[]");
+    tst_info("TEST: API test for pktdev_arg_get");
     if (pktdev_arg_get(lport) != NULL)
-        tst_ok("PASS --- TEST: pktdev_arg_get action pass\n");
+        tst_ok("PASS --- TEST: pktdev_arg_get action pass");
     else {
-        tst_error("ERROR - Return pktdev_arg_get() failed\n");
+        tst_error("ERROR - Return pktdev_arg_get() failed");
         goto leave;
     }
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for is_valid_port\n[]");
+    tst_info("TEST: API test for is_valid_port");
     if (pktdev_is_valid_port(lport) == 1)
-        tst_ok("PASS --- TEST: is_valid_port api test pass\n");
+        tst_ok("PASS --- TEST: is_valid_port api test pass");
     else {
-        tst_error("ERROR - Is_valid_port api test failed\n");
+        tst_error("ERROR - Is_valid_port api test failed");
         goto leave;
     }
     if (pktdev_is_valid_port(lport + 1) == 0)
-        tst_ok("PASS --- TEST: is_valid_port api test for invalid id pass\n");
+        tst_ok("PASS --- TEST: is_valid_port api test for invalid id pass");
     else {
-        tst_error("ERROR - is_valid_port api test for invalid id fail\n");
+        tst_error("ERROR - is_valid_port api test for invalid id fail");
         goto leave;
     }
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for pktdev_get_name_by_port\n[]");
+    tst_info("TEST: API test for pktdev_get_name_by_port");
     char name[100];
     int len = 100;
     if (pktdev_get_name_by_port(lport, name, len) == 0) {
-        tst_ok("PASS --- TEST: Get port name pass\n");
-        cne_printf("[blue]>>>[white]The pktdev name is: %s\n[]", name);
+        tst_info("The pktdev name is: %s", name);
+        tst_ok("PASS --- TEST: Get port name pass");
     } else {
-        tst_error("ERROR - Get port name failed\n");
+        tst_error("ERROR - Get port name failed");
         goto leave;
     }
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for pktdev_port_name\n[]");
+    tst_info("TEST: API test for pktdev_port_name");
     const char *name_link = NULL;
     name_link             = pktdev_port_name(lport);
     if (name_link != NULL) {
-        tst_ok("PASS --- TEST: Get port name pass\n");
-        cne_printf("[blue]>>>[white]the pktdev name is: %s\n[]", name_link);
+        tst_info("The pktdev name is: %d", name_link);
+        tst_ok("PASS --- TEST: Get port name pass");
     } else {
-        tst_error("ERROR - Get port name failed\n");
+        tst_error("ERROR - Get port name failed");
         goto leave;
     }
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for lport_cfg_dump\n[]");
+    tst_info("TEST: API test for lport_cfg_dump");
     lport_cfg_dump(NULL, &pc);
-    tst_ok("PASS --- TEST: lport config dump pass\n");
+    tst_ok("PASS --- TEST: lport config dump pass");
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for pktdev_start\n[]");
+    tst_info("TEST: API test for pktdev_start");
     if (pktdev_start(lport) < 0) {
-        tst_error("ERROR - Could not start the lport\n");
+        tst_error("ERROR - Could not start the lport");
         goto leave;
     }
     sleep(1);
 
-    cne_printf("\n[blue]>>>[white]TEST: API test for pktdev_stop\n[]");
+    tst_info("TEST: API test for pktdev_stop");
     if (pktdev_stop(lport) < 0) {
-        tst_error("ERROR - Could not stop the lport\n");
+        tst_error("ERROR - Could not stop the lport");
         goto leave;
     } else
-        tst_ok("PASS --- TEST: pktdev stop success\n");
+        tst_ok("PASS --- TEST: pktdev stop success");
     sleep(1);
 
     /* Cleanup lport and complete test*/
     if (pktdev_close(lport)) {
-        tst_error("ERROR - Could not close the lport\n");
+        tst_error("ERROR - Could not close the lport");
         goto leave;
     } else
-        tst_ok("PASS --- TEST: pktdev close success\n");
+        tst_ok("PASS --- TEST: pktdev close success");
 
     lport = -1;
     sleep(1);
@@ -363,8 +362,8 @@ pktdev_main(int argc, char **argv)
     for (int i = 0; i < cne_countof(tests); i++) {
         memset(ifname, 0, IF_NAMESIZE);
         if (!(strcmp(afxdp_ifname, "UNKNOWN"))) {
-            cne_printf("[red]>>> No interface was specified for the pktdev tests \n"
-                       "[white] Need to specify at least 1 interface with the -i parameter\n");
+            tst_error("No interface was specified for the pktdev tests \n"
+                      "Need to specify at least 1 interface with the -i parameter");
             goto leave;
         }
 
@@ -375,18 +374,17 @@ pktdev_main(int argc, char **argv)
         else
             strlcpy(ifname, afxdp_ifname, sizeof(ifname));
 
-        cne_printf("\n[blue]>>> %s Tests\n", tests[i]);
-        vt_color(VT_DEFAULT_FG, VT_NO_CHANGE, VT_OFF);
+        tst_info("%s Tests", tests[i]);
 
         if (general_tests(ifname, tests[i]) < 0)
             goto leave;
     }
-    cne_printf("\n[magenta]>>>[green]ALL TESTS COMPLETE\n");
     tst_end(tst, TST_PASSED);
 
     return 0;
 
 leave:
+    tst_error("pktdev tests failed");
     tst_end(tst, TST_FAILED);
     return -1;
 }


### PR DESCRIPTION
Tests improved: hash_test, hash_perf_test, pktdev_test, pkt_test, acl_test

- Improves #234
- Replaced cne_printf() with tst_*()
- Changed some output to improve readability

Signed-off-by: Byron Marohn <byron.marohn@intel.com>
Signed-off-by: Stephen Weeks <stephen.weeks@intel.com>
Signed-off-by: Matthew Leon <matthew.leon@intel.com>
Signed-off-by: Edmund Leemhuis <edmund.leemhuis@intel.com>