### PR TITLE
cnet: fix some init issues and cleanup IPv6 ifdefs

### DIFF
--- a/doc/guides/prog_guide/cnet.rst
+++ b/doc/guides/prog_guide/cnet.rst
@@ -178,36 +178,44 @@ the information to control the CNET stack. This structure is created once for al
 .. code-block:: c
    :caption: CNET Structure layout
 
-       struct cnet {
-           CNE_ATOMIC(uint_fast16_t) stk_order; /**< Order of the stack initializations */
-           uint16_t nb_ports;                   /**< Number of ports in the system */
-           uint32_t num_chnls;                  /**< Number of channels in system */
-           uint32_t num_routes;                 /**< Number of routes */
-           uint32_t num_arps;                   /**< Number of ARP entries */
-           uint16_t flags;                      /**< Flags */
-           u_id_t chnl_uids;                    /**< UID for channel descriptor like values */
-           void **chnl_descriptors;             /**< List of channel descriptors pointers */
-           void *netlink_info;                  /**< Netlink information structure */
-           struct stk_s **stks;                 /**< Vector list of stk_entry pointers */
-           struct drv_entry **drvs;             /**< Vector list of drv_entry pointers */
-           struct netif **netifs;               /**< List of active netif structures */
-           struct cne_mempool *rt4_obj;         /**< Route IPv4 table pointer */
-           struct cne_mempool *arp_obj;         /**< ARP object structures */
-           struct fib_info *rt4_finfo;          /**< Pointer to the IPv4 FIB information structure */
-           struct fib_info *arp_finfo;          /**< ARP FIB table pointer */
-           struct fib_info *pcb_finfo;          /**< PCB FIB table pointer */
-           struct fib_info *tcb_finfo;          /**< TCB FIB table pointer */
-       } __cne_cache_aligned;
+         struct cnet {
+            CNE_ATOMIC(uint_fast16_t) stk_order; /**< Order of the stack initializations */
+            uint16_t nb_ports;                   /**< Number of ports in the system */
+            uint32_t num_chnls;                  /**< Number of channels in system */
+            uint32_t num_routes;                 /**< Number of IPv4 routes */
+            uint32_t num_6routes;                /**< Number of IPv6 routes */
+            uint32_t num_arps;                   /**< Number of ARP entries */
+            uint32_t num_neighs;                 /**< Number of ND6 entries */
+            uint16_t flags;                      /**< Flags enable Punting, TCP, ... */
+            u_id_t chnl_uids;                    /**< UID for channel descriptor like values */
+            void **chnl_descriptors;             /**< List of channel descriptors pointers */
+            void *netlink_info;                  /**< Netlink information structure */
+            struct stk_s **stks;                 /**< Vector list of stk_entry pointers */
+            struct drv_entry **drvs;             /**< Vector list of drv_entry pointers */
+            struct netif **netifs;               /**< List of active netif structures */
+            struct cne_mempool *rt4_obj;         /**< Route IPv4 table pointer */
+            struct cne_mempool *rt6_obj;         /**< Route IPv6 table pointer */
+            struct cne_mempool *arp_obj;         /**< ARP object structures */
+            struct cne_mempool *nd6_obj;         /**< NDP for IPv6 object structures */
+            struct fib_info *rt4_finfo;          /**< Pointer to the IPv4 FIB information structure */
+            struct fib_info *rt6_finfo;          /**< Pointer to the IPv6 FIB information structure */
+            struct fib_info *arp_finfo;          /**< ARP FIB table pointer */
+            struct fib_info *nd6_finfo;          /**< NDP (for IPv6) FIB table pointer */
+            struct fib_info *pcb_finfo;          /**< PCB FIB table pointer */
+            struct fib_info *tcb_finfo;          /**< TCB FIB table pointer */
+         } __cne_cache_aligned;
 
 The **netlink_info** is the opaque pointer to the *Netlink* information and is used with the *netlink*
 library to manage the messages from the kernel. The next set of entries *nb_ports*, *num_chnls*,
-*num_routes* and *num_arps* are values set at startup time to define and limit the
+*num_routes*, *num_6routes* and *num_arps* are values set at startup time to define and limit the
 number of items created.
 
   - **nb_ports** defines the number of ports assigned to the application for the stack to use.
   - **num_chnls** defines the number of channel structures allowed in the stack.
-  - **num_routes** defines the number of routes structures allowed in the stack.
+  - **num_routes** defines the number of IPv4 routes structures allowed in the stack.
+  - **num_6routes** defines the number of IPv6 routes structures allowed in the stack.
   - **num_arps** defines the number of ARP structures allowed in the stack.
+  - **num_neighs** defines the number of MD6 structures allowed in the stack.
 
 The **flags** field defines a simple set of flags that can be used by the stack. The two currently
 defined are *CNET_PUNT_ENABLED* and *CNET_TCP_ENABLED* to control if we support punting packets to the
@@ -227,8 +235,12 @@ CNET stack. The **netifs** is the list of network interfaces attached to the CNE
 system network interfaces.
 
 The **rt4_obj** and **arp_obj** are mempools holding the number of IPv4 route structures and ARP structures
-to enable allocating/freeing these entries quickly, plus limiting the number of each item. The *fib*
-entries rt4, arp, pcb and tcb are used to locate these entries quickly using the *FIB* LPM library.
+to enable allocating/freeing these entries quickly, plus limiting the number of each item.
+
+The **rt6_obj** and **nd6_obj** are mempools holding the number of IPv6 route structures and ND6 structures
+to enable allocating/freeing these entries quickly, plus limiting the number of each item.
+
+The *fib* entries rt4, rt6, arp, nd6, pcb and tcb are used to locate these entries quickly using the *FIB* LPM library.
 
 CNET Stack Structure
 ^^^^^^^^^^^^^^^^^^^^

--- a/examples/cnet-graph/cnet-graph.c
+++ b/examples/cnet-graph/cnet-graph.c
@@ -95,11 +95,15 @@ initialize_graph(jcfg_thd_t *thd, graph_info_t *gi)
 
     if (cinfo->flags & FWD_DEBUG_STATS)
         cne_printf("  [magenta]Patterns[]: ");
+
     for (int i = 0; i < pattern_array->array_sz; i++) {
         char *pat = pattern_array->arr[i]->str;
 
         if ((CNET_ENABLE_TCP == 0) && !strncasecmp("tcp*", pat, 4))
             continue;
+        if ((CNET_ENABLE_IP6 == 0) && !strncasecmp("ip6*", pat, 4))
+            continue;
+
         if (cinfo->flags & FWD_DEBUG_STATS)
             cne_printf("'[orange]%s[]' ", pat);
 

--- a/lib/cnet/chnl/cnet_chnl.c
+++ b/lib/cnet/chnl/cnet_chnl.c
@@ -741,7 +741,6 @@ sendit(int cd, struct sockaddr *sa, pktmbuf_t **mbufs, uint16_t nb_mbufs)
             if (!md)
                 CNE_ERR_RET_VAL(__errno_set(EFAULT), "pktmbuf metadata is NULL\n");
 
-#if CNET_ENABLE_IP6
             if (is_ch_dom_inet6(ch)) {
                 struct sockaddr_in6 *addr;
 
@@ -753,7 +752,6 @@ sendit(int cd, struct sockaddr *sa, pktmbuf_t **mbufs, uint16_t nb_mbufs)
                     inet6_addr_copy(&md->faddr.cin6_addr, &addr->sin6_addr);
                 }
             } else {
-#endif
                 struct sockaddr_in *addr;
 
                 addr = (struct sockaddr_in *)&sa[i];
@@ -763,9 +761,7 @@ sendit(int cd, struct sockaddr *sa, pktmbuf_t **mbufs, uint16_t nb_mbufs)
                     md->faddr.cin_len         = sizeof(struct in_addr);
                     md->faddr.cin_addr.s_addr = addr->sin_addr.s_addr;
                 }
-#if CNET_ENABLE_IP6
             }
-#endif
         }
     }
 
