### PR TITLE
udp: fix double free in udp_destroy

### DIFF
--- a/lib/cnet/udp/cnet_udp.c
+++ b/lib/cnet/udp/cnet_udp.c
@@ -59,10 +59,6 @@ udp_destroy(void *_stk)
     stk_t *stk = _stk;
 
     if (stk->udp) {
-        struct pcb_entry *p;
-
-        vec_foreach_ptr (p, stk->udp->udp_hd.vec)
-            free(p);
         vec_free(stk->udp->udp_hd.vec);
         stk->udp->udp_hd.vec = NULL;
         free(stk->udp);


### PR DESCRIPTION
There is double free in the UDP stack.
The elements in `stk->udp->udp_hd.vec` are freed twice. Once in `pcb_destroy` by `mempool_destroy` and another time in `udp_destroy` by iterating the vector elements.

First time:
https://github.com/CloudNativeDataPlane/cndp/blob/0f006287cdf5dc567f2e31ccbf26bfcdb7d00c2e/lib/cnet/pcb/cnet_pcb.c#L174

Second time:
https://github.com/CloudNativeDataPlane/cndp/blob/0f006287cdf5dc567f2e31ccbf26bfcdb7d00c2e/lib/cnet/udp/cnet_udp.c#L65


valgrind report:
```
==317618== Invalid free() / delete / delete[] / realloc()
==317618==    at 0x484B27F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==317618==    by 0x4918D1F: udp_destroy (cnet_udp.c:65)
==317618==    by 0x491A033: __do_calls (cnet_reg.c:71)
==317618==    by 0x491A033: cnet_do_instance_calls (cnet_reg.c:87)
==317618==    by 0x115F0B: tcpecho_exit (main.c:39)
==317618==    by 0x49E351F: ??? (in /usr/lib/x86_64-linux-gnu/libc.so.6)
==317618==    by 0x487CBCF: ??? (cne.c:240)
==317618==    by 0x48C3E3B: cne_timer_manage (cne_timer.c:439)
==317618==    by 0x114ED4: tcpecho_timer (main.c:325)
==317618==    by 0x48BE9AE: __thread_init (cne_thread.c:121)
==317618==    by 0x4A35AC2: start_thread (pthread_create.c:442)
==317618==    by 0x4AC6A03: clone (clone.S:100)
==317618==  Address 0x1fcc3080 is 0 bytes inside a block of size 65,536 free'd
==317618==    at 0x484B27F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==317618==    by 0x48936F8: mempool_destroy (mempool.c:115)
==317618==    by 0x491A973: pcb_destroy (cnet_pcb.c:174)
==317618==    by 0x491A033: __do_calls (cnet_reg.c:71)
==317618==    by 0x491A033: cnet_do_instance_calls (cnet_reg.c:87)
==317618==    by 0x115F0B: tcpecho_exit (main.c:39)
==317618==    by 0x49E351F: ??? (in /usr/lib/x86_64-linux-gnu/libc.so.6)
==317618==    by 0x487CBCF: ??? (cne.c:240)
==317618==    by 0x48C3E3B: cne_timer_manage (cne_timer.c:439)
==317618==    by 0x114ED4: tcpecho_timer (main.c:325)
==317618==    by 0x48BE9AE: __thread_init (cne_thread.c:121)
==317618==    by 0x4A35AC2: start_thread (pthread_create.c:442)
==317618==    by 0x4AC6A03: clone (clone.S:100)
==317618==  Block was alloc'd at
==317618==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==317618==    by 0x489367C: mempool_populate (mempool.c:72)
==317618==    by 0x4893A53: mempool_create (mempool.c:200)
==317618==    by 0x491A9E0: pcb_create (cnet_pcb.c:191)
==317618==    by 0x491A05F: __do_calls (cnet_reg.c:71)
==317618==    by 0x491A05F: cnet_do_instance_calls (cnet_reg.c:87)
==317618==    by 0x491A6D2: cnet_stk_initialize (cnet_stk.c:82)
==317618==    by 0x115A9A: tcpecho_worker (main.c:282)
==317618==    by 0x48BE9AE: __thread_init (cne_thread.c:121)
==317618==    by 0x4A35AC2: start_thread (pthread_create.c:442)
==317618==    by 0x4AC6A03: clone (clone.S:100)
```
