### PR TITLE
Cnet ether punt node

### DIFF
--- a/lib/cnet/cmds/cnet_cmds.c
+++ b/lib/cnet/cmds/cnet_cmds.c
@@ -328,6 +328,7 @@ _node_style(char *name, int src)
         { 0,                    ARP_REQUEST_NODE_NAME,   "[fillcolor=mediumspringgreen]" },
         { 0,                    ETH_TX_NODE_NAME"*",     "[fillcolor=cyan]" },
         { 0,                    PUNT_KERNEL_NODE_NAME,   "[fillcolor=coral]" },
+        { 0,                    PUNT_ETHER_NODE_NAME,    "[fillcolor=coral]" },
         { 0,                    PTYPE_NODE_NAME,         "[fillcolor=goldenrod]" },
         { 0,                    GTPU_INPUT_NODE_NAME,    "[fillcolor=lightskyblue]" },
         { 0,                    "tcp_*",                 "[fillcolor=lightpink]" },

--- a/lib/cnet/incs/cnet_node_names.h
+++ b/lib/cnet/incs/cnet_node_names.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2022-2023 Intel Corporation
+ * Copyright (c) Red Hat Inc.
  */
 
 #ifndef __CNET_NODE_NAMES_H
@@ -35,6 +36,7 @@ extern "C" {
 #define PKT_DROP_NODE_NAME      "pkt_drop"
 #define PTYPE_NODE_NAME         "ptype"
 #define PUNT_KERNEL_NODE_NAME   "punt_kernel"
+#define PUNT_ETHER_NODE_NAME    "punt_l2_kernel"
 #define TCP_INPUT_NODE_NAME     "tcp_input"
 #define TCP_OUTPUT_NODE_NAME    "tcp_output"
 #define UDP_INPUT_NODE_NAME     "udp_input"

--- a/lib/cnet/meson.build
+++ b/lib/cnet/meson.build
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2018-2023 Intel Corporation
+# Copyright (c) Red Hat Inc.
 
 def_deps = [
     build_cfg,
@@ -14,7 +15,6 @@ def_deps = [
     pktdev,
     pktmbuf,
     fib,
-
     ring,
     cli,
     hash,
@@ -25,6 +25,9 @@ def_deps = [
     graph,
     jcfg,
     tun,
+    uds,
+    pmd_tap,
+    xskdev,
     ]
 
 dirs = [ # list is not sorted and must be in this order.

--- a/lib/cnet/ptype/ptype.c
+++ b/lib/cnet/ptype/ptype.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2021-2023 Intel Corporation.
  * Copyright (c) 2020 Marvell.
+ * Copyright (c) Red Hat Inc.
  */
 
 #include <pktmbuf.h>                 // for pktmbuf_t, pktmbuf_s::(anonymous)
@@ -25,6 +26,9 @@
 
 /* Next node for each ptype, default is '0' is "pkt_drop" */
 static const uint8_t p_nxt[_PTYPE_MASK + 1] __cne_cache_aligned = {
+    [CNE_PTYPE_L2_ETHER_ARP]                                 = PTYPE_NEXT_FRAME_PUNT,
+    [_L2_L3_IPV4]                                            = PTYPE_NEXT_IP4_INPUT,
+    [_L2_L3_IPV4_EXT]                                        = PTYPE_NEXT_PKT_PUNT,
     [_L2_L3_IPV4 | CNE_PTYPE_L4_UDP]                         = PTYPE_NEXT_IP4_INPUT,
     [_L2_L3_IPV4 | CNE_PTYPE_L4_TCP]                         = PTYPE_NEXT_IP4_INPUT,
     [_L2_L3_IPV4_EXT | CNE_PTYPE_L4_UDP]                     = PTYPE_NEXT_IP4_INPUT,
@@ -164,6 +168,7 @@ ptype_node_process(struct cne_graph *graph, struct cne_node *node, void **objs, 
         n_left_from -= 1;
 
         l0 = mbuf0->packet_type & ptype_mask;
+
         if (unlikely((l0 != last_type) && (p_nxt[l0] != next_index))) {
             /* Copy things successfully speculated till now */
             memcpy(to_next, from, last_spec * sizeof(from[0]));
@@ -191,6 +196,7 @@ ptype_node_process(struct cne_graph *graph, struct cne_node *node, void **objs, 
     cne_node_next_stream_put(graph, node, next_index, held);
 
     ctx->last_type = last_type;
+
     return nb_objs;
 }
 
@@ -204,6 +210,8 @@ struct cne_node_register ptype_node = {
         {
             /* Pkt drop node starts at '0' */
             [PTYPE_NEXT_PKT_DROP]   = PKT_DROP_NODE_NAME,
+            [PTYPE_NEXT_PKT_PUNT]   = PUNT_KERNEL_NODE_NAME,
+            [PTYPE_NEXT_FRAME_PUNT] = PUNT_ETHER_NODE_NAME,
             [PTYPE_NEXT_IP4_INPUT]  = IP4_INPUT_NODE_NAME,
             [PTYPE_NEXT_GTPU_INPUT] = GTPU_INPUT_NODE_NAME,
         },

--- a/lib/cnet/ptype/ptype.c
+++ b/lib/cnet/ptype/ptype.c
@@ -27,8 +27,6 @@
 /* Next node for each ptype, default is '0' is "pkt_drop" */
 static const uint8_t p_nxt[_PTYPE_MASK + 1] __cne_cache_aligned = {
     [CNE_PTYPE_L2_ETHER_ARP]                                 = PTYPE_NEXT_FRAME_PUNT,
-    [_L2_L3_IPV4]                                            = PTYPE_NEXT_IP4_INPUT,
-    [_L2_L3_IPV4_EXT]                                        = PTYPE_NEXT_PKT_PUNT,
     [_L2_L3_IPV4 | CNE_PTYPE_L4_UDP]                         = PTYPE_NEXT_IP4_INPUT,
     [_L2_L3_IPV4 | CNE_PTYPE_L4_TCP]                         = PTYPE_NEXT_IP4_INPUT,
     [_L2_L3_IPV4_EXT | CNE_PTYPE_L4_UDP]                     = PTYPE_NEXT_IP4_INPUT,

--- a/lib/cnet/ptype/ptype_priv.h
+++ b/lib/cnet/ptype/ptype_priv.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2021-2023 Intel Corporation.
  * Copyright (c) 2020 Marvell.
+ * Copyright (c) Red Hat Inc.
  */
 #ifndef __INCLUDE_PTYPE_PRIV_H__
 #define __INCLUDE_PTYPE_PRIV_H__
@@ -17,6 +18,8 @@ struct ptype_node_ctx {
 
 enum ptype_next_nodes {
     PTYPE_NEXT_PKT_DROP,
+    PTYPE_NEXT_PKT_PUNT,
+    PTYPE_NEXT_FRAME_PUNT,
     PTYPE_NEXT_IP4_INPUT,
     PTYPE_NEXT_GTPU_INPUT,
     PTYPE_NEXT_MAX,

--- a/lib/cnet/punt/meson.build
+++ b/lib/cnet/punt/meson.build
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2018-2023 Intel Corporation
+# Copyright (c) Red Hat Inc.
 
-sources += files('punt_kernel.c', 'kernel_recv.c')
+sources += files('punt_kernel.c', 'punt_ether_kernel.c', 'kernel_recv.c')

--- a/lib/cnet/punt/punt_ether_kernel.c
+++ b/lib/cnet/punt/punt_ether_kernel.c
@@ -1,0 +1,185 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) Red Hat Inc.
+ * Copyright (c) 2023 Intel Corporation
+ */
+
+#include <net/cne_ether.h>           // for ether_addr_copy, cne_ether_hdr, ether_ad...
+#include <cnet.h>                    // for cnet_add_instance, cnet, per_thread_cnet
+#include <cnet_stk.h>                // for proto_in_ifunc
+#include <cnet_drv.h>                // for drv_entry
+#include <cnet_route.h>              // for
+#include <cnet_arp.h>                // for arp_entry
+#include <netinet/in.h>              // for ntohs
+#include <netpacket/packet.h>        // for sockaddr_ll
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <linux/if_tun.h>
+#include <linux/if_ether.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <stddef.h>        // for NULL
+#include <sys/types.h>
+#include <fcntl.h>
+#include <bsd/string.h>
+#include <sys/uio.h>
+
+#include <cne_graph.h>               // for
+#include <cne_graph_worker.h>        // for
+#include <cne_log.h>                 // for CNE_LOG, CNE_LOG_DEBUG
+#include <mempool.h>                 // for mempool_t
+#include <pktdev.h>                  // for pktdev_rx_burst
+#include <xskdev.h>
+#include <pktmbuf.h>        // for pktmbuf_t, pktmbuf_data_len
+#include <pktmbuf_ptype.h>
+#include <cne_vec.h>        // for
+#include <cnet_eth.h>
+#include <hexdump.h>
+#include <cnet_netif.h>        // for
+#include <netinet/if_ether.h>
+#include <pmd_tap.h>
+#include <cnet_node_names.h>
+#include "punt_ether_kernel_priv.h"
+
+#define PREFETCH_CNT 6
+
+static __cne_always_inline void
+punt_ether_kernel_process_mbuf(struct cne_node *node, pktmbuf_t **mbufs, uint16_t cnt)
+{
+    punt_ether_kernel_node_ctx_t *ctx = (punt_ether_kernel_node_ctx_t *)node->ctx;
+
+    if (ctx->sock >= 0) {
+        for (int i = 0; i < cnt; i++)
+            pktmbuf_adj_offset(mbufs[i], -(mbufs[i]->l2_len));
+
+        int nb = pktdev_tx_burst(ctx->lport, mbufs, cnt);
+        if (nb == PKTDEV_ADMIN_STATE_DOWN)
+            CNE_WARN("Failed to send packets: %s\n", strerror(errno));
+    }
+}
+
+static uint16_t
+punt_ether_kernel_node_process(struct cne_graph *graph __cne_unused, struct cne_node *node,
+                               void **objs, uint16_t nb_objs)
+{
+    uint16_t n_left_from;
+    pktmbuf_t *mbufs[PREFETCH_CNT], **pkts;
+    int k;
+
+    pkts        = (pktmbuf_t **)objs;
+    n_left_from = nb_objs;
+
+    for (k = 0; k < PREFETCH_CNT && k < n_left_from; k++)
+        cne_prefetch0(pktmbuf_mtod_offset(pkts[k], void *, sizeof(struct cne_ether_hdr)));
+
+    while (n_left_from >= PREFETCH_CNT) {
+        /* Prefetch next-next mbufs */
+        if (likely(n_left_from > ((PREFETCH_CNT * 3) - 1))) {
+            cne_prefetch0(pkts[(PREFETCH_CNT * 2) + 0]);
+            cne_prefetch0(pkts[(PREFETCH_CNT * 2) + 1]);
+            cne_prefetch0(pkts[(PREFETCH_CNT * 2) + 2]);
+            cne_prefetch0(pkts[(PREFETCH_CNT * 2) + 3]);
+            cne_prefetch0(pkts[(PREFETCH_CNT * 2) + 4]);
+            cne_prefetch0(pkts[(PREFETCH_CNT * 2) + 5]);
+        }
+
+        /* Prefetch next mbuf data */
+        if (likely(n_left_from > ((PREFETCH_CNT * 2) - 1))) {
+            uint16_t pre = PREFETCH_CNT;
+
+            cne_prefetch0(pktmbuf_mtod_offset(pkts[pre + 0], void *, pkts[pre + 0]->l2_len));
+            cne_prefetch0(pktmbuf_mtod_offset(pkts[pre + 1], void *, pkts[pre + 1]->l2_len));
+            cne_prefetch0(pktmbuf_mtod_offset(pkts[pre + 2], void *, pkts[pre + 2]->l2_len));
+            cne_prefetch0(pktmbuf_mtod_offset(pkts[pre + 3], void *, pkts[pre + 3]->l2_len));
+            cne_prefetch0(pktmbuf_mtod_offset(pkts[pre + 4], void *, pkts[pre + 4]->l2_len));
+            cne_prefetch0(pktmbuf_mtod_offset(pkts[pre + 5], void *, pkts[pre + 5]->l2_len));
+        }
+
+        memcpy(mbufs, pkts, (PREFETCH_CNT * sizeof(void *)));
+
+        pkts += PREFETCH_CNT;
+        n_left_from -= PREFETCH_CNT;
+
+        punt_ether_kernel_process_mbuf(node, mbufs, PREFETCH_CNT);
+    }
+
+    while (n_left_from > 0) {
+        mbufs[0] = pkts[0];
+
+        n_left_from--;
+        pkts++;
+
+        punt_ether_kernel_process_mbuf(node, mbufs, 1);
+    }
+
+    return nb_objs;
+}
+
+static int
+punt_ether_kernel_node_init(const struct cne_graph *graph __cne_unused, struct cne_node *node)
+{
+    punt_ether_kernel_node_ctx_t *ctx = (punt_ether_kernel_node_ctx_t *)node->ctx;
+
+    lport_cfg_t cfg = {0}; /**< CFG for tun/tap setup */
+    ctx->mmap       = mmap_alloc(DEFAULT_MBUF_COUNT, DEFAULT_MBUF_SIZE, MMAP_HUGEPAGE_4KB);
+    if (ctx->mmap == NULL)
+        cne_panic("Failed to mmap(%lu, %s) memory",
+                  (uint64_t)DEFAULT_MBUF_COUNT * (uint64_t)DEFAULT_MBUF_SIZE,
+                  mmap_name_by_type(MMAP_HUGEPAGE_4KB));
+
+    memset(&cfg, 0, sizeof(cfg));
+
+    strlcpy(cfg.name, TAP_NAME, sizeof(cfg.name));
+    strlcpy(cfg.pmd_name, PMD_NET_TAP_NAME, sizeof(cfg.pmd_name));
+    strlcpy(cfg.ifname, TAP_NAME, sizeof(cfg.ifname));
+
+    cfg.addr = cfg.umem_addr = mmap_addr(ctx->mmap);
+    cfg.umem_size            = mmap_size(ctx->mmap, NULL, NULL);
+    cfg.qid                  = LPORT_DFLT_START_QUEUE_IDX;
+    cfg.bufsz                = LPORT_FRAME_SIZE;
+    cfg.bufcnt               = DEFAULT_MBUF_COUNT;
+    cfg.rx_nb_desc           = XSK_RING_PROD__DEFAULT_NUM_DESCS;
+    cfg.tx_nb_desc           = XSK_RING_CONS__DEFAULT_NUM_DESCS;
+    cfg.pi =
+        pktmbuf_pool_create(mmap_addr(ctx->mmap), DEFAULT_MBUF_COUNT, DEFAULT_MBUF_SIZE, 0, NULL);
+
+    ctx->lport = pktdev_port_setup(&cfg);
+    if (ctx->lport < 0)
+        CNE_ERR_RET("Failed to create TAP device\n");
+
+    if (netdev_set_link_up(TAP_NAME) < 0)
+        CNE_ERR_RET("netdev_set_link_up(%d) failed\n", ctx->lport);
+
+    return 0;
+}
+
+static void
+punt_ether_kernel_node_fini(const struct cne_graph *graph __cne_unused, struct cne_node *node)
+{
+    punt_ether_kernel_node_ctx_t *ctx = (punt_ether_kernel_node_ctx_t *)node->ctx;
+
+    if (pktdev_close(ctx->lport) < 0)
+        CNE_WARN("pktdev_close(%d) failed\n", ctx->lport);
+    mmap_free(ctx->mmap);
+
+    if (ctx->sock >= 0) {
+        close(ctx->sock);
+        ctx->sock = -1;
+    }
+}
+
+static struct cne_node_register punt_ether_kernel_node_base = {
+    .process = punt_ether_kernel_node_process,
+    .name    = PUNT_ETHER_NODE_NAME,
+
+    .init = punt_ether_kernel_node_init,
+    .fini = punt_ether_kernel_node_fini,
+
+};
+
+struct cne_node_register *
+punt_ether_kernel_node_get(void)
+{
+    return &punt_ether_kernel_node_base;
+}
+
+CNE_NODE_REGISTER(punt_ether_kernel_node_base);

--- a/lib/cnet/punt/punt_ether_kernel_priv.h
+++ b/lib/cnet/punt/punt_ether_kernel_priv.h
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) Red Hat Inc.
+ * Copyright (c) 2023 Intel Corporation
+ */
+#ifndef __INCLUDE_PUNT_ETHER_KERNEL_PRIV_H__
+#define __INCLUDE_PUNT_ETHER_KERNEL_PRIV_H__
+
+#include <cne_common.h>
+#include <tun_alloc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TAP_NAME "punt_ether"
+
+struct punt_ether_kernel_node_elem;
+struct punt_ether_kernel_node_ctx;
+typedef struct punt_ether_kernel_node_elem punt_ether_kernel_node_elem_t;
+
+/**
+ * @internal
+ *
+ * PUNT Ether Kernel node context structure.
+ */
+typedef struct punt_ether_kernel_node_ctx {
+    int sock;
+    int lport;
+    mmap_t *mmap;
+} punt_ether_kernel_node_ctx_t;
+
+/**
+ * @internal
+ *
+ * PUNT Ether Kernel node list element structure.
+ */
+struct punt_ether_kernel_node_elem {
+    struct punt_ether_kernel_node_elem *next; /**< Pointer to the next node element. */
+    struct punt_ether_kernel_node_ctx *ctx;   /**< node context. */
+    cne_node_t nid;                           /**< Node identifier of the PUNT ether Kernel node. */
+};
+
+/**
+ * @internal
+ *
+ * PUNT Ether Kernel node main structure.
+ */
+struct punt_ether_kernel_node_main {
+    punt_ether_kernel_node_elem_t *head; /**< Pointer to the head node element. */
+};
+
+/**
+ * @internal
+ *
+ * Get the PUNT Ether Kernel node.
+ *
+ * @return
+ *   Pointer to the PUNT Ether Kernel node.
+ */
+CNDP_API struct cne_node_register *punt_ether_kernel_node_get(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_PUNT_ETHER_KERNEL_PRIV_H__ */


### PR DESCRIPTION
Create a new punt node for ethernet frame. In the  case that the xsk bpf program doesn't filter only UDP/TCP traffic to cnet, then punt arp requests to the host kernel. This commit creates a new punt node called `punt_l2_kernel`. ARP requests are punted to it from the ptype node. The ARP request is then passed to the host through a tap device called `punt_ether`.


Maybe this can be combined with the IP packet punt node. But I went down this path to avoid having to do too many packet rechecks