### PR TITLE
`pktdev_close_all` should not call `pktdev_close` on unused pktdevs

### DIFF
--- a/lib/core/pktdev/pktdev.c
+++ b/lib/core/pktdev/pktdev.c
@@ -249,6 +249,8 @@ int
 pktdev_close_all(void)
 {
     PKTDEV_FOREACH (i) {
+        if (pktdev_devices[i].state == PKTDEV_UNUSED)
+            continue;
         if (pktdev_close(i) < 0)
             return -1;
     }


### PR DESCRIPTION
Closes #366 