### PR TITLE
cleanup console when quiting

### DIFF
--- a/examples/cndpfwd/main.c
+++ b/examples/cndpfwd/main.c
@@ -760,7 +760,7 @@ main(int argc, char **argv)
     if (pthread_barrier_destroy(&fwd->barrier))
         CNE_ERR_RET("Failed to destroy barrier\n");
 
-    cne_printf(">>> [cyan]Application Exiting[]: [green]Bye![]\n");
+    cne_printf_pos(99, 1, ">>> [cyan]Application Exiting[]: [green]Bye![]\n");
     return 0;
 
 err:
@@ -770,8 +770,10 @@ err:
     if (fwd->test == HYPERSCAN_TEST)
         hsfwd_finish(fwd);
 
-    cne_printf("\n*** [cyan]CNDPFWD Forward Application[], [green]API[]: [magenta]%s [green]PID[]: "
-               "[magenta]%d[] failed\n",
-               apis[fwd->pkt_api], getpid());
+    cne_printf_pos(
+        99, 1,
+        "\n*** [cyan]CNDPFWD Forward Application[], [green]API[]: [magenta]%s [green]PID[]: "
+        "[magenta]%d[] failed\n",
+        apis[fwd->pkt_api], getpid());
     return -1;
 }


### PR DESCRIPTION
When quiting the application normally the text was over written, move the cursor to the bottom of the terminal when quiting.

Signed-off-by: Keith Wiles <keith.wiles@intel.com>