### PR TITLE
Use a specific priority for PMD Constructors/Desctructors

### DIFF
--- a/lib/core/pktdev/pktdev_driver.h
+++ b/lib/core/pktdev/pktdev_driver.h
@@ -52,11 +52,11 @@ struct pktdev_driver {
  */
 void pktdev_register(struct pktdev_driver *driver);
 
-#define PMD_REGISTER_DEV(nm, vdrv) \
-    CNE_INIT_PRIO(vdrvinit_##vdrv, PMD)      \
-    {                              \
-        (vdrv).name = CNE_STR(nm); \
-        pktdev_register(&vdrv);    \
+#define PMD_REGISTER_DEV(nm, vdrv)      \
+    CNE_INIT_PRIO(vdrvinit_##vdrv, PMD) \
+    {                                   \
+        (vdrv).name = CNE_STR(nm);      \
+        pktdev_register(&vdrv);         \
     }
 
 /**

--- a/lib/core/pktdev/pktdev_driver.h
+++ b/lib/core/pktdev/pktdev_driver.h
@@ -53,7 +53,7 @@ struct pktdev_driver {
 void pktdev_register(struct pktdev_driver *driver);
 
 #define PMD_REGISTER_DEV(nm, vdrv) \
-    CNE_INIT(vdrvinit_##vdrv)      \
+    CNE_INIT_PRIO(vdrvinit_##vdrv, PMD)      \
     {                              \
         (vdrv).name = CNE_STR(nm); \
         pktdev_register(&vdrv);    \

--- a/lib/core/pmds/net/tap/pmd_tap.c
+++ b/lib/core/pmds/net/tap/pmd_tap.c
@@ -402,7 +402,7 @@ pmd_tun_probe(lport_cfg_t *c)
     return _tap_probe(IFF_TUN, c);
 }
 
-CNE_INIT(vdrvinit_tuntap)
+CNE_INIT_PRIO(vdrvinit_tuntap, PMD)
 {
     pktdev_register(&tap_drv);
     pktdev_register(&tun_drv);

--- a/lib/include/cne_common.h
+++ b/lib/include/cne_common.h
@@ -160,6 +160,7 @@ typedef uint16_t unaligned_uint16_t;
 #define CNE_PRIORITY_STATE  110
 #define CNE_PRIORITY_CLASS  120
 #define CNE_PRIORITY_STACK  130
+#define CNE_PRIORITY_PMD    30000
 #define CNE_PRIORITY_LAST   65535
 
 #define CNE_PRIO(prio) CNE_PRIORITY_##prio


### PR DESCRIPTION
Closes #360 

This PR defines and sets a new priority for PMD constructors/destructors instead of using the maximum priority value.
It allows developers who link the PMD .a file to their library or executable to have their own constructors/destructors when needed.
