### PR TITLE
fix build error due to missing declaration

### DIFF
--- a/lib/core/log/cne_log.h
+++ b/lib/core/log/cne_log.h
@@ -20,6 +20,7 @@
 #include <cne_stdio.h>
 
 #include "cne_build_config.h"        // for CNE_ENABLE_ASSERT
+#include "cne_branch_prediction.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
../lib/usr/app/cli/cli.h: In function 'get_root':                                                                                                                                                                                              
../lib/core/log/cne_log.h:344:13: error: implicit declaration of function 'unlikely' [-Werror=implicit-function-declaration]                                                                                                                   
  344 |         if (unlikely(!(exp)))