### PR TITLE
chnl: add chnl_port to get port from connected channel

### DIFF
--- a/lib/cnet/chnl/cnet_chnl.c
+++ b/lib/cnet/chnl/cnet_chnl.c
@@ -958,6 +958,21 @@ chnl_connect_common(struct chnl *ch, struct in_caddr *to, int32_t tolen __cne_un
     return 0;
 }
 
+/*
+ * Gets lport ID from channel descriptor. A use case is to allocate pktmbufs
+ * directly from the port mempool using `pktdev_buf_alloc`
+ */
+int
+chnl_port(int cd)
+{
+    struct chnl *ch = ch_get(cd);
+
+    if (!ch || !ch->ch_pcb || !ch->ch_pcb->netif)
+        return __errno_set(EFAULT);
+
+    return ch->ch_pcb->netif->lpid;
+}
+
 int
 chnl_validate_cb(const char *msg, struct chnl_buf *cb)
 {

--- a/lib/cnet/chnl/cnet_chnl.h
+++ b/lib/cnet/chnl/cnet_chnl.h
@@ -84,6 +84,16 @@ typedef enum {
 CNDP_API void chnl_dump(const char *msg, struct chnl *ch);
 
 /**
+ * @brief Gets port of connect'd or bind'd channel
+ *
+ * @param cd
+ *   Channel descriptor
+ * @return
+ *   -1 on error or pktdev port ID on success
+ */
+CNDP_API int chnl_port(int cd);
+
+/**
  * @brief Common channel connect routine used by protocols.
  *
  * @param ch


### PR DESCRIPTION
This PR adds a new `chnl_port` API function, allowing us to know which port this channel is bound to.
It is important to allocate mbufs when sending data e.g.

```c
pktmbuf_t* bufs[256];
int portid = chnl_port(cd);
pktdev_buf_alloc(portid, bufs, burst);
chnl_send(cd, bufs, burst);
```

This can be easily done as the PCB entry will be linked to a specific port (interface and queue) in the FIB when the connection has been established `chnl_accept` or `chnl_connect` has finished.