### PR TITLE
Fix dependency check for libnl-route-3.0 in main meson.build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -168,7 +168,7 @@ if nl_cli_dep.found()
 endif
 
 nl_route_dep = dependency('libnl-route-3.0', required: true, method: 'pkg-config', static: use_static_libs)
-if nl_cli_dep.found()
+if nl_route_dep.found()
     add_project_link_arguments('-lnl-route-3', language: 'c')
     extra_ldflags += '-lnl-route-3'
 endif


### PR DESCRIPTION
The meson code to check if `libnl-route-3` is available or not duplicates the code for `libnl-cli-3.0`.
Instead of `nl_route_dep.found()`, the build file checks for `libnl-cli-3` (again).