### PR TITLE
update to clang-format 15.0.2

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.13
+    - uses: DoozyX/clang-format-lint-action@v0.15
       with:
         source: '.'
         exclude: './examples/vpp-plugin'
         extensions: 'c,h,cc,cpp'
-        clangFormatVersion: 13
+        clangFormatVersion: 15.0.2

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -31,7 +31,6 @@ jobs:
           # that .golangci.yml is available to the golangci-lint linter
           # https://github.com/github/super-linter/blob/main/docs/using-rules-files.md
           LINTER_RULES_PATH: /
-          VALIDATE_CLANG_FORMAT: true
           VALIDATE_BASH: true
           VALIDATE_GITHUB_ACTIONS: true
           VALIDATE_GO: true

--- a/examples/cnet-quic/quic-cli.c
+++ b/examples/cnet-quic/quic-cli.c
@@ -114,7 +114,7 @@ static struct {
 struct {
     const char *path;
     int to_file;
-} * reqs;
+} *reqs;
 
 struct st_stream_data_t {
     quicly_streambuf_t streambuf;

--- a/test/common/test.h
+++ b/test/common/test.h
@@ -182,6 +182,9 @@ void add_test_command(struct test_command *t);
         .command  = CNE_STR(cmd),                    \
         .callback = func,                            \
     };                                               \
-    CNE_INIT(test_register_##cmd) { add_test_command(&test_struct_##cmd); }
+    CNE_INIT(test_register_##cmd)                    \
+    {                                                \
+        add_test_command(&test_struct_##cmd);        \
+    }
 
 #endif


### PR DESCRIPTION
Update to clang-format version to 15.0.2 to fix a formatting issue.
Turn off clang-format in super-linter as it appears it is not the
correct version.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>