### PR TITLE
txgen: reduce stats thread update to bring down cpu usage

### DIFF
--- a/usrtools/txgen/app/txgen.c
+++ b/usrtools/txgen/app/txgen.c
@@ -904,16 +904,16 @@ txgen_stats(void *arg)
         if (curr >= page) {
             page = curr + page_timo;
             txgen_page_display();
-        } else {
-            if (curr >= stats) {
-                stats = curr + process_timo;
-                PKTDEV_FOREACH (pid) {
-                    txgen_process_stats(pid);
-                    if (thd->quit)
-                        break;
-                }
-            } else
-                cne_pause();
         }
+
+        if (curr >= stats) {
+            stats = curr + process_timo;
+            PKTDEV_FOREACH (pid) {
+                txgen_process_stats(pid);
+                if (thd->quit)
+                    break;
+            }
+        }
+        usleep(100); /* 100ms */
     }
 }


### PR DESCRIPTION
The txgen_stats() function was causing a full core to run at 100%... the cne_pause() function wasn't really alleviating the issue. I've opted to usleep here for 100ms as this is the refresh rate we also use for the cli prompt. 