### PR TITLE
Add Wireguard patch to remove LD_PRELOAD from wireguard cndp script.

### DIFF
--- a/lang/rs/wireguard/patch/0002-Remove-LD_PRELOAD-from-cndprustwg-script.patch
+++ b/lang/rs/wireguard/patch/0002-Remove-LD_PRELOAD-from-cndprustwg-script.patch
@@ -1,0 +1,43 @@
+From 19abfa63a854cce6dc31aafc015c62bf47e9012b Mon Sep 17 00:00:00 2001
+From: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>
+Date: Wed, 18 Jan 2023 06:02:11 +0000
+Subject: [PATCH] Remove LD_PRELOAD from cndprustwg.sh script.
+
+- LD_PRELOAD of libpmd in cndprustwg.sh script is not required now.
+- Update README.md to mention that CNDP needs to be installed in the system
+  before building wireguard with CNDP.
+
+Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>
+---
+ src/platform/linux/cndp/README.md     | 1 +
+ src/platform/linux/cndp/cndprustwg.sh | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/platform/linux/cndp/README.md b/src/platform/linux/cndp/README.md
+index f390b63..d23f822 100644
+--- a/src/platform/linux/cndp/README.md
++++ b/src/platform/linux/cndp/README.md
+@@ -14,6 +14,7 @@ Wireguard with CNDP is most recently tested on Ubuntu 21.04, 5.11.0-18-generic k
+ 
+ To build wireguard-rs with CNDP on Linux:
+ 
++0. Build and install CNDP in the system and also set PKG_CONFIG_PATH, LD_LIBRARY_PATH. Please refer steps 1-4 in this [link](https://github.com/CloudNativeDataPlane/cndp/tree/main/lang/rs)
+ 1. Obtain nightly `cargo` and `rustc` through [rustup](https://rustup.rs/). Need cargo version >= 1.63.0
+ 2. Clone the repository: `git clone https://github.com/intel-innersource/networking.dataplane.cndp.thirdparty.wireguard-rs.git`.
+ 3. Use cndp branch - `git checkout cndp-release`
+diff --git a/src/platform/linux/cndp/cndprustwg.sh b/src/platform/linux/cndp/cndprustwg.sh
+index ea8f231..3568c12 100755
+--- a/src/platform/linux/cndp/cndprustwg.sh
++++ b/src/platform/linux/cndp/cndprustwg.sh
+@@ -63,7 +63,7 @@ else
+ 	ARGS="--disable-drop-privileges rsuwg0"
+ fi
+ 
+-RUN="sudo -E LD_LIBRARY_PATH=$LD_LIBRARY_PATH LD_PRELOAD=$LD_LIBRARY_PATH/libpmd_af_xdp.so RUST_LOG=$RUST_LOG_VAL `which cargo` run --bin $RUST_EXE"
++RUN="sudo -E LD_LIBRARY_PATH=$LD_LIBRARY_PATH RUST_LOG=$RUST_LOG_VAL `which cargo` run --bin $RUST_EXE"
+ if [ "$BUILD" == "debug" ]; then
+ 	$RUN -- $ARGS
+ else
+-- 
+2.34.1
+


### PR DESCRIPTION
Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>