### PR TITLE
workflow: check for updates to Docker-related dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/containerization/docker/fedora"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "docker"
+    directory: "/containerization/docker/ubuntu"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
Dependabot will now check Dockerfiles every Monday to see if the base images have any updates. If so, it'll open a PR to update it.