@@ -952,11 +948,9 @@ chnl_connect_common(struct chnl *ch, struct in_caddr *to, int32_t tolen __cne_un
     chnl_state_set(ch, _ISCONNECTED);
 
     if (!ch->ch_pcb->netif) {
-#if CNET_ENABLE_IP6
         if (is_ch_dom_inet6(ch))
             ch->ch_pcb->netif = cnet6_netif_match_subnet(&to->cin6_addr);
         else /* if AF_INET */
-#endif
             ch->ch_pcb->netif = cnet_netif_match_subnet(&to->cin_addr);
     }
 

--- a/lib/cnet/cmds/cnet_cmds.c
+++ b/lib/cnet/cmds/cnet_cmds.c
@@ -14,7 +14,9 @@
 #include <cnet_route.h>            // for
 #include <cnet_netif.h>            // for netif
 #include <cnet_route4.h>           // for cnet_route4_show
+#include <cnet_route6.h>           // for cnet_route6_show
 #include <cnet_arp.h>              // for cnet_arp_show
+#include <cnet_nd6.h>              // for cnet_nd6_show
 #include <hmap.h>                  // for hmap_list_dump
 #include <cnet_ip_common.h>        // for ip_info
 #include <cnet_meta.h>             // for cnet_metadata
@@ -46,6 +48,13 @@
     do {                                                                   \
         snprintf(pbuff, sizeof(pbuff), "sizeof([cyan]struct %s[])", #_s);  \
         cne_printf("%-40s : [magenta]%4lu[]\n", pbuff, sizeof(struct _s)); \
+    } while (0)
+
+#define _prt2(_s, _d, _t)                                                 \
+    do {                                                                  \
+        snprintf(pbuff, sizeof(pbuff), "sizeof([cyan]struct %s[])", #_s); \
+        cne_printf("%-40s : [magenta]%4lu[]", pbuff, sizeof(struct _s));  \
+        cne_printf(" * %5d([cyan]netifs[]) = [magenta]%lu[]\n", _d, _t);  \
     } while (0)
 
 #define gfprintf(f, format, args...)                 \
@@ -90,32 +99,39 @@ dump_sizes(void)
 
     tot = (sizeof(stk_t) * stk_cnt);
     total += tot;
-    _prt(stk_s);
-    cne_printf("%32s : * %5d([cyan]lcores[]) = [magenta]%lu[]\n", "", stk_cnt, tot);
+    _prt2(stk_s, stk_cnt, tot);
 
     tot = (sizeof(struct netif) * (stk_cnt * drv_cnt));
     total += tot;
-    _prt(netif);
-    cne_printf("%32s : * %5d([cyan]netifs[]) = [magenta]%lu[]\n", "", (stk_cnt * drv_cnt), tot);
+    _prt2(netif, (stk_cnt * drv_cnt), tot);
 
     tot = (sizeof(struct drv_entry) * drv_cnt);
     total += tot;
-    _prt(drv_entry);
-    cne_printf("%32s : * %5d([cyan]ports[])  = [magenta]%lu[]\n", "", drv_cnt, tot);
+    _prt2(drv_entry, drv_cnt, tot);
 
     tot = (sizeof(struct rt4_entry) * this_cnet->num_routes);
     total += tot;
-    _prt(rt4_entry);
-    cne_printf("%32s : * %5d([cyan]routes[]) = [magenta]%lu[]\n", "", this_cnet->num_routes, tot);
+    _prt2(rt4_entry, this_cnet->num_routes, tot);
+
+    tot = (sizeof(struct rt6_entry) * this_cnet->num_6routes);
+    total += tot;
+    _prt2(rt6_entry, this_cnet->num_6routes, tot);
+
+    tot = (sizeof(struct arp_entry) * this_cnet->num_arps);
+    total += tot;
+    _prt2(arp_entry, this_cnet->num_arps, tot);
+
+    tot = (sizeof(struct nd6_cache_entry) * this_cnet->num_neighs);
+    total += tot;
+    _prt2(nd6_cache_entry, this_cnet->num_neighs, tot);
 
     tot = sizeof(struct ipv4_entry);
     total += tot;
     _prt(ipv4_entry);
 
-    tot = (sizeof(struct arp_entry) * this_cnet->num_arps);
+    tot = sizeof(struct ipv6_entry);
     total += tot;
-    _prt(arp_entry);
-    cne_printf("%32s : * %5d([cyan]routes[]) = [magenta]%lu[]\n", "", this_cnet->num_arps, tot);
+    _prt(ipv6_entry);
 
     cne_printf("\n  Total memory used [magenta]%lu[] bytes\n", total);
 
@@ -190,7 +206,7 @@ cmd_info(int argc, char **argv)
 
     m = cli_mapping(info_map, argc, argv);
     if (!m)
-        return cli_cmd_error("Info command is invalid", "Info", argc, argv);
+        return cli_cmd_error("Command is invalid", "Info", argc, argv);
 
     switch (m->index) {
     case 10:
@@ -564,7 +580,10 @@ static struct cli_map ip_map[] = {
     {10, "ip link"},
     {11, "ip link %s"},
     {20, "ip route"},
-    {30, "ip neigh"},
+    {21, "ip route4"},
+    {22, "ip route6"},
+    {30, "ip arp"},
+    {31, "ip neigh"},
     {40, "ip stats"},
     {41, "ip stats %d"},
     {-1, NULL}
@@ -576,37 +595,40 @@ cmd_ip(int argc, char **argv)
     struct cli_map *m;
     stk_t *stk   = NULL;
     uint32_t idx = 0;
-    int ret;
+    char *iface  = NULL;
 
     m = cli_mapping(ip_map, argc, argv);
     if (!m)
-        return cli_cmd_error("Info command is invalid", "ip", argc, argv);
+        return cli_cmd_error("Command is invalid", "ip", argc, argv);
 
     switch (m->index) {
-    case 10:
-        if (cnet_ifshow(NULL) < 0)
-            return -1;
-        break;
     case 11:
-        if (cnet_ifshow(argv[2]) < 0)
+        iface = argv[2];
+        /* FALLTHRU */
+    case 10:
+        if (cnet_ifshow(iface) < 0)
             return -1;
         break;
     case 20:
-        if (cnet_rtshow(NULL, argc, argv) < 0)
+        if (cnet_rtshow(1, 1) < 0)
+            return -1;
+        break;
+    case 21:
+        if (cnet_rtshow(1, 0) < 0)
+            return -1;
+        break;
+    case 22:
+        if (cnet_rtshow(0, 1) < 0)
             return -1;
         break;
     case 30:
         if (cnet_arp_show() < 0)
             return -1;
         return 0;
-    case 40:
-        if (stk->ipv6)
-            ret = cnet_ipv6_stats_dump(stk);
-        else
-            ret = cnet_ipv4_stats_dump(stk);
-        if (ret < 0)
+    case 31:
+        if (cnet_nd6_show() < 0)
             return -1;
-        break;
+        return 0;
     case 41:
         idx = atoi(argv[2]);
 
@@ -614,12 +636,11 @@ cmd_ip(int argc, char **argv)
             stk = vec_at_index(this_cnet->stks, idx);
         else
             CNE_WARN("Unknown stack index showing all\n");
-
-        if (stk->ipv6)
-            ret = cnet_ipv6_stats_dump(stk);
-        else
-            ret = cnet_ipv4_stats_dump(stk);
-        if (ret < 0)
+        /* FALLTHRU */
+    case 40:
+        if (cnet_ipv4_stats_dump(stk) < 0)
+            return -1;
+        if (cnet_ipv6_stats_dump(stk) < 0)
             return -1;
         break;
     default:
@@ -688,7 +709,7 @@ cmd_tcp(int argc, char **argv)
 
     m = cli_mapping(tcp_map, argc, argv);
     if (!m)
-        return cli_cmd_error("Info command is invalid", "tcp", argc, argv);
+        return cli_cmd_error("Command is invalid", "tcp", argc, argv);
 
     switch (m->index) {
     case 10:
@@ -741,7 +762,7 @@ cmd_tcb(int argc, char **argv)
 
     m = cli_mapping(tcb_map, argc, argv);
     if (!m)
-        return cli_cmd_error("Info command is invalid", "tcb", argc, argv);
+        return cli_cmd_error("Command is invalid", "tcb", argc, argv);
 
     switch (m->index) {
     case 10:

--- a/lib/cnet/cnet/cnet.c
+++ b/lib/cnet/cnet/cnet.c
@@ -120,6 +120,7 @@ cnet_stop(void)
         cnet_drv_destroy(cnet);
         cnet_route4_destroy(cnet);
         cnet_arp_destroy(cnet);
+        cnet_nd6_destroy(cnet);
         cnet_netlink_destroy(cnet);
 
         vec_free(cnet->stks);

--- a/lib/cnet/cnet/cnet.c
+++ b/lib/cnet/cnet/cnet.c
@@ -119,10 +119,12 @@ cnet_stop(void)
     if (cnet && cnet_lock()) {
         cnet_drv_destroy(cnet);
         cnet_route4_destroy(cnet);
+        cnet_route6_destroy(cnet);
         cnet_arp_destroy(cnet);
         cnet_nd6_destroy(cnet);
         cnet_netlink_destroy(cnet);
 
+        vec_free(cnet->chnl_descriptors);
         vec_free(cnet->stks);
         vec_free(cnet->drvs);
         vec_free(cnet->netifs);

--- a/lib/cnet/cnet/cnet.c
+++ b/lib/cnet/cnet/cnet.c
@@ -30,6 +30,7 @@
 #include <cnet_route.h>
 #include <cnet_route4.h>
 #include <cnet_arp.h>            // for
+#include <cnet_nd6.h>            // for
 #include <cnet_netif.h>          // for
 #include <cnet_netlink.h>        // for
 
@@ -77,8 +78,14 @@ cnet_config_create(uint32_t num_chnls, uint32_t num_routes)
         if (cnet_route4_create(cnet, num_routes, 0) < 0)
             CNE_ERR_GOTO(leave, "Failed to create route\n");
 
+        if (cnet_route6_create(cnet, num_routes, 0) < 0)
+            CNE_ERR_GOTO(leave, "Failed to create route6\n");
+
         if (cnet_arp_create(cnet, 0, 0) < 0)
-            CNE_ERR_GOTO(leave, "Failed to create netif\n");
+            CNE_ERR_GOTO(leave, "Failed to create arp\n");
+
+        if (cnet_nd6_create(cnet, 0, 0) < 0)
+            CNE_ERR_GOTO(leave, "Failed to create nd6\n");
 
         if (cnet_netlink_create(cnet) < 0)
             CNE_ERR_GOTO(leave, "Failed to create netlink\n");

--- a/lib/cnet/cnet/cnet.h
+++ b/lib/cnet/cnet/cnet.h
@@ -34,8 +34,10 @@ struct cnet {
     CNE_ATOMIC(uint_fast16_t) stk_order; /**< Order of the stack initializations */
     uint16_t nb_ports;                   /**< Number of ports in the system */
     uint32_t num_chnls;                  /**< Number of channels in system */
-    uint32_t num_routes;                 /**< Number of routes */
+    uint32_t num_routes;                 /**< Number of IPv4 routes */
+    uint32_t num_6routes;                /**< Number of IPv6 routes */
     uint32_t num_arps;                   /**< Number of ARP entries */
+    uint32_t num_neighs;                 /**< Number of ND6 entries */
     uint16_t flags;                      /**< Flags enable Punting, TCP, ... */
     u_id_t chnl_uids;                    /**< UID for channel descriptor like values */
     void **chnl_descriptors;             /**< List of channel descriptors pointers */

--- a/lib/cnet/icmp6/cnet_icmp6.c
+++ b/lib/cnet/icmp6/cnet_icmp6.c
@@ -30,8 +30,6 @@ icmp6_create(void *_stk)
 
     CNE_ASSERT(psw != NULL);
 
-    cnet_ipproto_set(IPPROTO_ICMPV6, psw);
-
     stk->icmp6->cksum_on            = 1;
     stk->icmp6->rcv_size            = MAX_ICMP6_RCV_SIZE;
     stk->icmp6->snd_size            = MAX_ICMP6_SND_SIZE;

--- a/lib/cnet/ipv4/cnet_ipv4.c
+++ b/lib/cnet/ipv4/cnet_ipv4.c
@@ -31,7 +31,7 @@
 #include "cnet_const.h"        // for iofunc_t, BEST_MATCH, False, IPV4_IO
 #include "cnet_reg.h"
 #include "cnet_ipv4.h"           // for ipv4_entry, ipv4_stats, DEFAULT_I...
-#include "cnet_protosw.h"        // for protosw_entry, cnet_ipproto_get
+#include "cnet_protosw.h"        // for protosw_entry
 #include "pktmbuf.h"             // for pktmbuf_t, pktmbuf_free
 
 static void

--- a/lib/cnet/ipv4/cnet_ipv4.c
+++ b/lib/cnet/ipv4/cnet_ipv4.c
@@ -37,7 +37,7 @@
 static void
 __ipv4_stats_dump(stk_t *stk)
 {
-    cne_printf("[magenta]Network Stack statistics[]: [orange]%s[]\n", stk->name);
+    cne_printf("[yellow]IPv4 [magenta]Network Stack statistics[]: [orange]%s[]\n", stk->name);
 
 #define _(stat) cne_printf("    [magenta]%-24s[]= [orange]%'ld[]\n", #stat, stk->ipv4->stats.stat)
     _(ip_ver_error);

--- a/lib/cnet/ipv6/cnet_ipv6.c
+++ b/lib/cnet/ipv6/cnet_ipv6.c
@@ -30,7 +30,7 @@
 #include "cnet_const.h"        // for iofunc_t, BEST_MATCH, False, IPV4_IO
 #include "cnet_reg.h"
 #include "cnet_ipv6.h"            // for ipv6_entry, ipv6_stats, DEFAULT_I...
-#include "cnet_protosw.h"         // for protosw_entry, cnet_ipproto_get
+#include "cnet_protosw.h"         // for protosw_entry
 #include "pktmbuf.h"              // for pktmbuf_t, pktmbuf_free
 #include <cne_fib6.h>             // for IPV6_ADDR_LEN
 #include <ip6_flowlabel.h>        // for srhash_init0()

--- a/lib/cnet/ipv6/cnet_ipv6.c
+++ b/lib/cnet/ipv6/cnet_ipv6.c
@@ -38,7 +38,7 @@
 static void
 __ipv6_stats_dump(stk_t *stk)
 {
-    cne_printf("[magenta]Network Stack statistics[]: [orange]%s[]\n", stk->name);
+    cne_printf("[yellow]IPv6 [magenta]Network Stack statistics[]: [orange]%s[]\n", stk->name);
 
 #define _(stat) cne_printf("    [magenta]%-24s[]= [orange]%'ld[]\n", #stat, stk->ipv6->stats.stat)
     _(ip6_ver_error);
@@ -61,6 +61,9 @@ __ipv6_stats_dump(stk_t *stk)
 int
 cnet_ipv6_stats_dump(stk_t *stk)
 {
+    if (CNET_ENABLE_IP6 == 0)
+        return 0;
+
     if (stk)
         __ipv6_stats_dump(stk);
     else {
@@ -76,6 +79,9 @@ cnet_ipv6_dump(const char *msg, struct cne_ipv6_hdr *ip6)
     struct in6_addr daddr, saddr;
     char ip6_src[IP6_ADDR_STRLEN] = {0};
     char ip6_dst[IP6_ADDR_STRLEN] = {0};
+
+    if (CNET_ENABLE_IP6 == 0)
+        return;
 
     cne_printf("%s [cyan]IPv6 Header[] @ %p\n", (msg == NULL) ? "" : msg, ip6);
 

--- a/lib/cnet/ipv6/cnet_ipv6.h
+++ b/lib/cnet/ipv6/cnet_ipv6.h
@@ -128,19 +128,19 @@ CNDP_API int cnet_ipv6_stats_dump(struct stk_s *stk);
  */
 CNDP_API void cnet_ipv6_dump(const char *msg, struct cne_ipv6_hdr *ip);
 
-inline cne_be32_t
+static inline cne_be32_t
 ip6_get_flowlabel(struct cne_ipv6_hdr *ip6h)
 {
     return (ip6h->vtc_flow & IPV6_FLOWLABEL_MASK);
 }
 
-inline cne_be32_t
+static inline cne_be32_t
 ip6_get_tclass(struct cne_ipv6_hdr *ip6h)
 {
     return ((ip6h->vtc_flow & IPV6_TCLASS_MASK) >> IPV6_TCLASS_SHIFT);
 }
 
-inline cne_be32_t
+static inline cne_be32_t
 ip6_get_version(struct cne_ipv6_hdr *ip6h)
 {
     return ((ip6h->vtc_flow & IPV6_VERSION_MASK) >> IPV6_VERSION_SHIFT);

--- a/lib/cnet/nd6/cnet_nd6.c
+++ b/lib/cnet/nd6/cnet_nd6.c
@@ -218,6 +218,8 @@ cnet_nd6_create(struct cnet *cnet, uint32_t num_entries, uint32_t num_tbl8s)
     fib_info_t *fi           = NULL;
     struct cne_fib6 *fib     = NULL;
 
+    if (!CNET_ENABLE_IP6)
+        return 0;
     if (!cnet)
         return -1;
 
@@ -228,7 +230,7 @@ cnet_nd6_create(struct cnet *cnet, uint32_t num_entries, uint32_t num_tbl8s)
     num_entries    = cne_align32pow2(num_entries);
     cnet->num_arps = num_entries;
 
-    fcfg.type = CNE_FIB_DIR24_8;
+    fcfg.type = CNE_FIB_TRIE;
     fcfg.default_nh =
         (uint64_t)((CNE_NODE_IP6_INPUT_NEXT_PKT_DROP << ND6_NEXT_INDEX_SHIFT) | (num_entries + 1));
     fcfg.max_routes    = num_entries;

--- a/lib/cnet/nd6/cnet_nd6.c
+++ b/lib/cnet/nd6/cnet_nd6.c
@@ -203,6 +203,8 @@ _nd6_show(struct nd6_cache_entry *entry, void *arg __cne_unused)
 int
 cnet_nd6_show(void)
 {
+    if (CNET_ENABLE_IP6 == 0)
+        return 0;
     cne_printf("[magenta]NDP Table for CNET on lcore [orange]%d[]\n", cne_lcore_id());
     cne_printf("  [magenta]%-15s %-17s %-4s %3s %-16s[]\n", "Neighbor's IP6 Address", "MAC Address",
                "Reachability State", " IF", "Name");
@@ -218,7 +220,7 @@ cnet_nd6_create(struct cnet *cnet, uint32_t num_entries, uint32_t num_tbl8s)
     fib_info_t *fi           = NULL;
     struct cne_fib6 *fib     = NULL;
 
-    if (!CNET_ENABLE_IP6)
+    if (CNET_ENABLE_IP6 == 0)
         return 0;
     if (!cnet)
         return -1;
@@ -227,8 +229,8 @@ cnet_nd6_create(struct cnet *cnet, uint32_t num_entries, uint32_t num_tbl8s)
         num_entries = ND6_FIB_DEFAULT_ENTRIES;
     if (num_tbl8s == 0)
         num_tbl8s = ND6_FIB_DEFAULT_NUM_TBL8S;
-    num_entries    = cne_align32pow2(num_entries);
-    cnet->num_arps = num_entries;
+    num_entries      = cne_align32pow2(num_entries);
+    cnet->num_neighs = num_entries;
 
     fcfg.type = CNE_FIB_TRIE;
     fcfg.default_nh =
@@ -265,7 +267,7 @@ err:
 int
 cnet_nd6_destroy(struct cnet *cnet)
 {
-    if (cnet) {
+    if (CNET_ENABLE_IP6 && cnet) {
         fib_info_destroy(cnet->nd6_finfo);
         if (cnet->nd6_obj)
             mempool_destroy(cnet->nd6_obj);

--- a/lib/cnet/nd6/nd6.c
+++ b/lib/cnet/nd6/nd6.c
@@ -512,7 +512,7 @@ nd6_recv_requests(struct cne_graph *graph, struct cne_node *node, icmp6ip_t *iip
 static inline void
 nd6_init(void)
 {
-    CNE_DEBUG("All ND6 initilizations\n");
+    CNE_DEBUG("All ND6 initializations\n");
 }
 
 /* ND6 Utility functions */

--- a/lib/cnet/netlink/nl_neigh.c
+++ b/lib/cnet/netlink/nl_neigh.c
@@ -102,7 +102,7 @@ __nl_neigh(struct netlink_info *info, struct nl_object *obj, int action)
         NL_OBJ_DUMP(obj);
 
         if (nl_addr_get_family(dst) == AF_INET6) {
-            if (cnet_nd6_add(netif->netif_idx, &in6, &mac, ND_REACHABLE) == 0)
+            if (CNET_ENABLE_IP6 && cnet_nd6_add(netif->netif_idx, &in6, &mac, ND_REACHABLE) == 0)
                 CNE_RET("Unable to add ND6 entry\n");
         } else /* IPv4 */ {
             if (cnet_arp_add(netif->netif_idx, &in, &mac, 0) == 0)
@@ -115,7 +115,7 @@ __nl_neigh(struct netlink_info *info, struct nl_object *obj, int action)
         NL_OBJ_DUMP(obj);
 
         if (nl_addr_get_family(dst) == AF_INET6) {
-            if (cnet_nd6_add(netif->netif_idx, &in6, &mac, ND_REACHABLE) == 0)
+            if (CNET_ENABLE_IP6 && cnet_nd6_add(netif->netif_idx, &in6, &mac, ND_REACHABLE) == 0)
                 CNE_RET("Unable to add ND6 entry\n");
         } else /* IPv4 */ {
             if (cnet_arp_add(netif->netif_idx, &in, &mac, 0) == 0)
@@ -128,7 +128,7 @@ __nl_neigh(struct netlink_info *info, struct nl_object *obj, int action)
         NL_OBJ_DUMP(obj);
 
         if (nl_addr_get_family(dst) == AF_INET6) {
-            if (cnet_nd6_delete(&in6) < 0)
+            if (CNET_ENABLE_IP6 && cnet_nd6_delete(&in6) < 0)
                 CNE_RET("Unable to delete ND6 entry\n");
         } else /* IPv4 */ {
             if (cnet_arp_delete(&in) < 0)

--- a/lib/cnet/nodes/pkt_ctrl.c
+++ b/lib/cnet/nodes/pkt_ctrl.c
@@ -15,20 +15,22 @@
 #include "cne_log.h"             // for CNE_LOG_DEBUG
 #include "pktdev_api.h"          // for pktdev_is_valid_port
 #include "ip4_node_api.h"
+#include "ip6_node_api.h"
 #include "arp_request_priv.h"
 #include "udp_output_priv.h"
 #include "kernel_recv_priv.h"
 
-int
-cnet_eth_node_config(struct pkt_eth_node_config *conf, uint16_t nb_confs)
+static int
+eth_node4_config(struct pkt_eth_node_config *conf, uint16_t nb_confs)
 {
     struct cne_node_register *ip4_forward_node;
     struct cne_node_register *ip4_output_node;
     struct eth_tx_node_main *tx_node_data;
     uint16_t port_id;
     struct cne_node_register *tx_node;
-    char name[CNE_NODE_NAMESIZE] = {0};
-    const char *next_nodes       = name;
+    char name[CNE_NODE_NAMESIZE]           = {0};
+    const char *next_nodes                 = name;
+    char next_node_name[CNE_NODE_NAMESIZE] = {0};
     uint32_t id;
 
     ip4_forward_node = ip4_forward_node_get();
@@ -44,7 +46,7 @@ cnet_eth_node_config(struct pkt_eth_node_config *conf, uint16_t nb_confs)
             break;
 
         /* Create a per port tx node from base node */
-        snprintf(name, sizeof(name), "%u", port_id);
+        snprintf(next_node_name, sizeof(next_node_name), "%u", port_id);
 
         /* Create RX node for each lport */
         do {
@@ -56,9 +58,9 @@ cnet_eth_node_config(struct pkt_eth_node_config *conf, uint16_t nb_confs)
             rx_node      = eth_rx_node_get();
 
             /* Clone a new rx node with same edges as parent */
-            id = cne_node_clone(rx_node->id, name);
+            id = cne_node_clone(rx_node->id, next_node_name);
             if (id == CNE_NODE_ID_INVALID)
-                CNE_ERR_RET_VAL(-EIO, "Failed to clone rx node %s\n", name);
+                CNE_ERR_RET_VAL(-EIO, "Failed to clone rx node %s\n", next_node_name);
 
             /* Add it to list of rx nodes for lookup */
             elem = calloc(1, sizeof(eth_rx_node_elem_t));
@@ -71,7 +73,7 @@ cnet_eth_node_config(struct pkt_eth_node_config *conf, uint16_t nb_confs)
         } while (0);
 
         /* Clone a new node with same edges as parent */
-        id                           = cne_node_clone(tx_node->id, name);
+        id                           = cne_node_clone(tx_node->id, next_node_name);
         tx_node_data->nodes[port_id] = id;
 
         /* Prepare the actual name of the cloned node */
@@ -104,4 +106,64 @@ err:
         }
     } while (0 /*CONSTCOND*/);
     return -1;
+}
+
+static int
+eth_node6_config(struct pkt_eth_node_config *conf, uint16_t nb_confs)
+{
+    struct cne_node_register *ip6_forward_node;
+    struct cne_node_register *ip6_output_node;
+    uint16_t port_id;
+    char name[CNE_NODE_NAMESIZE] = {0};
+    const char *next_nodes       = name;
+
+    ip6_forward_node = ip6_forward_node_get();
+    ip6_output_node  = ip6_output_node_get();
+
+    for (int i = 0; i < nb_confs; i++) {
+        port_id = conf[i].port_id;
+
+        if (!pktdev_is_valid_port(port_id))
+            break;
+
+        /* Prepare the actual name of the cloned node */
+        snprintf(name, sizeof(name), "eth_tx-%u", port_id);
+
+        /* Add this tx port node as next output to ip6_forward_node */
+        cne_node_edge_update(ip6_forward_node->id, CNE_EDGE_ID_INVALID, &next_nodes, 1);
+
+        /* Add this tx port node as next output to ip6_output_node */
+        cne_node_edge_update(ip6_output_node->id, CNE_EDGE_ID_INVALID, &next_nodes, 1);
+
+        /* Assuming edge id is the last one alloc'ed */
+        if (ip6_forward_set_next(port_id, cne_node_edge_count(ip6_forward_node->id) - 1) < 0)
+            goto err;
+
+        /* Assuming edge id is the last one alloc'ed */
+        if (ip6_output_set_next(port_id, cne_node_edge_count(ip6_output_node->id) - 1) < 0)
+            goto err;
+    }
+
+    return 0;
+err:
+    do {
+        struct eth_rx_node_main *rx_node_data = eth_rx_get_node_data_get();
+        eth_rx_node_elem_t *elem;
+
+        while ((elem = rx_node_data->head) != NULL) {
+            rx_node_data->head = elem->next;
+            free(elem);
+        }
+    } while (0 /*CONSTCOND*/);
+    return -1;
+}
+
+int
+cnet_eth_node_config(struct pkt_eth_node_config *conf, uint16_t nb_confs)
+{
+    if (eth_node4_config(conf, nb_confs) < 0)
+        CNE_ERR_RET("failed to attach ipv4 node to output\n");
+    if (CNET_ENABLE_IP6 && eth_node6_config(conf, nb_confs) < 0)
+        CNE_ERR_RET("failed to attach ipv4 node to output\n");
+    return 0;
 }

--- a/lib/cnet/pcb/cnet_pcb.c
+++ b/lib/cnet/pcb/cnet_pcb.c
@@ -148,11 +148,9 @@ pcb_v6_lookup(struct pcb_entry **vec, struct pcb_key *key, int32_t flag)
 struct pcb_entry *
 cnet_pcb_lookup(struct pcb_hd *hd, struct pcb_key *key, int32_t flag)
 {
-#if CNET_ENABLE_IP6
     if (flag & IPV6_TYPE)
         return pcb_v6_lookup(hd->vec, key, flag);
     else
-#endif
         return pcb_v4_lookup(hd->vec, key, flag);
 }
 
@@ -215,17 +213,13 @@ pcb_show(struct pcb_entry *pcb)
     cne_printf("       [green]%-6s [orange] %04x [red]%6s[]", pcb->closed ? "Closed" : "Open",
                pcb->opt_flag, chnl_protocol_str(pcb->ip_proto));
 
-#if CNET_ENABLE_IP6
     if (is_pcb_dom_inet6(pcb)) {
         ret = inet_ntop6(ip1, sizeof(ip1), &pcb->key.faddr.cin6_addr, NULL);
         ret = inet_ntop6(ip2, sizeof(ip2), &pcb->key.laddr.cin6_addr, NULL);
     } else {
-#endif
         ret = inet_ntop4(ip1, sizeof(ip1), &pcb->key.faddr.cin_addr, NULL);
         ret = inet_ntop4(ip2, sizeof(ip2), &pcb->key.laddr.cin_addr, NULL);
-#if CNET_ENABLE_IP6
     }
-#endif
 
     if (snprintf(fbuf, sizeof(fbuf), "%s:%d", ret ? ret : "Invalid IP",
                  ntohs(CIN_PORT(&pcb->key.faddr))) < 0)
@@ -302,18 +296,19 @@ is_ch_dom_inet4(struct chnl *ch)
 bool
 is_tcb_dom_inet6(struct tcb_entry *tcb)
 {
-    return (tcb && tcb->pcb && tcb->pcb->ch && tcb->pcb->ch->ch_proto &&
+    return (CNET_ENABLE_IP6 && tcb && tcb->pcb && tcb->pcb->ch && tcb->pcb->ch->ch_proto &&
             (tcb->pcb->ch->ch_proto->domain == AF_INET6));
 }
 
 bool
 is_pcb_dom_inet6(struct pcb_entry *pcb)
 {
-    return (pcb && pcb->ch && pcb->ch->ch_proto && (pcb->ch->ch_proto->domain == AF_INET6));
+    return (CNET_ENABLE_IP6 && pcb && pcb->ch && pcb->ch->ch_proto &&
+            (pcb->ch->ch_proto->domain == AF_INET6));
 }
 
 bool
 is_ch_dom_inet6(struct chnl *ch)
 {
-    return (ch && ch->ch_proto && (ch->ch_proto->domain == AF_INET6));
+    return (CNET_ENABLE_IP6 && ch && ch->ch_proto && (ch->ch_proto->domain == AF_INET6));
 }

--- a/lib/cnet/protosw/cnet_protosw.c
+++ b/lib/cnet/protosw/cnet_protosw.c
@@ -14,6 +14,10 @@
 #include "cnet_protosw.h"
 #include "cne_log.h"        // for CNE_LOG, CNE_LOG_DEBUG, CNE_LOG_WARNING
 
+/**
+ * This module manages the list of "protocol switch" structures, each of which
+ * corresponds to a channel type, e.g. {AF_INET, AF_INET6, SOCK_DGRAM, IPPROTO_UDP, IPPROTO_TCP}.
+ */
 static struct protosw_entry *
 cnet_protosw_match(uint16_t domain, uint16_t type, uint16_t proto)
 {

--- a/lib/cnet/protosw/cnet_protosw.c
+++ b/lib/cnet/protosw/cnet_protosw.c
@@ -14,12 +14,6 @@
 #include "cnet_protosw.h"
 #include "cne_log.h"        // for CNE_LOG, CNE_LOG_DEBUG, CNE_LOG_WARNING
 
-/**
- * This module manages the list of "protocol switch" structures, each of which
- * corresponds to a channel type, e.g. {AF_INET, SOCK_DGRAM, IPPROTO_UDP}.
- */
-static struct protosw_entry *ipproto_table[CNET_MAX_IPPROTO];
-
 static struct protosw_entry *
 cnet_protosw_match(uint16_t domain, uint16_t type, uint16_t proto)
 {
@@ -85,22 +79,6 @@ cnet_protosw_add(const char *name, uint16_t domain, uint16_t type, uint16_t prot
     vec_add(this_stk->protosw_vec, psw);
 
     return psw;
-}
-
-int
-cnet_ipproto_set(uint8_t ipproto, struct protosw_entry *psw)
-{
-    if (ipproto_table[ipproto])
-        return -1;
-
-    ipproto_table[ipproto] = psw;
-    return 0;
-}
-
-struct protosw_entry *
-cnet_ipproto_get(uint8_t ipproto)
-{
-    return ipproto_table[ipproto];
 }
 
 struct protosw_entry *

--- a/lib/cnet/protosw/cnet_protosw.h
+++ b/lib/cnet/protosw/cnet_protosw.h
@@ -109,28 +109,6 @@ CNDP_API struct protosw_entry *cnet_protosw_find(uint16_t domain, uint16_t type,
 CNDP_API void cnet_protosw_dump(struct stk_s *stk);
 
 /**
- * @brief Set the IP proto value in the given protosw_entry pointer.
- *
- * @param ipproto
- *   The IP proto type value to be set in the structure.
- * @param psw
- *   The protosw_entry structure pointer.
- * @return
- *   -1 on error or 0 on success
- */
-CNDP_API int cnet_ipproto_set(uint8_t ipproto, struct protosw_entry *psw);
-
-/**
- * @brief Get the protosw_entry to locate using the IP proto type.
- *
- * @param ipproto
- *   The IP proto type value to be set in the structure.
- * @return
- *   NULL on error or a pointer to a protocol switch entry.
- */
-CNDP_API struct protosw_entry *cnet_ipproto_get(uint8_t ipproto);
-
-/**
  * @brief Find a protocol switch entry using the IP proto type.
  *
  * @param proto

--- a/lib/cnet/punt/punt_kernel.c
+++ b/lib/cnet/punt/punt_kernel.c
@@ -155,10 +155,8 @@ punt_kernel_node_init(const struct cne_graph *graph __cne_unused, struct cne_nod
     ctx->sock = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
     if (ctx->sock < 0)
         CNE_ERR_RET("Unable to open IPv4 RAW socket\n");
-    if (CNET_ENABLE_IP6) {
-        if ((ctx->sock6 = socket(AF_INET6, SOCK_RAW, IPPROTO_RAW)) < 0)
-            CNE_ERR_RET("Unable to open IPv6 RAW socket\n");
-    }
+    if (CNET_ENABLE_IP6 && (ctx->sock6 = socket(AF_INET6, SOCK_RAW, IPPROTO_RAW)) < 0)
+        CNE_ERR_RET("Unable to open IPv6 RAW socket\n");
     return 0;
 }
 

--- a/lib/cnet/route/cnet_route6.c
+++ b/lib/cnet/route/cnet_route6.c
@@ -162,13 +162,15 @@ cnet_route6_create(struct cnet *cnet, uint32_t num_rules, uint32_t num_tbl8s)
 
     struct mempool_cfg mcfg = {0};
 
+    if (CNET_ENABLE_IP6 == 0)
+        return 0;
     if (num_rules == 0 || (num_rules > RT6_MAX_RULES))
         num_rules = RT6_DEFAULT_NUM_RULES;
     if (num_tbl8s == 0)
         num_tbl8s = RT6_DEFAULT_NUM_TBL8S;
 
-    num_rules        = cne_align32pow2(num_rules);
-    cnet->num_routes = num_rules;
+    num_rules         = cne_align32pow2(num_rules);
+    cnet->num_6routes = num_rules;
 
     cfg.type = CNE_FIB_TRIE;
     cfg.default_nh =
@@ -241,6 +243,8 @@ route6_dump(struct rt6_entry *rt, void *arg __cne_unused)
 int
 cnet_route6_show(void)
 {
+    if (CNET_ENABLE_IP6 == 0)
+        return 0;
     cne_printf("[magenta]IPv6 Route Table for CNET on lcore [orange]%d[]\n", cne_lcore_id());
     cne_printf("  [magenta]%-17s %-17s  IF  %-17s Metric Timeout   Netdev[]\n", "Nexthop", "Mask",
                "Gateway");

--- a/lib/cnet/sbin/cnet_ifshow.c
+++ b/lib/cnet/sbin/cnet_ifshow.c
@@ -50,7 +50,7 @@ netif_show(struct netif *netif, char *ifname)
         return;
 
     /* When a interface is given only display that interface */
-    if (ifname && strncmp(ifname, netif->ifname, sizeof(netif->ifname)) == 0)
+    if (ifname && strncmp(ifname, netif->ifname, sizeof(netif->ifname)))
         return;
 
     if (pktdev_stats_get(netif->lpid, &stats) < 0)

--- a/lib/cnet/sbin/cnet_rtshow.c
+++ b/lib/cnet/sbin/cnet_rtshow.c
@@ -7,6 +7,7 @@
 #include <cnet_netif.h>         // for cnet_netif_from_index
 #include <cnet_route.h>         // for
 #include <cnet_route4.h>        // for cnet_route4_show
+#include <cnet_route6.h>        // for cnet_route6_show
 #include <cnet_ipv4.h>          // for cnet_ipv4_stats_dump
 #include <cnet_ipv6.h>          // for cnet_ipv6_stats_dump
 #include <stdint.h>             // for int32_t
@@ -18,71 +19,13 @@
 #include "cne_common.h"        // for __cne_unused
 #include "cnet_const.h"        // for CNET_UTILS_PRIO
 
-struct stk_s;
-
-#define RTSHOW_USAGE                              \
-    "Usage: rtshow [options]\n"                   \
-    "  options:\n"                                \
-    "  -4       - Show interface stats\n"         \
-    "  -? | -h  - Display the help information\n" \
-    "  No options then show the route table\n"    \
-    "\n"
-
 int
-cnet_rtshow(stk_t *stk, int argc, char **argv)
+cnet_rtshow(int ip4, int ip6)
 {
-    int opt, ip_stats;
-    char *iface = NULL;
-
-    optind   = 0;
-    ip_stats = 0;
-    while ((opt = getopt(argc, argv, "?h4")) != -1) {
-        switch (opt) {
-        case 'h':
-            /* fall through */
-        case '?':
-            /* fall through */
-        default:
-            cne_printf(RTSHOW_USAGE);
-            break;
-
-        case '4':
-            ip_stats = 4;
-            break;
-
-            /* TODO: Add IPv6 support */
-        }
-    }
-    if (optind < argc)
-        iface = argv[optind];
-
-    if (stk->ipv6) {
-        if (iface == NULL) {
-            if (!ip_stats)
-                cnet_route6_show();
-            else
-                cnet_ipv6_stats_dump(stk);
-            return 0;
-        } else {
-            if (!ip_stats)
-                cnet_route6_show();
-            else
-                cnet_ipv6_stats_dump(stk);
-        }
-    } else {
-        if (iface == NULL) {
-            if (!ip_stats)
-                cnet_route4_show();
-            else
-                cnet_ipv4_stats_dump(stk);
-            return 0;
-        } else {
-            if (!ip_stats)
-                cnet_route4_show();
-            else
-                cnet_ipv4_stats_dump(stk);
-        }
-    }
+    if (ip4)
+        cnet_route4_show();
+    if (ip6)
+        cnet_route6_show();
 
     return 0;
 }

--- a/lib/cnet/sbin/cnet_rtshow.h
+++ b/lib/cnet/sbin/cnet_rtshow.h
@@ -19,16 +19,14 @@ extern "C" {
 /**
  * @brief Show/modify routing information for a given stack instance.
  *
- * @param stk
- *   The current stack instance.
- * @param argc
- *   The number of arguments to be passed to the stack instance.
- * @param argv
- *   The arguments to be passed to the stack instance.
+ * @param ip4
+ *   Display route information for IPv4.
+ * @param ip6
+ *   Display route information for IPv6.
  * @return
  *   -1 on error, 0 on success.
  */
-CNDP_API int cnet_rtshow(stk_t *stk, int argc, char **argv);
+CNDP_API int cnet_rtshow(int ip4, int ip6);
 
 #ifdef __cplusplus
 }

--- a/lib/cnet/tcp/cnet_tcp.c
+++ b/lib/cnet/tcp/cnet_tcp.c
@@ -64,7 +64,7 @@
 #include "cne_vec.h"              // for vec_len, vec_add, vec_at_index
 #include <cnet_reg.h>
 #include "cnet_ipv4.h"           // for TOS_DEFAULT, TTL_DEFAULT, _OFF_DF
-#include "cnet_protosw.h"        // for protosw_entry, cnet_ipproto_set, cnet_pr...
+#include "cnet_protosw.h"        // for protosw_entry, cnet_pr...
 #include "cnet_udp.h"            // for chnl, chnl_buf, cb_space, chnl_cant_snd_...
 #include <pktmbuf_ptype.h>
 #include <cnet_fib_info.h>
@@ -4023,11 +4023,13 @@ tcp_init(int32_t n_tcb_entries, bool wscale, bool t_stamp)
     if (stk->seg_objs == NULL)
         goto err_exit;
 
-    psw = cnet_protosw_add("TCP", AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    if (!psw)
+    if (!cnet_protosw_add("TCP", AF_INET, SOCK_STREAM, IPPROTO_TCP))
         goto err_exit;
 
-    cnet_ipproto_set(IPPROTO_TCP, psw);
+    if (CNET_ENABLE_IP6) {
+        if (!cnet_protosw_add("TCPv6", AF_INET6, SOCK_STREAM, IPPROTO_TCP))
+            goto err_exit;
+    }
 
     cne_timer_init(&stk->tcp_timer);
 

--- a/lib/cnet/tcp/cnet_tcp.c
+++ b/lib/cnet/tcp/cnet_tcp.c
@@ -4026,10 +4026,8 @@ tcp_init(int32_t n_tcb_entries, bool wscale, bool t_stamp)
     if (!cnet_protosw_add("TCP", AF_INET, SOCK_STREAM, IPPROTO_TCP))
         goto err_exit;
 
-    if (CNET_ENABLE_IP6) {
-        if (!cnet_protosw_add("TCPv6", AF_INET6, SOCK_STREAM, IPPROTO_TCP))
-            goto err_exit;
-    }
+    if (CNET_ENABLE_IP6 && !cnet_protosw_add("TCPv6", AF_INET6, SOCK_STREAM, IPPROTO_TCP))
+        goto err_exit;
 
     cne_timer_init(&stk->tcp_timer);
 

--- a/lib/cnet/tcp/cnet_tcp_chnl.c
+++ b/lib/cnet/tcp/cnet_tcp_chnl.c
@@ -527,10 +527,17 @@ tcp_chnl_create(void *_stk __cne_unused)
 {
     struct protosw_entry *psw;
 
-    psw = cnet_protosw_find(AF_INET, SOCK_STREAM, 0);
+    psw = cnet_protosw_find(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (!psw)
         return -1;
     psw->funcs = &tcpFuncs;
+
+    if (CNET_ENABLE_IP6) {
+        psw = cnet_protosw_find(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+        if (!psw)
+            return -1;
+        psw->funcs = &tcpFuncs;
+    }
 
     cnet_chnl_opt_add(&tcp_sol_opts);
     cnet_chnl_opt_add(&tcp_ipproto_opts);

--- a/lib/cnet/udp/cnet_udp.c
+++ b/lib/cnet/udp/cnet_udp.c
@@ -33,7 +33,6 @@ static int
 udp_create(void *_stk)
 {
     stk_t *stk = _stk;
-    struct protosw_entry *psw;
 
     stk->udp = calloc(1, sizeof(struct udp_entry));
     if (stk->udp == NULL) {
@@ -41,18 +40,13 @@ udp_create(void *_stk)
         return -1;
     }
 
-#if CNET_ENABLE_IP6
-    if (stk->ipv4)
-#endif
-        psw = cnet_protosw_add("UDP", AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-#if CNET_ENABLE_IP6
-    else
-        psw = cnet_protosw_add("UDP", AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
-#endif
-    CNE_ASSERT(psw != NULL);
+    if (cnet_protosw_add("UDP", AF_INET, SOCK_DGRAM, IPPROTO_UDP) == NULL)
+        CNE_ERR_RET("Failed to add %s for INET %d\n", "UDP", AF_INET);
 
-    cnet_ipproto_set(IPPROTO_UDP, psw);
-
+    if (CNET_ENABLE_IP6) {
+        if (cnet_protosw_add("UDPv6", AF_INET6, SOCK_DGRAM, IPPROTO_UDP) == NULL)
+            CNE_ERR_RET("Failed to add %s for INET %d\n", "UDPv6", AF_INET6);
+    }
     stk->udp->cksum_on          = 1;
     stk->udp->rcv_size          = MAX_UDP_RCV_SIZE;
     stk->udp->snd_size          = MAX_UDP_SND_SIZE;

--- a/lib/cnet/udp/cnet_udp.c
+++ b/lib/cnet/udp/cnet_udp.c
@@ -43,10 +43,8 @@ udp_create(void *_stk)
     if (cnet_protosw_add("UDP", AF_INET, SOCK_DGRAM, IPPROTO_UDP) == NULL)
         CNE_ERR_RET("Failed to add %s for INET %d\n", "UDP", AF_INET);
 
-    if (CNET_ENABLE_IP6) {
-        if (cnet_protosw_add("UDPv6", AF_INET6, SOCK_DGRAM, IPPROTO_UDP) == NULL)
-            CNE_ERR_RET("Failed to add %s for INET %d\n", "UDPv6", AF_INET6);
-    }
+    if (CNET_ENABLE_IP6 && !cnet_protosw_add("UDPv6", AF_INET6, SOCK_DGRAM, IPPROTO_UDP))
+        CNE_ERR_RET("Failed to add %s for INET %d\n", "UDPv6", AF_INET6);
     stk->udp->cksum_on          = 1;
     stk->udp->rcv_size          = MAX_UDP_RCV_SIZE;
     stk->udp->snd_size          = MAX_UDP_SND_SIZE;

--- a/lib/cnet/udp/cnet_udp_chnl.c
+++ b/lib/cnet/udp/cnet_udp_chnl.c
@@ -172,19 +172,18 @@ static int
 udp_chnl_create(void *_stk __cne_unused)
 {
     struct protosw_entry *psw;
-#if CNET_ENABLE_IP6
-    stk_t *stk = _stk;
 
-    if (stk->ipv4)
-#endif
-        psw = cnet_protosw_find(AF_INET, SOCK_DGRAM, 0);
-#if CNET_ENABLE_IP6
-    else
-        psw = cnet_protosw_find(AF_INET6, SOCK_DGRAM, 0);
-#endif
+    psw = cnet_protosw_find(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (!psw)
         return -1;
     psw->funcs = &udpFuncs;
+
+    if (CNET_ENABLE_IP6) {
+        psw = cnet_protosw_find(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+        if (!psw)
+            return -1;
+        psw->funcs = &udpFuncs;
+    }
 
     return 0;
 }

--- a/lib/cnet/udp/udp_output.c
+++ b/lib/cnet/udp/udp_output.c
@@ -55,10 +55,7 @@ udp_output_header(pktmbuf_t *m, uint16_t nxt)
     udp->dgram_cksum = 0;
 
 #if CNET_ENABLE_IP6
-    struct pcb_entry *pcb;
-
-    pcb = m->userptr;
-    if (is_pcb_dom_inet6(pcb))
+    if (is_pcb_dom_inet6((struct pcb_entry *)m->userptr))
         nxt = UDP_OUTPUT_NEXT_IP6_OUTPUT;
     else
 #endif
@@ -78,7 +75,7 @@ udp_output_node_do(struct cne_graph *graph, struct cne_node *node, void **objs, 
     uint16_t n_left_from;
     uint16_t held = 0;
 
-    /* This is defaul, and not using UDP_OUTPUT_NEXT_IP6_OUTPUT in the beginning.
+    /* This is default, and not using UDP_OUTPUT_NEXT_IP6_OUTPUT in the beginning.
      * The next0, next1 etc. should take care below if it's IPv6 */
     next_index = UDP_OUTPUT_NEXT_IP4_OUTPUT;
 

--- a/lib/include/cne_inet.h
+++ b/lib/include/cne_inet.h
@@ -142,6 +142,4 @@ typedef struct l3_4route_s {
 #endif /* __CNE_INET_H */
 
 #include <cne_inet4.h>
-#ifdef CNET_ENABLE_IP6
 #include <cne_inet6.h>
-#endif

--- a/meson.build
+++ b/meson.build
@@ -420,6 +420,7 @@ endif
 cne_conf.set('CNET_NUM_TCBS', get_option('cnet_num_tcbs'))
 cne_conf.set('CNET_NUM_CHANNELS', get_option('cnet_num_channels'))
 cne_conf.set('CNET_NUM_ROUTES', get_option('cnet_num_routes'))
+cne_conf.set('CNET_NUM_6ROUTES', get_option('cnet_num_6routes'))
 cne_conf.set('CNET_NUM_SEGMENTS', get_option('cnet_num_segs'))
 
 # ----

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -40,7 +40,10 @@ option('cnet_num_channels', type: 'integer', value: '512',
     description: 'Max number of Channels')
 
 option('cnet_num_routes', type: 'integer', value: '512',
-    description: 'Max number of Routes')
+    description: 'Max number of IPv4 Routes')
+
+option('cnet_num_6routes', type: 'integer', value: '512',
+    description: 'Max number of IPv6 Routes')
 
 option('cnet_num_segs', type: 'integer', value: '8192',
     description: 'Max number of TCB segments')

--- a/usrtools/txgen/app/cli-functions.c
+++ b/usrtools/txgen/app/cli-functions.c
@@ -186,10 +186,6 @@ set_cmd(int argc, char **argv)
     char *what, *p;
     int value, n;
     struct cli_map *m;
-    struct in_addr ip;
-#if CNET_ENABLE_IP6
-    struct in6_addr ip6;
-#endif
     int prefixlen;
     uint32_t u1, u2;
 
@@ -263,22 +259,22 @@ set_cmd(int argc, char **argv)
             if (errno)
                 CNE_ERR_RET("IP address prefix length: %s\n", strerror(errno));
 
-#if CNET_ENABLE_IP6
             if (cne_addr_family(argv[4]) == AF_INET6) {
+                struct in6_addr ip6;
+
                 if (!inet_net_pton(AF_INET6, argv[4], &ip6, sizeof(struct in6_addr)))
                     CNE_ERR_RET("Invalid IP address: %s\n", strerror(errno));
                 foreach_port(portlist,
                     single_set_ipaddr6(info, 's', &ip6, prefixlen));
 
             } else /* IPv4 */ {
-#endif
+                struct in_addr ip;
+
                 if (!inet_aton(argv[4], &ip))
                     CNE_ERR_RET("Invalid IP address: %s\n", strerror(errno));
                 foreach_port(portlist,
                     single_set_ipaddr(info, 's', &ip, prefixlen));
-#if CNET_ENABLE_IP6
             }
-#endif
             break;
         case 31:
             /* Remove the /XX mask value if supplied */
@@ -287,22 +283,22 @@ set_cmd(int argc, char **argv)
                 CNE_WARN("Subnet mask not required, removing subnet mask value\n");
                 *p = '\0';
             }
-#if CNET_ENABLE_IP6
             if (cne_addr_family(argv[4]) == AF_INET6) {
+                struct in6_addr ip6;
+
                 if (!inet_net_pton(AF_INET6, argv[4], &ip6, sizeof(struct in6_addr)))
                     CNE_ERR_RET("Invalid IP address: %s\n", strerror(errno));
                 foreach_port(portlist,
                     single_set_ipaddr6(info, 'd', &ip6, 0));
 
             } else /* IPv4 */ {
-#endif
+                struct in_addr ip;
+
                 if (!inet_aton(argv[4], &ip))
                     CNE_ERR_RET("Invalid IP address: %s\n", strerror(errno));
                 foreach_port(portlist,
                     single_set_ipaddr(info, 'd', &ip, 0));
-#if CNET_ENABLE_IP6
             }
-#endif
             break;
         case 100:
             u1 = strtol(argv[4], NULL, 0);

--- a/usrtools/txgen/app/cmds.c
+++ b/usrtools/txgen/app/cmds.c
@@ -78,14 +78,11 @@ _dump_lport(jcfg_info_t *j __cne_unused, void *obj, void *arg, int idx __cne_unu
     fprintf(fd, "set %d sport %d\n", pid, pkt->sport);
     fprintf(fd, "set %d dport %d\n", pid, pkt->dport);
     fprintf(fd, "set %d type %s\n", lport->lpid,
-            (pkt->ethType == CNE_ETHER_TYPE_IPV4) ? "ipv4"
-#if CNET_ENABLE_IP6
+            (pkt->ethType == CNE_ETHER_TYPE_IPV4)   ? "ipv4"
             : (pkt->ethType == CNE_ETHER_TYPE_IPV6) ? "ipv6"
-#endif
                                                     : "unknown");
     fprintf(fd, "set %d proto %s\n", lport->lpid, (pkt->ipProto == IPPROTO_TCP) ? "tcp" : "udp");
 
-#if CNET_ENABLE_IP6
     if (pkt->ethType == CNE_ETHER_TYPE_IPV6) {
         struct in6_addr mask6, ip6_dst, ip6_src;
 
@@ -99,7 +96,6 @@ _dump_lport(jcfg_info_t *j __cne_unused, void *obj, void *arg, int idx __cne_unu
         fprintf(fd, "set %d src ip %s\n", pid, (b) ? b : "InvalidIP");
 
     } else /* IPv4 */ {
-#endif
         struct in_addr mask = {.s_addr = 0xFFFFFFFF}, ip_dst, ip_src;
 
         ip_dst.s_addr = be32toh(pkt->ip_dst_addr.s_addr);
@@ -108,9 +104,7 @@ _dump_lport(jcfg_info_t *j __cne_unused, void *obj, void *arg, int idx __cne_unu
         ip_src.s_addr = be32toh(pkt->ip_src_addr.s_addr);
         b             = inet_ntop4(buff, sizeof(buff), &ip_src, (struct in_addr *)&pkt->ip_mask);
         fprintf(fd, "set %d src ip %s\n", pid, (b) ? b : "InvalidIP");
-#if CNET_ENABLE_IP6
     }
-#endif
     fprintf(fd, "set %d dst mac %s\n", pid, inet_mtoa(buff, sizeof(buff), &pkt->eth_dst_addr));
     fprintf(fd, "set %d src mac %s\n", pid, inet_mtoa(buff, sizeof(buff), &pkt->eth_src_addr));
 

--- a/usrtools/txgen/app/latency.c
+++ b/usrtools/txgen/app/latency.c
@@ -106,17 +106,14 @@ txgen_print_latency(void)
         snprintf(buff, sizeof(buff), "%d/%5d/%5d", pkt->ttl, pkt->sport, pkt->dport);
         cne_printf_pos(row++, col, "%*s", COLUMN_WIDTH_1, buff);
         snprintf(buff, sizeof(buff), "%s / %s",
-                 (pkt->ethType == CNE_ETHER_TYPE_IPV4) ? "IPv4"
-#if CNET_ENABLE_IP6
+                 (pkt->ethType == CNE_ETHER_TYPE_IPV4)   ? "IPv4"
                  : (pkt->ethType == CNE_ETHER_TYPE_IPV6) ? "IPv6"
-#endif
                                                          : "unknown",
                  (pkt->ipProto == IPPROTO_TCP) ? "TCP" : "UDP");
         cne_printf_pos(row++, col, "%*s", COLUMN_WIDTH_1, buff);
 
         display_set_color("stats.ip");
         memset(buff, 0, sizeof(buff));
-#if CNET_ENABLE_IP6
         if (pkt->ethType == CNE_ETHER_TYPE_IPV6) {
             struct in6_addr mask6, ip6_dst, ip6_src;
 
@@ -130,7 +127,6 @@ txgen_print_latency(void)
             cne_printf_pos(row++, col, "%*s", COLUMN_WIDTH_1, (b) ? b : "InvalidIP");
 
         } else /* IPv4 */ {
-#endif
             struct in_addr mask = {.s_addr = 0xFFFFFFFF}, ip_dst, ip_src;
 
             ip_dst.s_addr = be32toh(pkt->ip_dst_addr.s_addr);
@@ -140,9 +136,7 @@ txgen_print_latency(void)
             ip_src.s_addr = be32toh(pkt->ip_src_addr.s_addr);
             b = inet_ntop4(buff, sizeof(buff), &ip_src, (struct in_addr *)&pkt->ip_mask);
             cne_printf_pos(row++, col, "%*s", COLUMN_WIDTH_1, (b) ? b : "InvalidIP");
-#if CNET_ENABLE_IP6
         }
-#endif
         display_set_color("stats.mac");
         cne_printf_pos(row++, col, "%*s", COLUMN_WIDTH_1,
                        inet_mtoa(buff, sizeof(buff), &pkt->eth_dst_addr));

--- a/usrtools/txgen/app/pcap.c
+++ b/usrtools/txgen/app/pcap.c
@@ -123,12 +123,10 @@ txgen_print_pcap(uint16_t pid)
         if (type == CNE_ETHER_TYPE_VLAN) {
             vlan = ntohs(((uint16_t *)&hdr->eth.ether_type)[1]);
             type = ntohs(((uint16_t *)&hdr->eth.ether_type)[2]);
-#if CNET_ENABLE_IP6
-            if (type == CNE_ETHER_TYPE_IPV6)
+            if (type == CNE_ETHER_TYPE_IPV6) {
                 /* Why offset 4, will it be different for ipv6 ? */
                 proto = ((struct cne_ipv6_hdr *)((char *)&hdr->ipv6 + 4))->proto;
-            else
-#endif
+            } else
                 proto = ((struct cne_ipv4_hdr *)((char *)&hdr->ipv4 + 4))->next_proto_id;
         }
 
@@ -148,9 +146,7 @@ txgen_print_pcap(uint16_t pid)
                      ntohs(hdr->uip.udp.dst_port));
             cne_printf_pos(row, col, "%*s", 12, buff);
             col += 12;
-        }
-#if CNET_ENABLE_IP6
-        else if (type == CNE_ETHER_TYPE_IPV6) {
+        } else if (type == CNE_ETHER_TYPE_IPV6) {
             struct in6_addr mask;
             char *b;
 
@@ -167,9 +163,7 @@ txgen_print_pcap(uint16_t pid)
                      ntohs(hdr->uip.udp.dst_port));
             cne_printf_pos(row, col, "%*s", 12, buff);
             col += 12;
-        }
-#endif
-        else {
+        } else {
             skip++;
             col += ((2 * COLUMN_WIDTH_1) + 2 + 12);
         }

--- a/usrtools/txgen/app/stats.c
+++ b/usrtools/txgen/app/stats.c
@@ -143,7 +143,6 @@ txgen_print_static_data(void)
 
         display_set_color("stats.ip");
         memset(buff, 0, sizeof(buff));
-#if CNET_ENABLE_IP6
         if (pkt->ethType == CNE_ETHER_TYPE_IPV6) {
             struct in6_addr mask6, ip6_dst, ip6_src;
 
@@ -157,7 +156,6 @@ txgen_print_static_data(void)
             cne_printf_pos(row++, col, "%*s", COLUMN_WIDTH_1, (b) ? b : "InvalidIP");
 
         } else /* IPv4 */ {
-#endif
             struct in_addr mask = {.s_addr = 0xFFFFFFFF}, ip_dst, ip_src;
 
             ip_dst.s_addr = be32toh(pkt->ip_dst_addr.s_addr);
@@ -167,9 +165,7 @@ txgen_print_static_data(void)
             ip_src.s_addr = be32toh(pkt->ip_src_addr.s_addr);
             b = inet_ntop4(buff, sizeof(buff), &ip_src, (struct in_addr *)&pkt->ip_mask);
             cne_printf_pos(row++, col, "%*s", COLUMN_WIDTH_1, (b) ? b : "InvalidIP");
-#if CNET_ENABLE_IP6
         }
-#endif
         display_set_color("stats.mac");
         cne_printf_pos(row++, col, "%*s", COLUMN_WIDTH_1,
                        inet_mtoa(buff, sizeof(buff), &pkt->eth_dst_addr));

--- a/usrtools/txgen/app/tcp.c
+++ b/usrtools/txgen/app/tcp.c
@@ -62,9 +62,7 @@ txgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type __cne_unused)
 
         tcp->cksum = cne_ipv4_udptcp_cksum(ipv4, (const void *)tcp);
 
-    }
-#if CNET_ENABLE_IP6
-    else if (pkt->ethType == CNE_ETHER_TYPE_IPV6) {
+    } else if (pkt->ethType == CNE_ETHER_TYPE_IPV6) {
         struct cne_ipv6_hdr *ipv6 = (struct cne_ipv6_hdr *)hdr;
         tcp                       = (struct cne_tcp_hdr *)&ipv6[1];
 
@@ -80,7 +78,6 @@ txgen_tcp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type __cne_unused)
 
         tcp->cksum = cne_ipv6_udptcp_cksum(ipv6, (const void *)tcp);
     }
-#endif
 
     /* In this case we return the original value to allow IP ctor to work */
     return hdr;

--- a/usrtools/txgen/app/txgen.c
+++ b/usrtools/txgen/app/txgen.c
@@ -187,12 +187,9 @@ txgen_tstamp_apply(port_info_t *info, pktmbuf_t **pkts, int cnt)
 
         /* Construct the UDP header */
         txgen_udp_hdr_ctor(pkt, l3_hdr, pkt->ethType);
-#if CNET_ENABLE_IP6
-        if (pkt->ethType == CNE_ETHER_TYPE_IPV6)
-            /* IPv6 Header constructor */
+        if (pkt->ethType == CNE_ETHER_TYPE_IPV6) /* IPv6 Header constructor */
             txgen_ipv6_ctor(pkt, l3_hdr);
         else
-#endif
             /* IPv4 Header constructor */
             txgen_ipv4_ctor(pkt, l3_hdr);
     }
@@ -297,9 +294,7 @@ txgen_packet_ctor(port_info_t *info)
             /* IPv4 Header constructor */
             txgen_ipv4_ctor(pkt, l3_hdr);
         }
-    }
-#if CNET_ENABLE_IP6
-    else if (pkt->ethType == CNE_ETHER_TYPE_IPV6) {
+    } else if (pkt->ethType == CNE_ETHER_TYPE_IPV6) {
         if (likely(pkt->ipProto == IPPROTO_TCP)) {
             /* Construct the TCP header */
             txgen_tcp_hdr_ctor(pkt, l3_hdr, CNE_ETHER_TYPE_IPV6);
@@ -314,9 +309,7 @@ txgen_packet_ctor(port_info_t *info)
             txgen_ipv6_ctor(pkt, l3_hdr);
         }
 
-    }
-#endif
-    else
+    } else
         cne_printf("Unknown EtherType 0x%04x", pkt->ethType);
 }
 

--- a/usrtools/txgen/app/udp.c
+++ b/usrtools/txgen/app/udp.c
@@ -58,9 +58,7 @@ txgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type __cne_unused)
         udp              = txgen_init_udp_hdr(udp, pkt, sizeof(struct cne_ipv4_hdr));
         udp->dgram_cksum = cne_ipv4_udptcp_cksum(ipv4, (const void *)udp);
 
-    }
-#if CNET_ENABLE_IP6
-    else if (pkt->ethType == CNE_ETHER_TYPE_IPV6) {
+    } else if (pkt->ethType == CNE_ETHER_TYPE_IPV6) {
         struct cne_ipv6_hdr *ipv6 = hdr;
         udp                       = (struct cne_udp_hdr *)&ipv6[1];
 
@@ -75,7 +73,6 @@ txgen_udp_hdr_ctor(pkt_seq_t *pkt, void *hdr, int type __cne_unused)
         udp              = txgen_init_udp_hdr(udp, pkt, sizeof(struct cne_ipv6_hdr));
         udp->dgram_cksum = cne_ipv6_udptcp_cksum(ipv6, (const void *)udp);
     }
-#endif
 
     if (udp && udp->dgram_cksum == 0)
         udp->dgram_cksum = 0xFFFF;


### PR DESCRIPTION
- Add test case to check for ipv6 in graph patterns
- Remove some CNET_ENABLE_IP6 ifdefs and add the test at runtime, the compile will remove the code based on CNET_ENABLE_IP6 value.
- Missing initialization for route6 and nd6 in cnet_config_create()
- Remove some dead code in cnet_protosw.c
- Change ip6_get_flowlable, ip6_get_tclass and ip6_get_version routines to static inline, because when building use debug mode the compiler would flag this as an error.
- fixed a couple comment typos
- fix up pkt_ctrl.c code to link IPv6 routines to the Rx/Tx output routines. Verified by running CNET cli command 'gdot' and then use xdot program to display the cnet_2.dot file in top level directory.
- Make sure protosw contains the UDP and TCP entries for IPv6. Plus a few bugs were found because of IPv6 was added.