### PR TITLE
cndpfwd: fix mode selection after adding l3fwd

### DIFF
--- a/examples/cndpfwd/main.c
+++ b/examples/cndpfwd/main.c
@@ -700,8 +700,8 @@ main(int argc, char **argv)
         "Unknown", "Drop",
         "Loopback",
         "Tx Only",
-        "L3 Forward"
-        "Forward",
+		"Forward",
+        "L3 Forward",
         "ACL Strict",
         "ACL Permissive",
         "Tx Only+RX",


### PR DESCRIPTION
There seemed to be an issue in the display of the mode for cndpfwd when selecting fwd mode due to a missing comma and a change in ordering.

Signed-off-by: Maryam Tahhan <mtahhan@redhat.com>