### PR TITLE
workflow: create a PR for rust autoupdate

### DIFF
--- a/.github/workflows/update-rust-deps.yml
+++ b/.github/workflows/update-rust-deps.yml
@@ -3,7 +3,11 @@ name: Update Rust Dependencies
 on: # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 5 * * 1'  # Every Monday at 05:00 UTC
-  workflow_dispatch:     # Also allow manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   update:
@@ -14,7 +18,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Needed for commits
+          fetch-depth: 0
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1.0.7
@@ -38,15 +42,22 @@ jobs:
       - name: Check if anything changed
         id: git-check
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           if [[ -n $(git status --porcelain) ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push changes
+      - name: Create Pull Request
         if: steps.git-check.outputs.changed == 'true'
-        run: |
-          git add .
-          git commit -m "chore: auto-update Rust dependencies via cargo upgrade"
-          git push
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: rust-deps-upgrade
+          title: "chore: auto-update Rust dependencies"
+          commit-message: "chore: auto-update Rust dependencies via cargo upgrade"
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          sign-commits: true
+          body: |
+            This PR updates Rust dependencies using `cargo upgrade`.
+          labels: dependencies
+          draft: false


### PR DESCRIPTION
Change the job that autoupdates rust to create a PR instead of trying to commit straight to main... 