### PR TITLE
add hyperscan forwarding support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,18 @@ sudo apt-get update && sudo apt-get install -y \
     libpcap-dev meson pkg-config
 ```
 
+### Hyperscan support
+
+The cndpfwd example application supports a simple hyperscan forwarding type mode. The Hyperscan
+forwarding mode uses expressions in Hyperscan style in the jsonc file in options.hs_patterns array.
+The example can be expanded to be a DDOS or DPI or a load balancer using Hyperscan. If wanting to
+try Hyperscan you must install Hyperscan. Ubuntu has a package which can be installed to enable the
+build process to detect and use Hyperscan.
+
+```bash
+sudo apt-get install -y libhyperscan-dev # In Ubuntu 22.10 the Hyperscan version is 5.4.0
+```
+
 #### Optional packages needed to build documentation
 
 ```bash

--- a/examples/cndpfwd/acl-func.c
+++ b/examples/cndpfwd/acl-func.c
@@ -311,8 +311,9 @@ int
 acl_fwd_test(jcfg_lport_t *lport, struct fwd_info *fwd)
 {
     /* do we forward non-matching packets? */
-    const bool fwd_non_matching = fwd->test == ACL_PERMISSIVE_TEST;
-    struct fwd_port *pd         = lport->priv_;
+    const bool fwd_non_matching                  = fwd->test == ACL_PERMISSIVE_TEST;
+    struct fwd_port *pd                          = lport->priv_;
+    struct create_txbuff_thd_priv_t *thd_private = pd->thd->priv_;
     struct acl_classify_t acl_classify_ctx;
     struct acl_fwd_stats *stats = &pd->acl_stats;
     uint16_t n_pkts, n_filtered, n_permit, n_deny;
@@ -322,7 +323,7 @@ acl_fwd_test(jcfg_lport_t *lport, struct fwd_info *fwd)
     if (!pd)
         return 0;
 
-    txbuff = pd->thd->priv_;
+    txbuff = thd_private->txbuffs;
 
     /* receive buffers from the network */
     switch (fwd->pkt_api) {
@@ -389,7 +390,7 @@ acl_fwd_test(jcfg_lport_t *lport, struct fwd_info *fwd)
         if (!dst)
             continue;
 
-        /* Could hang here is we can never flush the TX packets */
+        /* Could hang here if we can never flush the TX packets */
         while (txbuff_count(txbuff[dst->lpid]) > 0)
             txbuff_flush(txbuff[dst->lpid]);
     }

--- a/examples/cndpfwd/fwd.jsonc
+++ b/examples/cndpfwd/fwd.jsonc
@@ -122,7 +122,7 @@
     //   no-restapi - (O) Disable RestAPI support
     //   cli        - (O) Enable/Disable CLI supported
     //   mode       - (O) Mode type [drop | rx-only], tx-only, [lb | loopback], fwd, tx-only-rx,
-    //                    acl-strict, acl-permissive
+    //                    acl-strict, acl-permissive, [hyperscan | hs]
     //   uds_path   - (O) Path to unix domain socket to get xsk map fd
     "options": {
         "pkt_api": "xskdev",
@@ -130,9 +130,19 @@
         "no-restapi": false,
         "cli": true,
         "mode": "drop",
+        // FIB rules <IP Address>,<Destination MAC>,<destination port>
         "l3fwd-fib-rules": [
             "198.18.0.0/24,02:00:01:02:03:04,1",
             "198.18.1.0/24,06:00:01:02:03:04,0"
+        ],
+        // The lport ID value (bits 16-23) is destination port, lower 16bits is unique ID value.
+        // If bits 31 is set then matching packets are dropped. See Hyperscan
+        // documentation for regex and flags values. <ID>:/<expression>/<flags>
+        // Any packets not matching a pattern below are dropped.
+        "hs-patterns": [
+            "0x80000000:/foobar/iH",
+            "0x00010001:/foo/i",
+            "0x00000002:/bar/i"
         ]
     },
 

--- a/examples/cndpfwd/hs-fwd.c
+++ b/examples/cndpfwd/hs-fwd.c
@@ -1,0 +1,273 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2023 Intel Corporation.
+ */
+
+#include <cne_strings.h>          // for cne_strtok
+#include <net/cne_ether.h>        // for ether_addr
+#include <txbuff.h>               // for txbuff_add, txbuff_t
+#include <cne_log.h>              // for CNE_ERR_RET, CNE_LOG_ERR
+
+#include "main.h"
+
+#ifdef ENABLE_HYPERSCAN
+/*
+ * This is the event handler callback for hyperscan. The ID value is encoded into two
+ * 16 bits values. The upper 16 bits is the destination lport ID and flags with the lower 16 bits
+ * is the unique ID value to make sure all of the Hyperscan IDs are unique values.
+ *
+ * This routine returns a 16 bit value pointed to by ctx, which is bits 16-31 of the ID value.
+ * For the hyperscan forwarding code to work the bits 16-23 define the lport ID and
+ * if bit 15 0x8000 of these 16 bits is set then the packet is dropped and not forwarded.
+ */
+static int
+hsfwd_handler(unsigned int id, unsigned long long from, unsigned long long to, unsigned int flags,
+              void *ctx)
+{
+    uint16_t *lport = ctx;
+
+    CNE_SET_USED(from);
+    CNE_SET_USED(to);
+    CNE_SET_USED(flags);
+
+    /* return bits 16-31 a 16 bit value using pointer to lport */
+    if (lport)
+        *lport = (uint16_t)(id >> 16);
+
+    return 0;
+}
+#endif /* ENABLE_HYPERSCAN */
+
+int
+hsfwd_test(jcfg_lport_t *lport, struct fwd_info *fwd)
+{
+#ifdef ENABLE_HYPERSCAN
+    /* do we forward non-matching packets? */
+    struct fwd_port *pd                          = lport->priv_;
+    struct create_txbuff_thd_priv_t *thd_private = pd->thd->priv_;
+    uint16_t n_pkts;
+    txbuff_t **txbuff;
+
+    if (!pd)
+        return -1;
+
+    txbuff = thd_private->txbuffs;
+
+    if (!thd_private->scratch)
+        if (hs_clone_scratch(fwd->hs_scratch, &thd_private->scratch) != HS_SUCCESS)
+            return -1;
+
+    /* receive buffers from the network */
+    switch (fwd->pkt_api) {
+    case XSKDEV_PKT_API:
+        n_pkts = xskdev_rx_burst(pd->xsk, (void **)pd->rx_mbufs, BURST_SIZE);
+        break;
+    case PKTDEV_PKT_API:
+        n_pkts = pktdev_rx_burst(pd->lport, pd->rx_mbufs, BURST_SIZE);
+        if (n_pkts == PKTDEV_ADMIN_STATE_DOWN) {
+            hs_free_scratch(thd_private->scratch);
+            thd_private->scratch = NULL;
+            return 0;
+        }
+        break;
+    default:
+        n_pkts = 0;
+        break;
+    }
+
+    for (int i = 0; i < n_pkts; i++) {
+        pktmbuf_t *pkt = pd->rx_mbufs[i];
+        uint16_t dst_lport;
+        jcfg_lport_t *dst;
+
+        dst_lport = 0x8000; /* indicates a packet does not match any expressions, drop it */
+        if (hs_scan(fwd->hs_database, pktmbuf_mtod(pkt, char *), pktmbuf_data_len(pkt), 0,
+                    thd_private->scratch, hsfwd_handler, &dst_lport) != HS_SUCCESS) {
+            hs_free_scratch(thd_private->scratch);
+            thd_private->scratch = NULL;
+            return -1;
+        }
+
+        if (dst_lport & 0x8000) {
+            pktmbuf_free(pkt);
+            continue;
+        }
+
+        dst = jcfg_lport_by_index(fwd->jinfo, (dst_lport & 0xFF));
+        if (!dst)
+            /* Cannot forward to non-existing port, so echo back on incoming interface */
+            dst = lport;
+
+        MAC_SWAP(pktmbuf_mtod(pkt, void *));
+        (void)txbuff_add(txbuff[dst->lpid], pkt);
+    }
+
+    int nb_lports = jcfg_num_lports(fwd->jinfo);
+    for (int i = 0; i < nb_lports; i++) {
+        jcfg_lport_t *dst = jcfg_lport_by_index(fwd->jinfo, i);
+
+        if (!dst)
+            continue;
+
+        /* Could hang here if we can never flush the TX packets */
+        while (txbuff_count(txbuff[dst->lpid]) > 0)
+            txbuff_flush(txbuff[dst->lpid]);
+    }
+
+    hs_free_scratch(thd_private->scratch);
+    thd_private->scratch = NULL;
+    return 0;
+#else
+    CNE_SET_USED(lport);
+    CNE_SET_USED(fwd);
+    return -1;
+#endif /* ENABLE HYPERSCAN */
+}
+
+#ifdef ENABLE_HYPERSCAN
+static unsigned
+hs_parse_flags(const char *str)
+{
+    unsigned flags = 0;
+
+    if (!str)
+        return flags;
+
+    for (; *str != '\0'; str++) {
+        switch (*str) {
+        case 'i':
+            flags |= HS_FLAG_CASELESS;
+            break;
+        case 'm':
+            flags |= HS_FLAG_MULTILINE;
+            break;
+        case 's':
+            flags |= HS_FLAG_DOTALL;
+            break;
+        case 'H':
+            flags |= HS_FLAG_SINGLEMATCH;
+            break;
+        case 'V':
+            flags |= HS_FLAG_ALLOWEMPTY;
+            break;
+        case '8':
+            flags |= HS_FLAG_UTF8;
+            break;
+        case 'W':
+            flags |= HS_FLAG_UCP;
+            break;
+        case '\r':        // stray carriage-return
+            break;
+        case '\n':        // stray newline
+            break;
+        default:
+            cne_printf("Unsupported flag \'%c'\n", *str);
+            exit(-1);
+        }
+    }
+    return flags;
+}
+
+static int
+process_patterns(struct fwd_info *fwd)
+{
+    char *entries[4];
+    unsigned int id;
+
+    fwd->hs_ids         = (unsigned int *)calloc(fwd->hs_pattern_count + 1, sizeof(unsigned int));
+    fwd->hs_expressions = calloc(fwd->hs_pattern_count + 1, sizeof(char *));
+    fwd->hs_flags       = (unsigned int *)calloc(fwd->hs_pattern_count + 1, sizeof(unsigned int));
+    if (!fwd->hs_expressions || !fwd->hs_flags || !fwd->hs_ids) {
+        free(fwd->hs_ids);
+        free((void *)(uintptr_t)fwd->hs_expressions);
+        free(fwd->hs_flags);
+        return -1;
+    }
+
+    for (int i = 0; i < fwd->hs_pattern_count; i++) {
+        char saved[128];
+        int n;
+
+        /* Save a copy of the original string for errors */
+        memset(saved, 0, sizeof(saved)); /* make sure we have a NULL terminated string */
+        strncpy(saved, fwd->hs_patterns[i], sizeof(saved) - 1);
+
+        n = cne_strtok(fwd->hs_patterns[i], "/", entries, cne_countof(entries));
+
+        if (n < 2 || n > 3)
+            CNE_ERR_RET("Hyperscan pattern count '%s' is invalid\n", saved);
+
+        if (entries[0] == NULL)
+            CNE_ERR_RET("Hyperscan pattern ID '%s' is invalid\n", saved);
+        errno = 0;
+        id    = strtoul(entries[0], NULL, 0);
+        if (errno)
+            CNE_ERR_RET("Hyperscan ID in pattern '%s' is invalid: %s\n", saved, strerror(errno));
+        fwd->hs_ids[i]         = id;
+        fwd->hs_expressions[i] = entries[1];
+        fwd->hs_flags[i]       = hs_parse_flags(entries[2]);
+        CNE_DEBUG("ID:0x%08x, Flags:0x%08x, Pattern:%s\n", fwd->hs_ids[i], fwd->hs_flags[i],
+                  fwd->hs_expressions[i]);
+    }
+
+    return 0;
+}
+#endif /* ENABLE HYPERSCAN */
+
+void
+hsfwd_finish(struct fwd_info *fwd)
+{
+#ifdef ENABLE_HYPERSCAN
+    if (!fwd)
+        return;
+
+    free(fwd->hs_ids);
+    free(fwd->hs_expressions);
+    free(fwd->hs_flags);
+    fwd->hs_ids         = NULL;
+    fwd->hs_expressions = NULL;
+    fwd->hs_flags       = NULL;
+
+    hs_free_database(fwd->hs_database);
+    hs_free_scratch(fwd->hs_scratch);
+    fwd->hs_database = NULL;
+    fwd->hs_scratch  = NULL;
+#else
+    CNE_SET_USED(fwd);
+#endif /* ENABLE HYPERSCAN */
+}
+
+int
+hsfwd_init(struct fwd_info *fwd)
+{
+#ifdef ENABLE_HYPERSCAN
+    hs_compile_error_t *compile_err;
+
+    if (process_patterns(fwd) < 0)
+        return -1;
+
+    if (hs_compile_multi((const char *const *)fwd->hs_expressions, fwd->hs_flags, fwd->hs_ids,
+                         fwd->hs_pattern_count, HS_MODE_BLOCK, NULL, &fwd->hs_database,
+                         &compile_err) != HS_SUCCESS) {
+        cne_printf("[red]ERROR[]: Unable to compile patterns: %s\n", compile_err->message);
+        hs_free_compile_error(compile_err);
+        return -1;
+    }
+    free(fwd->hs_ids);
+    free((void *)(uintptr_t)fwd->hs_expressions);
+    free(fwd->hs_flags);
+    fwd->hs_ids         = NULL;
+    fwd->hs_expressions = NULL;
+    fwd->hs_flags       = NULL;
+
+    fwd->hs_scratch = NULL;
+    if (hs_alloc_scratch(fwd->hs_database, &fwd->hs_scratch) != HS_SUCCESS) {
+        if (hs_free_database(fwd->hs_database) != HS_SUCCESS)
+            cne_printf("hs_free_database() failed\n");
+        return -1;
+    }
+#else
+    CNE_SET_USED(fwd);
+    CNE_ERR("Not supported, Hyperscan needs to be installed\n");
+#endif /* ENABLE HYPERSCAN */
+    return 0;
+}

--- a/examples/cndpfwd/main.c
+++ b/examples/cndpfwd/main.c
@@ -15,7 +15,6 @@
 #include <cne.h>               // for cne_init, cne_on_exit, CNE_CALLED_EXIT, CNE_...
 #include <cne_log.h>           // for CNE_LOG_ERR, CNE_ERR, CNE_DEBUG, CNE_LOG_DEBUG
 #include <metrics.h>           // for metrics_destroy
-#include <txbuff.h>            // for txbuff_t, txbuff_add, txbuff_free, txbuff_pk...
 #include <cne_system.h>        // for cne_lcore_id
 #include <jcfg.h>              // for jcfg_thd_t, jcfg_lport_t, jcfg_lport_by_index
 #include <idlemgr.h>
@@ -24,11 +23,6 @@
 
 static struct fwd_info fwd_info;
 static struct fwd_info *fwd = &fwd_info;
-
-struct create_txbuff_thd_priv_t {
-    txbuff_t **txbuffs; /**< txbuff_t double pointer */
-    pkt_api_t pkt_api;  /**< The packet API mode */
-};
 
 #define foreach_thd_lport(_t, _lp) \
     for (int _i = 0; _i < _t->lport_cnt && (_lp = _t->lports[_i]); _i++, _lp = _t->lports[_i])
@@ -458,6 +452,7 @@ thread_func(void *arg)
         {acl_fwd_test},
         {acl_fwd_test},
         {_txonly_rx_test},
+        {hsfwd_test},
         {NULL}
     };
     // clang-format on
