### PR TITLE
CNET Chnls: deterministic protocol finding

### DIFF
--- a/lib/cnet/chnl/cnet_chnl.c
+++ b/lib/cnet/chnl/cnet_chnl.c
@@ -249,7 +249,7 @@ initialize_chnl(struct chnl *ch, int typ)
             pcb->opt_flag |= UDP_CHKSUM_FLAG;
 
         ch->ch_proto->proto = IPPROTO_UDP;
-    } else {
+    } else if (typ == SOCK_STREAM) {
         rb->cb_size = rb->cb_hiwat = stk->tcp->rcv_size;
         sb->cb_size = sb->cb_hiwat = stk->tcp->snd_size;
         rb->cb_lowat = sb->cb_lowat = 1;
@@ -258,7 +258,8 @@ initialize_chnl(struct chnl *ch, int typ)
             return __errno_set(ENOBUFS);
 
         ch->ch_proto->proto = IPPROTO_TCP;
-    }
+    } else
+        return __errno_set(EPROTONOSUPPORT);
 
     pcb->ch    = ch;
     ch->ch_pcb = pcb;

--- a/lib/cnet/protosw/cnet_protosw.c
+++ b/lib/cnet/protosw/cnet_protosw.c
@@ -35,7 +35,7 @@ cnet_protosw_match(uint16_t domain, uint16_t type, uint16_t proto)
 }
 
 struct protosw_entry *
-cnet_protosw_find(uint16_t domain, uint16_t type, uint16_t proto)
+cnet_protosw_find(int domain, int type, int proto)
 {
     struct protosw_entry *p;
 

--- a/lib/cnet/protosw/cnet_protosw.h
+++ b/lib/cnet/protosw/cnet_protosw.h
@@ -96,7 +96,7 @@ CNDP_API struct protosw_entry *cnet_protosw_add(const char *name, uint16_t domai
  * @return
  *   NULL on error or a pointer to a protocol switch entry.
  */
-CNDP_API struct protosw_entry *cnet_protosw_find(uint16_t domain, uint16_t type, uint16_t proto);
+CNDP_API struct protosw_entry *cnet_protosw_find(int domain, int type, int proto);
 
 /**
  * @brief Dump out the list of protocol switch values.

--- a/lib/cnet/tcp/cnet_tcp.c
+++ b/lib/cnet/tcp/cnet_tcp.c
@@ -3515,7 +3515,7 @@ cnet_tcp_input(struct pcb_entry *pcb, pktmbuf_t *mbuf)
 
 free_seg:
     free_seg(seg);
-    CNE_DEBUG("Leave\n\n");
+    CNE_DEBUG("Leave\n");
     return rc;
 }
 

--- a/lib/usr/clib/graph/cne_graph_worker.h
+++ b/lib/usr/clib/graph/cne_graph_worker.h
@@ -520,7 +520,7 @@ cne_node_next_stream_move(struct cne_graph *graph, struct cne_node *src, cne_edg
 {
     struct cne_node *dst = __cne_node_next_node_get(src, next);
 
-    CNE_DEBUG("Src %-16s', Dst '%-16s' next %d\n", src->name, dst->name, next);
+    CNE_DEBUG("Src '%-16s', Dst '%-16s' next %d\n", src->name, dst->name, next);
 
     /* Swap the pointers if dst doesn't have valid objs */
     if (likely(dst->idx == 0)) {


### PR DESCRIPTION
The `initialize_chnl` and `cnet_protosw` in the `channel(int, int, int)` function can encounter bugs if the input to the `channel` is wrong.
Assume the user input of `type` arg in `channel` is equal to 10002 or the value of `SOCK_CLOEXEC | SOCK_DGRAM`:

- `cnet_protosw_find` will accept the value (even if it is wrong) just because of casting from 4B signed int of `channel` arguments to 2B unsigned int of `cnet_protosw_find` arguments. The function will return that the desired protocol is `SOCK_DGRAM` even if it might not be. Any value that can result in 2 when cast to uint16 will have a correct value even if this is not the desired behavior. A simple mitigation is to prevent casting, especially since higher-level APIs like `channel` use `int` not `uint_16`.

- `initialize_chnl` also sinks all non-DGRAM and non-ICMP6 channel types as TCP. This can be problematic if `cnet_protosw_find` returns a wrong value. I also think it is neater to check the protocol here and not only assume it will be TCP, for future protocol additions and integrity.

The branch also has minor log fixes.