### PR TITLE
tcp-chnl: add TCP connection established callback for connect and accept

### DIFF
--- a/doc/guides/sample_app_ug/cnet_graph.rst
+++ b/doc/guides/sample_app_ug/cnet_graph.rst
@@ -219,13 +219,13 @@ The channel callback types are shown below:
 .. code-block:: c
 
     /** Channel callback types */
-    typedef enum {
-        CHNL_UDP_RECV_TYPE,   /**< Callback for receiving UDP packets */
-        CHNL_UDP_CLOSE_TYPE,  /**< Callback for UDP close */
-        CHNL_TCP_ACCEPT_TYPE, /**< Callback type for accepting TCP connection */
-        CHNL_TCP_RECV_TYPE,   /**< Callback for receiving TCP packets */
-        CHNL_TCP_CLOSE_TYPE,  /**< Callback for TCP close */
-        CHNL_CALLBACK_TYPES   /**< Maximum number of callback types */
+   typedef enum {
+        CHNL_UDP_RECV_TYPE,        /**< Callback for receiving UDP packets */
+        CHNL_UDP_CLOSE_TYPE,       /**< Callback for UDP close */
+        CHNL_TCP_ESTABLISHED_TYPE, /**< Callback for when TCP is established: `accept` or `connect` */
+        CHNL_TCP_RECV_TYPE,        /**< Callback for receiving TCP packets */
+        CHNL_TCP_CLOSE_TYPE,       /**< Callback for TCP close */
+        CHNL_CALLBACK_TYPES        /**< Maximum number of callback types */
     } chnl_type_t;
 
 Packet Forwarding using Graph Walk

--- a/lib/cnet/chnl/cnet_chnl.h
+++ b/lib/cnet/chnl/cnet_chnl.h
@@ -65,12 +65,12 @@ enum {
 
 /** Channel callback types */
 typedef enum {
-    CHNL_UDP_RECV_TYPE,   /**< Callback for receiving UDP packets */
-    CHNL_UDP_CLOSE_TYPE,  /**< Callback for UDP close */
-    CHNL_TCP_ACCEPT_TYPE, /**< Callback type for accepting TCP connection */
-    CHNL_TCP_RECV_TYPE,   /**< Callback for receiving TCP packets */
-    CHNL_TCP_CLOSE_TYPE,  /**< Callback for TCP close */
-    CHNL_CALLBACK_TYPES   /**< Maximum number of callback types */
+    CHNL_UDP_RECV_TYPE,        /**< Callback for receiving UDP packets */
+    CHNL_UDP_CLOSE_TYPE,       /**< Callback for UDP close */
+    CHNL_TCP_ESTABLISHED_TYPE, /**< Callback for when TCP is established: `accept` or `connect` */
+    CHNL_TCP_RECV_TYPE,        /**< Callback for receiving TCP packets */
+    CHNL_TCP_CLOSE_TYPE,       /**< Callback for TCP close */
+    CHNL_CALLBACK_TYPES        /**< Maximum number of callback types */
 } chnl_type_t;
 
 /**

--- a/lib/cnet/tcp/cnet_tcp.c
+++ b/lib/cnet/tcp/cnet_tcp.c
@@ -1389,8 +1389,10 @@ tcp_do_state_change(struct pcb_entry *pcb, int32_t new_state)
                     cnet_tcp_abort(pcb);
                     CNE_ERR("Failed to enqueue PCB to backlog queue\n");
                 }
-                pcb->ch->ch_callback(CHNL_TCP_ACCEPT_TYPE, tcb->ppcb->ch->ch_cd);
+                pcb->ch->ch_callback(CHNL_TCP_ESTABLISHED_TYPE, tcb->ppcb->ch->ch_cd);
             }
+        } else {
+            pcb->ch->ch_callback(CHNL_TCP_ESTABLISHED_TYPE, pcb->ch->ch_cd);
         }
 
         tcb->idle              = 0;


### PR DESCRIPTION
CNDP follows an asynchronous pattern. We cannot call some functions before the connection is established e.g. `chnl_send`, so we need a notification that the TCP connection has been established.
The commit adds calls to the TCP connection callback for clients when they establish a connection i.e. the connection is ready to send and receive data.

To simplify things, `CHNL_TCP_ACCEPT_TYPE` is renamed to `CHNL_TCP_ESTABLISHED_TYPE`. The callback type is used for both the server's `accept` and the client's `connect`. In the case of `accept`, the listening channel descriptor is passed to the callback. In the case of `connect`, the client channel descriptor is passed.