@@ -474,7 +469,7 @@ thread_func(void *arg)
         goto leave_no_lport;
 
     if (fwd->test == FWD_TEST || fwd->test == L3_FWD_TEST || fwd->test == ACL_STRICT_TEST ||
-        fwd->test == ACL_PERMISSIVE_TEST) {
+        fwd->test == ACL_PERMISSIVE_TEST || fwd->test == HYPERSCAN_TEST) {
         if (create_per_thread_txbuff(thd, fwd))
             cne_exit("Failed to create txbuff(s) for \"%s\" thread\n", thd->name);
     }
@@ -540,7 +535,7 @@ thread_func(void *arg)
 
 leave:
     if (fwd->test == FWD_TEST || fwd->test == L3_FWD_TEST || fwd->test == ACL_STRICT_TEST ||
-        fwd->test == ACL_PERMISSIVE_TEST)
+        fwd->test == ACL_PERMISSIVE_TEST || fwd->test == HYPERSCAN_TEST)
         destroy_per_thread_txbuff(thd, fwd);
 leave_no_lport:
     if (imgr)
@@ -697,7 +692,8 @@ main(int argc, char **argv)
 {
     // clang-format off
     const char *tests[] = {
-        "Unknown", "Drop",
+        "Unknown",
+        "Drop",
         "Loopback",
         "Tx Only",
 		"Forward",
@@ -705,11 +701,13 @@ main(int argc, char **argv)
         "ACL Strict",
         "ACL Permissive",
         "Tx Only+RX",
+        "Hyperscan",
         NULL
     };
     // clang-format on
     const char *apis[] = {"Unknown", "XSKDEV", "PKTDEV", NULL};
     int signals[]      = {SIGINT, SIGUSR1, SIGTERM};
+    char c;
 
     memset(&fwd_info, 0, sizeof(struct fwd_info));
 
@@ -734,13 +732,21 @@ main(int argc, char **argv)
     if (fwd->test == L3_FWD_TEST && l3fwd_fib_init(fwd) < 0)
         goto err;
 
+    if (fwd->test == HYPERSCAN_TEST && hsfwd_init(fwd) < 0)
+        goto err;
+
     /* don't start any threads before we initialize ACL */
     if (pthread_barrier_wait(&fwd->barrier) > 0)
         CNE_ERR_GOTO(err, "Failed to wait for barrier\n");
 
+    /* Set up tty to be able to see any key being pressed to exit */
+    if (tty_setup(-1, -1) < 0)
+        CNE_ERR_RET("unable to setup tty, exiting\n");
+
     fwd->timer_quit = 0;
     for (;;) {
-        sleep(1);
+        if (tty_poll(&c, 1, 1000))
+            break;
 
         if (fwd->timer_quit) /* Test for quitting after sleep to avoid calling print_port_stats() */
             break;
@@ -748,8 +754,11 @@ main(int argc, char **argv)
         if (fwd->opts.cli)
             print_port_stats_all(fwd);
     }
+    if (fwd->test == HYPERSCAN_TEST)
+        hsfwd_finish(fwd);
+
     if (pthread_barrier_destroy(&fwd->barrier))
-        CNE_ERR_GOTO(err, "Failed to destroy barrier\n");
+        CNE_ERR_RET("Failed to destroy barrier\n");
 
     cne_printf(">>> [cyan]Application Exiting[]: [green]Bye![]\n");
     return 0;
@@ -757,6 +766,9 @@ main(int argc, char **argv)
 err:
     if (fwd->barrier_inited && pthread_barrier_destroy(&fwd->barrier))
         CNE_ERR("Failed to destroy barrier\n");
+
+    if (fwd->test == HYPERSCAN_TEST)
+        hsfwd_finish(fwd);
 
     cne_printf("\n*** [cyan]CNDPFWD Forward Application[], [green]API[]: [magenta]%s [green]PID[]: "
                "[magenta]%d[] failed\n",

--- a/examples/cndpfwd/meson.build
+++ b/examples/cndpfwd/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2020-2022 Intel Corporation
 
-sources = files('main.c', 'parse-args.c', 'stats.c', 'acl-func.c', 'l3-fwd.c')
+sources = files('main.c', 'parse-args.c', 'stats.c', 'acl-func.c', 'l3-fwd.c', 'hs-fwd.c')
 
 deps += [
     acl,

--- a/examples/cndpfwd/parse-args.c
+++ b/examples/cndpfwd/parse-args.c
@@ -77,16 +77,27 @@ process_callback(jcfg_info_t *j __cne_unused, void *_obj, void *arg, int idx)
                     CNE_ERR_RET("UDS handshake failed\n");
             }
         } else if (!strncmp(obj.opt->name, FIB_RULES_TAG, nlen)) {
-            uint16_t i;
             if (obj.opt->val.type == ARRAY_OPT_TYPE) {
                 f->fib_rules = calloc(obj.opt->val.array_sz, sizeof(char *));
                 if (!f->fib_rules)
                     CNE_ERR_RET("Unable to allocate fib_rules array\n");
 
-                for (i = 0; i < obj.opt->val.array_sz; ++i)
+                for (int i = 0; i < obj.opt->val.array_sz; ++i) {
                     f->fib_rules[i] = obj.opt->val.arr[i]->str;
+                    f->fib_size++;
+                }
+            }
+        } else if (!strncmp(obj.opt->name, HS_PATTERN_TAG, nlen)) {
+            if (obj.opt->val.type == ARRAY_OPT_TYPE) {
+                f->hs_patterns = calloc(obj.opt->val.array_sz, sizeof(char *));
+                if (!f->hs_patterns)
+                    CNE_ERR_RET("Unable to allocate hsfwd information array\n");
 
-                f->fib_size = i;
+                for (int i = 0; i < obj.opt->val.array_sz; ++i) {
+                    CNE_DEBUG("Hyperscan pattern: '%s'\n", obj.opt->val.arr[i]->str);
+                    f->hs_patterns[i] = obj.opt->val.arr[i]->str;
+                    f->hs_pattern_count++;
+                }
             }
         }
         break;
@@ -266,7 +277,8 @@ print_usage(char *prog_name)
 {
     cne_printf("Usage: %s [-h] [-c json_file] [-b burst] <mode>\n"
                "  <mode>         Mode types [drop | rx-only], tx-only, [lb | loopback], fwd, "
-               "acl-strict or acl-permissive\n"
+               "acl-strict, acl-permissive\n"
+               "                 or [hyperscan | hs] Hyperscan needs to be installed to work\n"
                "  -a <api>       The API type to use xskdev or pktdev APIs, default is xskdev.\n"
                "                 The -a option overrides JSON file.\n"
                "  -b <burst>     Burst size. If not present default burst size %d max %d.\n"

--- a/meson.build
+++ b/meson.build
@@ -145,6 +145,14 @@ if pcap_dep.found()
     extra_ldflags += '-lpcap'
 endif
 
+# Check for libhs (hyperscan) for cndpfwd
+hs_dep = dependency('libhs', required: false, static: use_static_libs)
+if hs_dep.found()
+    add_project_link_arguments('-lhs', language: 'c')
+    extra_ldflags += '-lhs'
+    cne_conf.set('ENABLE_HYPERSCAN', 1)
+endif
+
 add_project_arguments('-I/usr/include/libnl3', language: 'c')
 
 nl_dep = dependency('libnl-3.0', required: true, method: 'pkg-config', static: use_static_libs)


### PR DESCRIPTION
Add a simple forwarding mode using Hyperscan regex expressions to cndpfwd application. The example can be expanded to be a DDOS or DPI or a load balancer using Hyperscan. The example needs Hyperscan installed to work.

The cndpfwd application in Hyperscan mode will drop or forward packets to a different port. The Hyperscan string format is ```<ID>:/<regex>/<flags>``` flags are the standard Hyperscan flags.

The ID number can be in hex or decimal, but hex 0x00000000 is easier to use as the value is encoded with the port ID value in bits 16-23 , which is a value 0-N N being lport ID. The bits 24-31 can be used for flags and the only flag today is 0x80, which means the packets that match this expression should be dropped. The lower 16 bits is a unique ID value for each expression and is not used by the application.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>