### PR TITLE
cnet: add send completion events 

### DIFF
--- a/examples/cnet-graph/cnet-graph.c
+++ b/examples/cnet-graph/cnet-graph.c
@@ -266,10 +266,24 @@ tcp_close(int cd __cne_unused)
 }
 
 static int
+udp_sent(int cd)
+{
+    CNE_INFO("UDP Sending was complete on Channel=%d\n", cd);
+    return 0;
+}
+
+static int
+tcp_sent(int cd)
+{
+    CNE_INFO("TCP Sending was complete on Channel=%d\n", cd);
+    return 0;
+}
+
+static int
 proto_callback(int ctype, int cd)
 {
     static cb_types_t funcs[CHNL_CALLBACK_TYPES] = {
-        udp_recv, udp_close, tcp_accept, tcp_recv, tcp_close,
+        udp_sent, udp_recv, udp_close, tcp_sent, tcp_accept, tcp_recv, tcp_close,
     };
 
     if (ctype >= 0 && ctype < CHNL_CALLBACK_TYPES)

--- a/lib/cnet/chnl/chnl_callback_priv.h
+++ b/lib/cnet/chnl/chnl_callback_priv.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2024-2024 Intel Corporation
+ */
+
+#ifndef __INCLUDE_CHNL_CALLBACK_PRIV_H__
+#define __INCLUDE_CHNL_CALLBACK_PRIV_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct chnl_callback_node_ctx;
+typedef struct chnl_callback_node_ctx chnl_callback_node_ctx_t;
+
+/**
+ * @internal
+ *
+ * Types of source nodes
+ */
+typedef enum chnl_callback_source_node {
+    CHNL_CALLBACK_SOURCE_ETH_TX,
+    CHNL_CALLBACK_SOURCE_CHNL_RECV,
+} chnl_callback_source_node_t;
+
+/**
+ * @internal
+ *
+ * Chnl Callback node context structure.
+ */
+struct chnl_callback_node_ctx {
+    chnl_callback_source_node_t source; /**< Source Node of CHNL Callback */
+};
+
+void chnl_callback_node_set_source(struct cne_node *node, chnl_callback_source_node_t source);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_CHNL_CALLBACK_PRIV_H__ */

--- a/lib/cnet/chnl/cnet_chnl.h
+++ b/lib/cnet/chnl/cnet_chnl.h
@@ -65,8 +65,10 @@ enum {
 
 /** Channel callback types */
 typedef enum {
+    CHNL_UDP_SENT_TYPE,        /**< Callback for send completion of UDP packets */
     CHNL_UDP_RECV_TYPE,        /**< Callback for receiving UDP packets */
     CHNL_UDP_CLOSE_TYPE,       /**< Callback for UDP close */
+    CHNL_TCP_SENT_TYPE,        /**< Callback for send completion of TCP packets */
     CHNL_TCP_ESTABLISHED_TYPE, /**< Callback for when TCP is established: `accept` or `connect` */
     CHNL_TCP_RECV_TYPE,        /**< Callback for receiving TCP packets */
     CHNL_TCP_CLOSE_TYPE,       /**< Callback for TCP close */

--- a/lib/cnet/eth/eth_tx_priv.h
+++ b/lib/cnet/eth/eth_tx_priv.h
@@ -13,6 +13,7 @@ struct eth_tx_node_ctx;
 typedef struct eth_tx_node_ctx eth_tx_node_ctx_t;
 
 enum eth_tx_next_nodes {
+    ETH_TX_NEXT_PKT_CALLBACK,
     ETH_TX_NEXT_MAX,
 };
 

--- a/lib/core/xskdev/xskdev.c
+++ b/lib/core/xskdev/xskdev.c
@@ -503,7 +503,6 @@ xskdev_tx_burst_locked(xskdev_info_t *xi, void **bufs, uint16_t nb_pkts)
     xsk_ring_prod__submit(&txq->tx, nb_free);
 
     pull_umem_cq(xi);
-
     xi->stats.opackets += nb_free;
     xi->stats.obytes += tx_bytes;
 


### PR DESCRIPTION
CNET now has an event to know if sending has been processed. 
Now, eth_tx is also linked to `chnl_callback`. I added 2 new callback types: `CHNL_UDP_SENT_TYPE` and `CHNL_TCP_SENT_TYPE`.

