### PR TITLE
`chnl_connect` should accept operations from Channel 0

### DIFF
--- a/lib/cnet/chnl/cnet_chnl.c
+++ b/lib/cnet/chnl/cnet_chnl.c
@@ -483,10 +483,10 @@ chnl_connect(int cd, struct sockaddr *sa, int namelen)
     struct protosw_entry *psw;
     struct in_caddr faddr = {0};
 
-    if (!cd || this_stk == NULL)
+    if (!ch || this_stk == NULL)
         return __errno_set(EFAULT);
 
-    if (!name || (namelen > (int)sizeof(struct in_caddr)) || !ch || !ch->ch_proto)
+    if (!name || (namelen > (int)sizeof(struct in_caddr)) || !ch->ch_proto)
         CNE_ERR_RET_VAL(__errno_set(EINVAL), "Channel name %p or len %d != %ld\n", name, namelen,
                         sizeof(struct in_caddr));
 


### PR DESCRIPTION
The current implementation of `chnl_connect` rejects operations from channel 0 and returns `EFAULT`.
I did not understand the reason for this. Assume the CNDP application is a usual TCP client, then the first channel
created to initialize a connection could be channel 0 which is rejected.

https://github.com/CloudNativeDataPlane/cndp/blob/9413087ac193cabdbd3db2f6df64986232acb4df/lib/cnet/chnl/cnet_chnl.c#L486

Is this a typo (the developer wanted to check the channel data structure `ch` for NULL values instead of channel descriptor `cd`)? If so, this PR fixes the typo and does necessary refactoring.