### PR TITLE
cnet: punt unknown ip4 packets to the kernel.

### DIFF
--- a/lib/cnet/ipv4/ip4_forward.c
+++ b/lib/cnet/ipv4/ip4_forward.c
@@ -157,6 +157,7 @@ ip4_forward_node_process(struct cne_graph *graph, struct cne_node *node, void **
             }
         }
 
+        fi = cnet->rt4_finfo;
         /* Enqueue four to next node */
         cne_edge_t fix_spec =
             ((n_index ^ n0) && (n_index ^ n1) && (n_index ^ n2) && (n_index ^ n3));

--- a/lib/cnet/ipv4/ip4_proto.c
+++ b/lib/cnet/ipv4/ip4_proto.c
@@ -43,8 +43,8 @@ ip4_proto_node_process(struct cne_graph *graph, struct cne_node *node, void **ob
     int i;
 
     /* Speculative next
-     * If the packet is a proto that we don't know it will get punted to the Kernel
-     * instead of being dropped.
+     * If the packet has made it this far and isn't UDP/TCP,
+     * punt it to the kernel if punt is enabled, else drop it.
      */
     next_index = (cnet->flags & CNET_PUNT_ENABLED) ? CNE_NODE_IP4_INPUT_PROTO_PUNT
                                                    : CNE_NODE_IP4_INPUT_PROTO_DROP;
@@ -209,8 +209,8 @@ static struct cne_node_register ip4_proto_node = {
     .next_nodes =
         {
             [CNE_NODE_IP4_INPUT_PROTO_DROP] = PKT_DROP_NODE_NAME,
-            [CNE_NODE_IP4_INPUT_PROTO_UDP]  = UDP_INPUT_NODE_NAME,
             [CNE_NODE_IP4_INPUT_PROTO_PUNT] = PUNT_KERNEL_NODE_NAME,
+            [CNE_NODE_IP4_INPUT_PROTO_UDP]  = UDP_INPUT_NODE_NAME,
 #if CNET_ENABLE_TCP
             [CNE_NODE_IP4_INPUT_PROTO_TCP] = TCP_INPUT_NODE_NAME,
 #endif

--- a/lib/cnet/ipv4/ip4_proto_priv.h
+++ b/lib/cnet/ipv4/ip4_proto_priv.h
@@ -21,8 +21,8 @@ extern "C" {
 
 enum cne_node_ip4_proto_next {
     CNE_NODE_IP4_INPUT_PROTO_DROP, /**< Packet drop node. */
-    CNE_NODE_IP4_INPUT_PROTO_UDP,  /**< UDP protocol. */
     CNE_NODE_IP4_INPUT_PROTO_PUNT,
+    CNE_NODE_IP4_INPUT_PROTO_UDP, /**< UDP protocol. */
 #if CNET_ENABLE_TCP
     CNE_NODE_IP4_INPUT_PROTO_TCP, /**< TCP protocol. */
 #endif

--- a/lib/cnet/ipv4/ip4_proto_priv.h
+++ b/lib/cnet/ipv4/ip4_proto_priv.h
@@ -22,6 +22,7 @@ extern "C" {
 enum cne_node_ip4_proto_next {
     CNE_NODE_IP4_INPUT_PROTO_DROP, /**< Packet drop node. */
     CNE_NODE_IP4_INPUT_PROTO_UDP,  /**< UDP protocol. */
+    CNE_NODE_IP4_INPUT_PROTO_PUNT,
 #if CNET_ENABLE_TCP
     CNE_NODE_IP4_INPUT_PROTO_TCP, /**< TCP protocol. */
 #endif


### PR DESCRIPTION
Hey Keith
The idea here is that if we've made it to the ip_proto node and the protocol isn't UDP/TCP then we punt the packet to the kernel rather than drop it.

I haven't tested this yet - but would be interested to know your initial feedback.
