### PR TITLE
Add more test cases for go binding api

### DIFF
--- a/lang/go/bindings/cne/jcfg_test.go
+++ b/lang/go/bindings/cne/jcfg_test.go
@@ -6,6 +6,7 @@
 package cne
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -26,15 +27,167 @@ var lcoreInfoMarshalTests = []struct {
 var lcoreInfoUnmarshalTests = []struct {
 	str   string
 	cores LCoreInfo
+	noErr bool
 }{
-	{`[]`, LCoreInfo{}},
-	{` [  ]  `, LCoreInfo{}},
-	{` [ "3" ] `, LCoreInfo{3}},
-	{`[4,5,6]`, LCoreInfo{4, 5, 6}},
-	{`["4-6"]`, LCoreInfo{4, 5, 6}},
-	{`[1,4,7]`, LCoreInfo{1, 4, 7}},
-	{` [ 1, 4 , 7] `, LCoreInfo{1, 4, 7}},
-	{` [ 4, 7, 7, 9,4] `, LCoreInfo{4, 7, 9}},
+	{``, nil, false},
+	{`{1,2}`, nil, false},
+	{`["-1"]`, nil, false},
+	{`[]`, LCoreInfo{}, true},
+	{` [  ]  `, LCoreInfo{}, true},
+	{` [ "3" ] `, LCoreInfo{3}, true},
+	{`[4,5,6]`, LCoreInfo{4, 5, 6}, true},
+	{`["4-6"]`, LCoreInfo{4, 5, 6}, true},
+	{`["4-6-9"]`, nil, false},
+	{`["4-n"]`, nil, false},
+	{`["n-6"]`, nil, false},
+	{`["6-4"]`, nil, false},
+	{`["4-4"]`, LCoreInfo{4}, true},
+	{`[1,4,7]`, LCoreInfo{1, 4, 7}, true},
+	{` [ 1, 4 , 7] `, LCoreInfo{1, 4, 7}, true},
+	{` [ 4, 7, 7, 9,4] `, LCoreInfo{4, 7, 9}, true},
+}
+
+var validateRegionsTests = []struct {
+	jcfg *Config
+	err  string
+}{
+	{
+		&Config{
+			UmemInfoMap: map[string]*UmemInfo{},
+		},
+		"",
+	},
+	{
+		&Config{
+			UmemInfoMap: map[string]*UmemInfo{
+				"umem1": {Regions: []uint{1, 2}},
+				"umem2": {Regions: []uint{3}},
+			},
+		},
+		"",
+	},
+	{
+		&Config{
+			UmemInfoMap: map[string]*UmemInfo{
+				"umem1": {Regions: make([]uint, UmemMaxRegions)},
+			},
+		},
+		fmt.Sprintf("invalid number of regions %d with umem umem1", UmemMaxRegions),
+	},
+}
+
+var validateLCoreGroupsTests = []struct {
+	jcfg *Config
+	err  string
+}{
+	{
+		&Config{
+			LCoreGroupData: map[string]LCoreInfo{
+				"group0": {3, 4, 5},
+			},
+		},
+		"",
+	},
+	{
+		&Config{
+			LCoreGroupData: map[string]LCoreInfo{
+				"group0": {},
+			},
+		},
+		"",
+	},
+	{
+		&Config{
+			LCoreGroupData: map[string]LCoreInfo{
+				"group0": {-1, 1},
+			},
+		},
+		"core -1 in lcore group group0 is < 0",
+	},
+}
+
+var validateThreadInfoMapTests = []struct {
+	jcfg *Config
+	err  string
+}{
+	{
+		&Config{
+			ThreadInfoMap: map[string]*ThreadInfo{
+				"thread0": {
+					Group:  "group0",
+					LPorts: []string{"eth0"},
+				},
+			},
+			LCoreGroupData: map[string]LCoreInfo{
+				"group0": {3, 4},
+			},
+			LPortInfoMap: map[string]*LPortInfo{
+				"eth0": {},
+			},
+		},
+		"",
+	},
+	{
+		&Config{
+			ThreadInfoMap: map[string]*ThreadInfo{
+				"thread0": {
+					Group:  "group1",
+					LPorts: []string{"eth0"},
+				},
+			},
+			LCoreGroupData: map[string]LCoreInfo{
+				"group0": {3, 4},
+			},
+			LPortInfoMap: map[string]*LPortInfo{
+				"eth0": {},
+			},
+		},
+		"lcore group group1 for thread thread0 is missing or empty",
+	},
+	{
+		&Config{
+			ThreadInfoMap: map[string]*ThreadInfo{
+				"thread0": {
+					Group:  "group0",
+					LPorts: []string{"eth1"},
+				},
+			},
+			LCoreGroupData: map[string]LCoreInfo{
+				"group0": {3, 4},
+			},
+			LPortInfoMap: map[string]*LPortInfo{
+				"eth0": {},
+			},
+		},
+		"invalid lport eth1 for thread thread0",
+	},
+}
+
+var processConfigTests = []struct {
+	input  []byte
+	expect *Config
+	err    string
+}{
+	{
+		[]byte(" "),
+		nil,
+		"empty json text string",
+	},
+	{
+		[]byte("#{}"),
+		nil,
+		"string does not appear to be a valid JSON text missing starting '{'",
+	},
+	{
+		[]byte("{\"foo\":null,\"bar\":null"),
+		nil,
+		"unexpected end of JSON input",
+	},
+	{
+		[]byte("{\"application\":null,\"defaults\":null}"),
+		nil,
+		"",
+	},
 }
 
 func TestLCoreInfo(t *testing.T) {
@@ -53,11 +206,63 @@ func TestLCoreInfo(t *testing.T) {
 			var cores LCoreInfo
 			err := cores.UnmarshalJSON([]byte(ct.str))
 
-			if err != nil {
+			if err != nil && ct.noErr {
 				t.Errorf("LCoreInfo.UnmarshalJSON(%s) error: %s", ct.str, err.Error())
 			} else if !reflect.DeepEqual(cores, ct.cores) {
 				t.Errorf("LCoreInfo.UnmarshalJSON(%s) failed: want '%v' got '%v'", ct.str, ct.cores, cores)
 			}
 		}
 	})
+}
+
+func TestConfig(t *testing.T) {
+	t.Run("validateRegions", func(t *testing.T) {
+		for _, ct := range validateRegionsTests {
+			err := ct.jcfg.validateRegions()
+			if err != nil {
+				if err.Error() != ct.err {
+					t.Errorf("Config.validateRegions() error: %s", err.Error())
+				}
+			} else if len(ct.err) != 0 {
+				t.Errorf("Config.validateRegions() failed: want '%s'", ct.err)
+			}
+		}
+	})
+	t.Run("validateLCoreGroups", func(t *testing.T) {
+		for _, ct := range validateLCoreGroupsTests {
+			err := ct.jcfg.validateLCoreGroups()
+			if err != nil {
+				if err.Error() != ct.err {
+					t.Errorf("Config.validateLCoreGroups() error: %s", err.Error())
+				}
+			} else if len(ct.err) != 0 {
+				t.Errorf("Config.validateLCoreGroups() failed: want '%s'", ct.err)
+			}
+		}
+	})
+	t.Run("validateThreadInfoMap", func(t *testing.T) {
+		for _, ct := range validateThreadInfoMapTests {
+			err := ct.jcfg.validateThreadInfoMap()
+			if err != nil {
+				if err.Error() != ct.err {
+					t.Errorf("Config.validateThreadInfoMap() error: %s", err.Error())
+				}
+			} else if len(ct.err) != 0 {
+				t.Errorf("Config.validateThreadInfoMap() failed: want '%s'", ct.err)
+			}
+		}
+	})
+	t.Run("processConfig", func(t *testing.T) {
+		for _, ct := range processConfigTests {
+			_, err := processConfig(ct.input)
+			if err != nil {
+				if err.Error() != ct.err {
+					t.Errorf("processConfig(%s) error: %s", string(ct.input), err.Error())
+				}
+			} else if len(ct.err) != 0 {
+				t.Errorf("processConfig(%s) failed: want '%s'", string(ct.input), ct.err)
+			}
+		}
+	})
+
 }

