### PR TITLE
Quicly hotfix  pcb - fix chksum verify

### DIFF
--- a/examples/cnet-quic/README.md
+++ b/examples/cnet-quic/README.md
@@ -76,7 +76,7 @@ Edit the cndp/examples/quic.jsonc file to add your interfaces and other machine 
 % sudo ifconfig enp94s0f0 198.18.0.2/24 up
 % sudo ethtool -N enp94s0f0 flow-type udp4 action 11  # must match the qid in the jsonc file.
 %
-% ./tools/rcndp cnet-quic -c examples/cnet-quic/quic.jsonc -- -c examples/cnet-quic/server.crt -k examples/cnet-quic/server.key 0.0.0.0 4433
+% ./tools/rcndp cnet-quic -c examples/cnet-quic/quic.jsonc -- -c examples/cnet-quic/server.crt -k examples/cnet-quic/server.key 192.168.0.2 4433
 ```
 
 ``` console

--- a/examples/cnet-quic/meson.build
+++ b/examples/cnet-quic/meson.build
@@ -35,6 +35,7 @@ if quicly_dep.found()
     ]
 
     warning_flags = [
+        '-Wno-error',
         '-Wno-cast-qual',
         '-Wno-unused-parameter',
         '-Wno-sign-compare',
@@ -56,7 +57,7 @@ if quicly_dep.found()
             quic_cflags += arg
         endif
     endforeach
-    quic_cflags += ['-I'+quicly_path+'/include', '-I'+picotls_path+'/include']
+    quic_cflags += ['-I'+quicly_path+'/../include', '-I'+picotls_path+'/../include']
     quic_cflags += ['-DPICOTLS_USE_DTRACE=0', '-DQUICLY_HAVE_FUSION=1']
 
     executable('cnet-quic',

--- a/examples/cnet-quic/meson.build
+++ b/examples/cnet-quic/meson.build
@@ -57,7 +57,7 @@ if quicly_dep.found()
             quic_cflags += arg
         endif
     endforeach
-    quic_cflags += ['-I'+quicly_path+'/../include', '-I'+picotls_path+'/../include']
+    quic_cflags += ['-I'+quicly_path+'/include', '-I'+picotls_path+'/include']
     quic_cflags += ['-DPICOTLS_USE_DTRACE=0', '-DQUICLY_HAVE_FUSION=1']
 
     executable('cnet-quic',

--- a/examples/cnet-quic/quic-cli.c
+++ b/examples/cnet-quic/quic-cli.c
@@ -825,8 +825,8 @@ run_server(int cd, pktmbuf_t *mbuf)
                 break;
             } else {
                 /* new connection */
-                int ret =
-                    quicly_accept(&conn, &ctx, NULL, &remote.sa, &packet, token, &next_cid, NULL);
+                int ret = quicly_accept(&conn, &ctx, NULL, &remote.sa, &packet, token, &next_cid,
+                                        NULL, NULL);
                 if (ret == 0) {
                     assert(conn != NULL);
                     ++next_cid.master_id;
@@ -1493,7 +1493,7 @@ open_quic_channel(void)
 
         ret =
             quicly_connect(&conn, &ctx, cinfo->host, (struct sockaddr *)&cinfo->sa, NULL, &next_cid,
-                           resumption_token, &hs_properties, &resumed_transport_params);
+                           resumption_token, &hs_properties, &resumed_transport_params, NULL);
         assert(ret == 0);
         ++next_cid.master_id;
         enqueue_requests(conn);

--- a/lib/cnet/tcp/tcp_input.c
+++ b/lib/cnet/tcp/tcp_input.c
@@ -47,7 +47,9 @@ tcp_input_lookup(struct cne_node *node, pktmbuf_t *m, struct pcb_hd *hd)
     struct pcb_key key = {0};
     struct pcb_entry *pcb;
     struct cnet_metadata *md;
+#if 0
     uint16_t csum;
+#endif
     int a_family, a_len;
     struct pcb_entry *pcb2;
 
@@ -90,14 +92,14 @@ tcp_input_lookup(struct cne_node *node, pktmbuf_t *m, struct pcb_hd *hd)
     pcb = cnet_pcb_lookup(hd, &key, BEST_MATCH);
     if (likely(pcb)) {
         int rc = TCP_INPUT_NEXT_PKT_DROP;
-
+#if 0        // Disable till cne_ipv4_udptcp_cksum_verify is fixed
         if (is_pcb_dom_inet6(pcb))
             csum = cne_ipv6_udptcp_cksum_verify(&tip->ip6, &tip->tcp);
         else
             csum = cne_ipv4_udptcp_cksum_verify(&tip->ip4, &tip->tcp);
         if (csum)
             return rc;
-
+#endif
         m->userptr = pcb;
         in_caddr_copy(&md->faddr, &key.faddr); /* Save the foreign address */
         in_caddr_copy(&md->laddr, &key.laddr); /* Save the local address */

--- a/lib/cnet/tcp/tcp_input.c
+++ b/lib/cnet/tcp/tcp_input.c
@@ -96,9 +96,9 @@ tcp_input_lookup(struct cne_node *node, pktmbuf_t *m, struct pcb_hd *hd)
     if (likely(pcb)) {
         int rc = TCP_INPUT_NEXT_PKT_DROP;
         if (is_pcb_dom_inet6(pcb))
-            csum = cne_ipv6_udptcp_cksum_verify(pktmbuf_mtod(m, void *), tcp);
+            csum = cne_ipv6_udptcp_cksum_verify(l3, tcp);
         else
-            csum = cne_ipv4_udptcp_cksum_verify(pktmbuf_mtod(m, void *), tcp);
+            csum = cne_ipv4_udptcp_cksum_verify(l3, tcp);
         if (csum < 0)
             return rc;
 

--- a/lib/cnet/udp/udp_input.c
+++ b/lib/cnet/udp/udp_input.c
@@ -100,9 +100,9 @@ udp_input_lookup(pktmbuf_t *m, struct pcb_hd *hd)
     if (likely(pcb)) {
         if ((pcb->opt_flag & UDP_CHKSUM_FLAG) && udp->dgram_cksum) {
             if (is_pcb_dom_inet6(pcb))
-                csum = cne_ipv6_udptcp_cksum_verify(pktmbuf_mtod(m, void *), udp);
+                csum = cne_ipv6_udptcp_cksum_verify(l3, udp);
             else {
-                csum = cne_ipv4_udptcp_cksum_verify(pktmbuf_mtod(m, void *), udp);
+                csum = cne_ipv4_udptcp_cksum_verify(l3, udp);
             }
             if (csum < 0)
                 return UDP_INPUT_NEXT_PKT_DROP;


### PR DESCRIPTION
Depends on https://github.com/CloudNativeDataPlane/cndp/pull/340

Fixes the PCB lookup failure in the UDP input node for cnet and the failing csum verifications ...
Note: it looks like the same issue exists in the tcp input node also... so I applied the same fix

Note: Only tested UDP path with quicly client application... 