### PR TITLE
dockerfiles: move rust installation further up

### DIFF
--- a/containerization/docker/fedora/Dockerfile
+++ b/containerization/docker/fedora/Dockerfile
@@ -30,6 +30,15 @@ RUN ./configure
 RUN make -j; PREFIX=/usr make -j install
 ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig
 
+# Install Rust bindgen dependencies.
+RUN dnf -y install clang-devel curl
+
+# Install Rust and Cargo.
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Set Cargo path.
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # Copy CNDP sources, build, and install
 RUN mkdir /cndp
 WORKDIR /cndp
@@ -47,15 +56,6 @@ RUN make && make install
 # Build the prometheus-metrics app
 WORKDIR /cndp/lang/go/stats/prometheus
 RUN go build prometheus.go
-
-# Install Rust bindgen dependencies.
-RUN dnf -y install clang-devel curl
-
-# Install Rust and Cargo.
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# Set Cargo path.
-ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Build and install Rust packet fwd example application.
 # 'fwd' binary will be installed in /cndp/usr/local/bin

--- a/containerization/docker/ubuntu/Dockerfile
+++ b/containerization/docker/ubuntu/Dockerfile
@@ -31,6 +31,12 @@ RUN set -o pipefail \
     | tar -xzC / \
     && make -j -C /libbpf-0.5.0/src install
 
+# Install Rust and Cargo.
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Set Cargo path.
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # Copy CNDP sources, build, and install
 RUN mkdir /cndp
 WORKDIR /cndp
@@ -48,12 +54,6 @@ RUN make && make install
 # Build the prometheus-metrics app
 WORKDIR /cndp/lang/go/stats/prometheus
 RUN go build prometheus.go
-
-# Install Rust and Cargo.
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# Set Cargo path.
-ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Build and install Rust packet fwd example application.
 WORKDIR /cndp/lang/rs


### PR DESCRIPTION
Move the rust installation earlier in the dockerfiles, before CNDP src files are copied to the container image to avoid reinstalling rust (slow operation) everytime.

Signed-off-by: Maryam Tahhan <mtahhan@redhat.com>