--- a/lang/go/bindings/cne/util_test.go
+++ b/lang/go/bindings/cne/util_test.go
@@ -1,0 +1,25 @@
+package cne
+
+import (
+	"testing"
+)
+
+var swapUint16Tests = []struct {
+	input  uint16
+	expect uint16
+}{
+	{uint16(0x1234), uint16(0x3412)},
+	{uint16(0xABCD), uint16(0xCDAB)},
+	{uint16(0xFFFF), uint16(0xFFFF)},
+}
+
+func TestUtil(t *testing.T) {
+	t.Run("SwapUint16", func(t *testing.T) {
+		for _, ct := range swapUint16Tests {
+			got := SwapUint16(ct.input)
+			if got != ct.expect {
+				t.Errorf("SwapUint16(%v) failed: want '%v' got '%v'", ct.input, ct.expect, got)
+			}
+		}
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Add more test cases to improve go code coverage.
Due to time limits, we only update 2 files test cases, would like to add more after hackathon.

Before is:
```
github.com/CloudNativeDataPlane/cndp/lang/go/bindings/cne/jcfg.go (68.1%)
github.com/CloudNativeDataPlane/cndp/lang/go/bindings/cne/util.go (45.5%)
```

Now is:
```
github.com/CloudNativeDataPlane/cndp/lang/go/bindings/cne/jcfg.go (77.7%)
github.com/CloudNativeDataPlane/cndp/lang/go/bindings/cne/util.go (54.5%)
```

#### Which issue(s) this PR fixes:
Fixes part of #288 

Signed-off-by: Hao Ruan [hao.ruan@intel.com](mailto:hao.ruan@intel.com)
Signed-off-by: Xiaotian Chen [xiaotian.chen@intel.com](mailto:xiaotian.chen@intel.com)